### PR TITLE
Add image-to-3D picker to Studio's New from Prompt dialog

### DIFF
--- a/crates/mogen-llm/src/gemini.rs
+++ b/crates/mogen-llm/src/gemini.rs
@@ -6,6 +6,7 @@
 
 use std::time::Duration;
 
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -93,12 +94,32 @@ pub enum GeminiError {
     InvalidResponse(String),
 }
 
+/// One image attached to the user turn. Sent to Gemini as an `inline_data`
+/// part alongside the text prompt — vision-capable models (the Pro tier and
+/// the multimodal Flash variants) interpret these as visual context. Used by
+/// the Studio "New from Prompt" dialog to support image-to-3D generation.
+#[derive(Debug, Clone)]
+pub struct ImageInput {
+    /// MIME type, e.g. `"image/png"` or `"image/jpeg"`. Must start with
+    /// `image/` — Gemini rejects anything else on a vision turn.
+    pub mime_type: String,
+    /// Raw bytes of the image. Encoded as base64 in the request body; not
+    /// kept in memory after [`GeminiClient::generate`] returns.
+    pub data: Vec<u8>,
+}
+
 /// One full request to `generateContent`.
 #[derive(Debug, Clone)]
 pub struct GenerateConfig {
     pub model: String,
-    /// Single-shot prompt from the user (e.g. `"a wooden stool"`).
+    /// Single-shot prompt from the user (e.g. `"a wooden stool"`). May be
+    /// empty when [`Self::user_images`] is non-empty — the image alone is a
+    /// valid input on vision-capable models.
     pub user_prompt: String,
+    /// Optional images attached to the user turn (image-to-3D). Encoded as
+    /// `inline_data` parts on every call, including repair iterations, so the
+    /// model retains the visual reference while it fixes validation errors.
+    pub user_images: Vec<ImageInput>,
     /// Prior turns (e.g. first attempt's DSL + diagnostic feedback for repair).
     pub history: Vec<Turn>,
     /// System instruction (grammar + stdlib). See [`crate::prompt`].
@@ -128,6 +149,7 @@ impl GenerateConfig {
         Self {
             model: DEFAULT_MODEL.to_string(),
             user_prompt: user_prompt.into(),
+            user_images: Vec::new(),
             history: Vec::new(),
             system_instruction: None,
             cached_content: None,
@@ -356,9 +378,24 @@ fn build_request(cfg: &GenerateConfig) -> serde_json::Value {
             "parts": [{ "text": turn.text }],
         }));
     }
+
+    // Build the user turn's parts list: optional images first (Gemini's docs
+    // recommend image-before-text ordering for vision prompts), then the text.
+    // The text part is always present even when empty, so the request is
+    // well-formed when only images were supplied.
+    let mut user_parts: Vec<serde_json::Value> = Vec::with_capacity(cfg.user_images.len() + 1);
+    for img in &cfg.user_images {
+        user_parts.push(serde_json::json!({
+            "inline_data": {
+                "mime_type": img.mime_type,
+                "data": STANDARD.encode(&img.data),
+            }
+        }));
+    }
+    user_parts.push(serde_json::json!({ "text": cfg.user_prompt }));
     contents.push(serde_json::json!({
         "role": "user",
-        "parts": [{ "text": cfg.user_prompt }],
+        "parts": user_parts,
     }));
 
     let mut req = serde_json::json!({ "contents": contents });

--- a/crates/mogen-llm/src/lib.rs
+++ b/crates/mogen-llm/src/lib.rs
@@ -20,7 +20,7 @@ pub mod textures;
 
 pub use cache::{default_cache_path, resolve_or_create as resolve_or_create_cache, DEFAULT_TTL_SECONDS};
 pub use gemini::{
-    CachedContent, GeminiClient, GeminiError, GenerateConfig, ThinkingLevel, Usage,
+    CachedContent, GeminiClient, GeminiError, GenerateConfig, ImageInput, ThinkingLevel, Usage,
     DEFAULT_FAST_MODEL,
 };
 pub use image::{GeneratedImage, DEFAULT_IMAGE_MODEL};

--- a/crates/mogen-llm/tests/mock_server.rs
+++ b/crates/mogen-llm/tests/mock_server.rs
@@ -6,7 +6,7 @@ use std::io::Read;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use mogen_llm::gemini::{GeminiClient, GenerateConfig};
+use mogen_llm::gemini::{GeminiClient, GenerateConfig, ImageInput};
 use mogen_llm::{generate_with_repair, RepairConfig};
 
 struct MockServer {
@@ -166,6 +166,36 @@ fn fenced_markdown_output_is_stripped_before_validation() {
 
     assert!(outcome.is_ok(), "diagnostics: {:?}", outcome.diagnostics);
     assert!(!outcome.dsl.contains("```"));
+}
+
+#[test]
+fn user_images_become_inline_data_parts_on_the_user_turn() {
+    // Image-to-3D path: an attached image should serialize as a sibling
+    // `inline_data` part on the user turn, base64-encoded, alongside the text
+    // prompt. The legacy text-only request shape is preserved when no image
+    // is attached (covered by the other tests in this file).
+    let dsl = "scene { box \"b\" (size=[1,1,1]) }";
+    let server = MockServer::start(vec![&candidate_body(dsl)]);
+    let client = GeminiClient::with_base_url("test-key", server.base_url());
+
+    let mut cfg = GenerateConfig::new("a box");
+    cfg.user_images.push(ImageInput {
+        mime_type: "image/png".into(),
+        // Three bytes the test can spot once base64-encoded ("AQID").
+        data: vec![0x01, 0x02, 0x03],
+    });
+    let _ = generate_with_repair(&client, cfg, &RepairConfig { max_iters: 0, on_iteration: None })
+        .expect("request ok");
+
+    let reqs = server.requests.lock().unwrap();
+    assert_eq!(reqs.len(), 1);
+    let body: serde_json::Value = serde_json::from_str(&reqs[0]).expect("valid JSON");
+    let parts = body["contents"][0]["parts"].as_array().expect("parts array");
+    // Image part comes first, text part second — vision-prompt convention.
+    assert_eq!(parts.len(), 2, "got: {body}");
+    assert_eq!(parts[0]["inline_data"]["mime_type"], "image/png");
+    assert_eq!(parts[0]["inline_data"]["data"], "AQID");
+    assert_eq!(parts[1]["text"], "a box");
 }
 
 #[test]

--- a/crates/mogen-studio/src/app.rs
+++ b/crates/mogen-studio/src/app.rs
@@ -35,7 +35,8 @@ mod watcher;
 
 use self::types::{
     AskInFlight, AutocompleteState, BuildOutcome, EnhanceInFlight, EnhanceTarget,
-    ExternalConflict, FileState, FindState, SessionUsage, ThumbCache, VIEWER_BG_COLOR,
+    ExternalConflict, FileState, FindState, GenImageInput, SessionUsage, ThumbCache,
+    VIEWER_BG_COLOR,
 };
 use self::util::locate_project_root;
 
@@ -116,6 +117,10 @@ pub struct MogenStudioApp {
     /// generator only surfaces here — it is no longer part of the inspector.
     show_new_prompt: bool,
     new_prompt_draft: String,
+    /// Optional image staged inside the New-from-Prompt modal (image-to-3D).
+    /// Moved into the new tab's `FileState.gen_image` on submit; cleared when
+    /// the dialog closes. None until the user picks a file.
+    new_prompt_image: Option<GenImageInput>,
     /// Latched when the modal is opened so the dialog can grab focus on its
     /// first frame; cleared after the focus request fires.
     new_prompt_focus_pending: bool,
@@ -308,6 +313,7 @@ impl MogenStudioApp {
             onboarding_api_key_draft: String::new(),
             show_new_prompt: false,
             new_prompt_draft: String::new(),
+            new_prompt_image: None,
             new_prompt_focus_pending: false,
             show_quit_confirm: false,
             confirmed_quit: false,

--- a/crates/mogen-studio/src/app/llm.rs
+++ b/crates/mogen-studio/src/app/llm.rs
@@ -19,11 +19,12 @@ use super::MogenStudioApp;
 impl MogenStudioApp {
     pub(super) fn start_llm_generate(&mut self, ctx: egui::Context) {
         let prompt = self.active().gen_prompt.trim().to_string();
-        if prompt.is_empty() {
+        let image = self.active().gen_image.clone();
+        if prompt.is_empty() && image.is_none() {
             self.active_mut().status = "enter a prompt first".into();
             return;
         }
-        self.spawn_llm(ctx, LlmKind::Generate, prompt, None);
+        self.spawn_llm(ctx, LlmKind::Generate, prompt, None, image);
     }
 
     pub(super) fn start_llm_modify(&mut self, ctx: egui::Context) {
@@ -43,7 +44,7 @@ impl MogenStudioApp {
             self.active_mut().status = "modify needs existing DSL to edit".into();
             return;
         }
-        self.spawn_llm(ctx, LlmKind::Modify, prompt, Some(existing));
+        self.spawn_llm(ctx, LlmKind::Modify, prompt, Some(existing), None);
     }
 
     /// Kick off a Gemini repair call on the current buffer. No prompt field —
@@ -73,6 +74,7 @@ impl MogenStudioApp {
             LlmKind::Repair,
             "repair validation errors".to_string(),
             Some(existing),
+            None,
         );
     }
 
@@ -93,7 +95,7 @@ impl MogenStudioApp {
             self.active_mut().status = "animate needs existing DSL to edit".into();
             return;
         }
-        self.spawn_llm(ctx, LlmKind::Animate, prompt, Some(existing));
+        self.spawn_llm(ctx, LlmKind::Animate, prompt, Some(existing), None);
     }
 
     pub(super) fn start_llm_textures(&mut self, ctx: egui::Context) {
@@ -411,6 +413,7 @@ impl MogenStudioApp {
         kind: LlmKind,
         prompt: String,
         existing: Option<String>,
+        image: Option<crate::app::types::GenImageInput>,
     ) {
         let api_key = match self.resolve_api_key() {
             Some(k) => k,
@@ -466,8 +469,16 @@ impl MogenStudioApp {
         };
 
         let worker_tx = tx.clone();
+        // The thumbnail handle is GUI-only; convert to the LLM crate's
+        // `ImageInput` shape so the worker thread carries just the bytes.
+        let llm_image = image.map(|img| mogen_llm::ImageInput {
+            mime_type: img.mime_type,
+            data: img.data,
+        });
         std::thread::spawn(move || {
-            let outcome = run_llm(kind, prompt, existing, api_key, run_cfg, sys_instr, worker_tx);
+            let outcome = run_llm(
+                kind, prompt, existing, llm_image, api_key, run_cfg, sys_instr, worker_tx,
+            );
             let _ = tx.send(LlmMessage::Done(outcome));
             ctx.request_repaint();
         });

--- a/crates/mogen-studio/src/app/types.rs
+++ b/crates/mogen-studio/src/app/types.rs
@@ -497,6 +497,25 @@ impl Default for TextureUiConfig {
     }
 }
 
+/// One image attached to a Generate prompt (image-to-3D). The `path` is kept
+/// only for display in the dialog and the `// prompt:` header; the bytes are
+/// what flow to Gemini as `inline_data`. `thumbnail` is loaded once when the
+/// user picks the file so the dialog can render a preview without re-decoding
+/// every frame; it is dropped before the worker thread starts.
+#[derive(Clone)]
+pub(super) struct GenImageInput {
+    pub(super) path: PathBuf,
+    pub(super) mime_type: String,
+    pub(super) data: Vec<u8>,
+    pub(super) thumbnail: Option<egui::TextureHandle>,
+}
+
+/// Hard cap on image bytes (raw, pre-base64). Gemini accepts up to 20 MB
+/// inline, but base64 expands by ~33%; capping the source at 8 MB keeps the
+/// encoded body well under the limit and avoids surprise failures on phone
+/// photos. The dialog rejects files larger than this with a status message.
+pub(super) const MAX_GEN_IMAGE_BYTES: usize = 8 * 1024 * 1024;
+
 /// Transient state for the editor autocomplete popup. One instance lives on
 /// the app since only one editor is visible at a time — switching tabs or
 /// losing focus closes the popup, so there's no need to persist per-file.
@@ -583,6 +602,11 @@ pub(super) struct FileState {
     pub(super) last_watch_check: Option<Instant>,
 
     pub(super) gen_prompt: String,
+    /// Optional image attached to the generate prompt (image-to-3D). Carried
+    /// on the FileState — not just on the dialog — so the Retry button can
+    /// re-issue the same call after a transient failure without forcing the
+    /// user to re-pick the file.
+    pub(super) gen_image: Option<GenImageInput>,
     pub(super) mod_prompt: String,
     pub(super) anim_prompt: String,
     pub(super) texture_cfg: TextureUiConfig,
@@ -660,6 +684,7 @@ impl FileState {
             disk_mtime: None,
             last_watch_check: None,
             gen_prompt: String::new(),
+            gen_image: None,
             mod_prompt: String::new(),
             anim_prompt: String::new(),
             texture_cfg: TextureUiConfig::default(),
@@ -700,6 +725,7 @@ impl FileState {
             disk_mtime,
             last_watch_check: None,
             gen_prompt: String::new(),
+            gen_image: None,
             mod_prompt: String::new(),
             anim_prompt: String::new(),
             texture_cfg: TextureUiConfig::default(),

--- a/crates/mogen-studio/src/app/ui_dialogs.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use eframe::egui;
 
 use crate::settings::{
@@ -5,8 +7,68 @@ use crate::settings::{
 };
 use crate::theme::{apply_theme, theme_label, Theme, THEMES};
 
-use super::types::{ExternalChangeKind, EnhanceTarget, DOCS_URL, GITHUB_REPO_URL, LICENSE_URL};
+use super::types::{
+    EnhanceTarget, ExternalChangeKind, GenImageInput, MAX_GEN_IMAGE_BYTES, DOCS_URL,
+    GITHUB_REPO_URL, LICENSE_URL,
+};
 use super::MogenStudioApp;
+
+/// Decode the image bytes via the `image` crate, downscale to a thumbnail
+/// (96 px on the long side), and upload to the GPU as an `egui::TextureHandle`
+/// so the dialog can show a preview without re-decoding every frame. Returns
+/// `None` if decoding fails — the dialog will still send the raw bytes to
+/// Gemini in that case (the model can handle PNG/JPG/WEBP), it just won't
+/// show a thumbnail.
+fn make_image_thumbnail(
+    ctx: &egui::Context,
+    bytes: &[u8],
+    name: &str,
+) -> Option<egui::TextureHandle> {
+    let img = image::load_from_memory(bytes).ok()?;
+    let thumb = img.thumbnail(96, 96);
+    let rgba = thumb.to_rgba8();
+    let size = [rgba.width() as usize, rgba.height() as usize];
+    let color_image = egui::ColorImage::from_rgba_unmultiplied(size, &rgba.into_raw());
+    Some(ctx.load_texture(
+        format!("gen_prompt_thumb:{name}"),
+        color_image,
+        egui::TextureOptions::LINEAR,
+    ))
+}
+
+/// Map an image's bytes (sniffed) and file extension to an `image/*` MIME
+/// string Gemini accepts. Sniffing wins over the extension because phone
+/// cameras frequently mislabel `.jpg` as `.heic` or vice versa; we only
+/// fall back to the extension when sniffing fails.
+fn guess_image_mime(bytes: &[u8], path: &Path) -> String {
+    use image::ImageFormat;
+    if let Ok(fmt) = image::guess_format(bytes) {
+        return match fmt {
+            ImageFormat::Png => "image/png",
+            ImageFormat::Jpeg => "image/jpeg",
+            ImageFormat::WebP => "image/webp",
+            ImageFormat::Gif => "image/gif",
+            ImageFormat::Bmp => "image/bmp",
+            ImageFormat::Tiff => "image/tiff",
+            _ => "application/octet-stream",
+        }
+        .to_string();
+    }
+    match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("png") => "image/png",
+        Some("jpg" | "jpeg") => "image/jpeg",
+        Some("webp") => "image/webp",
+        Some("gif") => "image/gif",
+        Some("bmp") => "image/bmp",
+        _ => "application/octet-stream",
+    }
+    .to_string()
+}
 
 /// Models surfaced in the Preferences dropdown. Free-form text still wins if
 /// a user types one in, but these cover the tiers almost every user will
@@ -682,6 +744,12 @@ impl MogenStudioApp {
     /// "New from Prompt…" dialog — the only place the LLM *generator* is
     /// surfaced. Producing a new scene always spawns a fresh untitled tab
     /// so the active MOG file isn't silently overwritten.
+    ///
+    /// The dialog accepts an optional reference image alongside the text
+    /// prompt (image-to-3D). Either input on its own is enough to enable
+    /// the Generate button — the Pro vision model can interpret the image
+    /// without supplementing text, and a text-only prompt keeps the legacy
+    /// flow working unchanged.
     pub(super) fn ui_new_prompt(&mut self, ctx: &egui::Context) {
         if !self.show_new_prompt {
             return;
@@ -689,7 +757,10 @@ impl MogenStudioApp {
         let mut open = true;
         let mut close_after = false;
         let mut spawn_now = false;
+        let mut pick_image = false;
+        let mut clear_image = false;
         let has_key = self.resolve_api_key().is_some();
+        let mut image_status: Option<String> = None;
         egui::Window::new("New from Prompt")
             .open(&mut open)
             .collapsible(false)
@@ -706,7 +777,10 @@ impl MogenStudioApp {
                     |ui, text| {
                         ui.add(
                             egui::TextEdit::multiline(text)
-                                .hint_text("e.g. a wooden stool with three legs")
+                                .hint_text(
+                                    "e.g. a wooden stool with three legs \
+                                     (optional when an image is attached)",
+                                )
                                 .desired_rows(4)
                                 .desired_width(f32::INFINITY)
                                 .id(prompt_id),
@@ -722,6 +796,51 @@ impl MogenStudioApp {
                     EnhanceTarget::Generate,
                     "Rewrite the prompt with the fast model",
                 );
+
+                ui.add_space(8.0);
+                ui.separator();
+                ui.add_space(4.0);
+                ui.label("Reference image (optional):");
+                ui.add_space(2.0);
+                ui.horizontal(|ui| {
+                    if let Some(img) = self.new_prompt_image.as_ref() {
+                        if let Some(tex) = img.thumbnail.as_ref() {
+                            // Letterbox into a 64×64 slot so the row height is
+                            // stable regardless of the source image's aspect.
+                            let aspect = {
+                                let s = tex.size_vec2();
+                                if s.y > 0.0 { s.x / s.y } else { 1.0 }
+                            };
+                            let h = 64.0;
+                            let w = (h * aspect).clamp(24.0, 96.0);
+                            ui.image((tex.id(), egui::vec2(w, h)));
+                        }
+                        let label = img
+                            .path
+                            .file_name()
+                            .map(|n| n.to_string_lossy().into_owned())
+                            .unwrap_or_else(|| img.path.display().to_string());
+                        ui.vertical(|ui| {
+                            ui.label(label);
+                            let kib = (img.data.len() as f64) / 1024.0;
+                            let size_label = if kib >= 1024.0 {
+                                format!("{:.1} MB · {}", kib / 1024.0, img.mime_type)
+                            } else {
+                                format!("{:.0} KB · {}", kib, img.mime_type)
+                            };
+                            ui.weak(size_label);
+                        });
+                        if ui.button("Remove").clicked() {
+                            clear_image = true;
+                        }
+                        if ui.button("Replace…").clicked() {
+                            pick_image = true;
+                        }
+                    } else if ui.button("Choose image…").clicked() {
+                        pick_image = true;
+                    }
+                });
+
                 if !has_key {
                     ui.add_space(4.0);
                     ui.colored_label(
@@ -732,10 +851,18 @@ impl MogenStudioApp {
                 ui.add_space(8.0);
                 ui.horizontal(|ui| {
                     let prompt_ok = !self.new_prompt_draft.trim().is_empty();
-                    let can_generate = has_key && prompt_ok;
+                    let image_ok = self.new_prompt_image.is_some();
+                    let can_generate = has_key && (prompt_ok || image_ok);
+                    let hover = if image_ok && !prompt_ok {
+                        "Create a new tab and generate from the attached image"
+                    } else if image_ok {
+                        "Create a new tab and generate from the prompt + image"
+                    } else {
+                        "Create a new tab and run the generator on it"
+                    };
                     if ui
                         .add_enabled(can_generate, egui::Button::new("Generate"))
-                        .on_hover_text("Create a new tab and run the generator on it")
+                        .on_hover_text(hover)
                         .clicked()
                     {
                         spawn_now = true;
@@ -746,17 +873,86 @@ impl MogenStudioApp {
                     }
                 });
             });
+
+        if pick_image {
+            if let Err(msg) = self.pick_gen_prompt_image(ctx) {
+                image_status = Some(msg);
+            }
+        }
+        if clear_image {
+            self.new_prompt_image = None;
+        }
+        if let Some(msg) = image_status {
+            // Surface picker errors (too large / unreadable) on the active
+            // tab's status bar so the user sees them after the dialog closes.
+            self.active_mut().status = msg;
+        }
+
         if !open || close_after {
             self.show_new_prompt = false;
         }
         if spawn_now {
             let prompt = self.new_prompt_draft.trim().to_string();
+            // Move the staged image (if any) into the new tab so Retry can
+            // re-issue the same call without re-picking the file. Strip the
+            // GPU thumbnail handle before transfer — the worker thread
+            // doesn't need it and TextureHandle isn't worth shuttling around.
+            let mut staged = self.new_prompt_image.take();
+            if let Some(img) = staged.as_mut() {
+                img.thumbnail = None;
+            }
             self.new_untitled();
             self.active_mut().gen_prompt = prompt;
+            self.active_mut().gen_image = staged;
             let ctx_clone = ctx.clone();
             self.start_llm_generate(ctx_clone);
             self.new_prompt_draft.clear();
         }
+        if !self.show_new_prompt {
+            // Drop any staged image when the dialog closes without submitting,
+            // so re-opening starts fresh and the GPU thumbnail handle is freed.
+            self.new_prompt_image = None;
+        }
+    }
+
+    /// Open a native file dialog for an image and stash the result on
+    /// `self.new_prompt_image`. Returns `Err(msg)` on read / size failures so
+    /// the caller can surface the message to the user.
+    fn pick_gen_prompt_image(&mut self, ctx: &egui::Context) -> Result<(), String> {
+        let dialog = rfd::FileDialog::new()
+            .add_filter("Images", &["png", "jpg", "jpeg", "webp", "gif", "bmp"])
+            .set_directory(&self.project_root);
+        let Some(path) = dialog.pick_file() else {
+            return Ok(());
+        };
+        let bytes = std::fs::read(&path)
+            .map_err(|e| format!("couldn't read image: {e}"))?;
+        if bytes.len() > MAX_GEN_IMAGE_BYTES {
+            return Err(format!(
+                "image too large ({:.1} MB); cap is {} MB — try a smaller file",
+                (bytes.len() as f64) / (1024.0 * 1024.0),
+                MAX_GEN_IMAGE_BYTES / (1024 * 1024),
+            ));
+        }
+        let mime_type = guess_image_mime(&bytes, &path);
+        if !mime_type.starts_with("image/") {
+            return Err(format!(
+                "unsupported file type ({}) — pick a PNG, JPG, WEBP, GIF, or BMP",
+                mime_type,
+            ));
+        }
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "image".to_string());
+        let thumbnail = make_image_thumbnail(ctx, &bytes, &name);
+        self.new_prompt_image = Some(GenImageInput {
+            path,
+            mime_type,
+            data: bytes,
+            thumbnail,
+        });
+        Ok(())
     }
 
     /// Modal raised by the on-disk watcher when an open MOG file changed

--- a/crates/mogen-studio/src/app/util.rs
+++ b/crates/mogen-studio/src/app/util.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use mogen_core::SceneGraph;
 use mogen_export::ExportOptions;
-use mogen_llm::gemini::{GeminiClient, GenerateConfig, Usage};
+use mogen_llm::gemini::{GeminiClient, GenerateConfig, ImageInput, Usage};
 use mogen_llm::textures::{
     build_plan, default_textures_dir, run_plan, splice_textures, PlanAction,
     TextureProgress, TexturesArgs,
@@ -462,6 +462,7 @@ pub(super) fn run_llm(
     kind: LlmKind,
     prompt: String,
     existing: Option<String>,
+    image: Option<ImageInput>,
     api_key: String,
     run_cfg: LlmRunConfig,
     sys_instr: Arc<String>,
@@ -485,7 +486,22 @@ pub(super) fn run_llm(
     // For edit-an-existing-file kinds, keep the original `// prompt: …` header
     // so the provenance line isn't overwritten with the modify/animate text.
     let header_prompt = match kind {
-        LlmKind::Generate | LlmKind::Textures => prompt.clone(),
+        LlmKind::Generate | LlmKind::Textures => {
+            // When an image was attached, annotate the seed header so the
+            // `// prompt:` line records *why* the file looks the way it does
+            // (otherwise an image-only generate writes an empty `prompt:` line,
+            // which is misleading).
+            if image.is_some() {
+                let trimmed = prompt.trim();
+                if trimmed.is_empty() {
+                    "[image attached]".to_string()
+                } else {
+                    format!("[image attached] {trimmed}")
+                }
+            } else {
+                prompt.clone()
+            }
+        }
         LlmKind::Modify | LlmKind::Animate | LlmKind::Repair => existing
             .as_deref()
             .and_then(parse_prompt_header)
@@ -493,7 +509,31 @@ pub(super) fn run_llm(
     };
 
     let user_prompt = match kind {
-        LlmKind::Generate => prompt.clone(),
+        LlmKind::Generate => {
+            // When the only input is an image, a non-empty text part still
+            // helps the model commit to the DSL output mode (the system
+            // instruction handles the schema, but Gemini's vision path
+            // sometimes regresses to describing the image otherwise).
+            // Concatenate the user's text with a short directive when an
+            // image is attached; pass the prompt through unchanged when
+            // there's no image so the legacy flow stays bit-for-bit.
+            if image.is_some() {
+                let trimmed = prompt.trim();
+                if trimmed.is_empty() {
+                    "Generate a mogen DSL scene that recreates the attached \
+                     reference image as a 3D model."
+                        .to_string()
+                } else {
+                    format!(
+                        "Generate a mogen DSL scene that recreates the attached \
+                         reference image as a 3D model. Additional guidance from \
+                         the user:\n\n{trimmed}",
+                    )
+                }
+            } else {
+                prompt.clone()
+            }
+        }
         LlmKind::Modify => format!(
             "You are editing an existing mogen DSL file. Apply this modification:\n\n\
             {mod_prompt}\n\n\
@@ -588,6 +628,12 @@ pub(super) fn run_llm(
     cfg.thinking_level = Some(run_cfg.thinking);
     cfg.temperature = Some(run_cfg.temperature);
     cfg.system_instruction = Some((*sys_instr).clone());
+    if let Some(img) = image {
+        // Carried through every repair iteration: `repair.rs` rewrites
+        // `cfg.user_prompt` but leaves `cfg.user_images` alone, so the model
+        // keeps the visual reference while it fixes validator errors.
+        cfg.user_images.push(img);
+    }
 
     send_progress(LlmProgress::Status(format!(
         "calling Gemini ({}) — thinking={:?}",


### PR DESCRIPTION
Lets users attach an optional reference image alongside (or instead of)
the text prompt. The image is sent to Gemini as an inline_data part on
the user turn so vision-capable models can use it as visual context.

- mogen-llm: GenerateConfig gains a user_images: Vec<ImageInput> field;
  build_request emits inline_data parts before the text part on the user
  turn. Repair iterations preserve user_images so the model keeps the
  visual reference while it fixes validator errors.
- mogen-studio: New from Prompt dialog gets a "Reference image (optional)"
  row with a file picker, thumbnail preview, and Replace/Remove buttons.
  Generate is enabled when either the prompt or an image is present.
  The staged image moves into the new tab's FileState on submit so Retry
  can re-issue the call without re-picking the file. 8 MB cap on raw
  bytes keeps the base64-encoded body under Gemini's 20 MB limit.