### PR TITLE
Add OpenAI, Anthropic, and Ollama LLM providers alongside Gemini

### DIFF
--- a/crates/mogen-llm/src/anthropic.rs
+++ b/crates/mogen-llm/src/anthropic.rs
@@ -1,0 +1,293 @@
+//! Anthropic Messages API client.
+//!
+//! Talks to `POST {base_url}/messages` with the Claude-style
+//! `messages: [{role, content}]` shape. The system instruction goes in a
+//! top-level `system` field rather than as a message role.
+//!
+//! [`ThinkingLevel`] is mapped to the `thinking` block (Claude 3.7+ extended
+//! thinking). Pre-3.7 models silently ignore the field.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::types::{GenerateConfig, GenerateResponse, Usage};
+
+/// Default heavy text model. Sonnet sits at the price/quality sweet spot for
+/// the structured-output workload `mogen` runs.
+pub const DEFAULT_MODEL: &str = "claude-sonnet-4-5";
+
+/// Default fast model used by the Studio Prompt Enhancer / Ask modal.
+pub const DEFAULT_FAST_MODEL: &str = "claude-haiku-4-5";
+
+const DEFAULT_BASE_URL: &str = "https://api.anthropic.com/v1";
+
+/// Required `anthropic-version` header. Pinned to a known-good revision
+/// rather than `latest` so a future breaking change can't silently break the
+/// CLI.
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+/// Cap on `max_tokens`. Required by the Messages API. Set high enough to
+/// fit a sizeable DSL file without truncation; callers that want a hard cap
+/// should set [`GenerateConfig::budget_tokens`] instead.
+const DEFAULT_MAX_TOKENS: u32 = 8192;
+
+#[derive(Debug, Error)]
+pub enum AnthropicError {
+    #[error("missing ANTHROPIC_API_KEY (set env var or pass --api-key)")]
+    MissingApiKey,
+    #[error("transport error: {0}")]
+    Transport(#[from] reqwest::Error),
+    #[error("API error ({status}): {message}")]
+    Api { status: u16, message: String },
+    #[error("empty response: model produced no text content")]
+    EmptyResponse,
+    #[error("budget exceeded: {used} input+output tokens exceeds --budget-tokens={budget}")]
+    BudgetExceeded { used: u32, budget: u32 },
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
+}
+
+pub struct AnthropicClient {
+    http: reqwest::blocking::Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl AnthropicClient {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self::with_base_url(api_key, DEFAULT_BASE_URL)
+    }
+
+    pub fn with_base_url(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
+        let http = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(600))
+            .build()
+            .expect("reqwest client");
+        Self { http, api_key: api_key.into(), base_url: base_url.into() }
+    }
+
+    pub fn from_env() -> Result<Self, AnthropicError> {
+        let key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| AnthropicError::MissingApiKey)?;
+        if key.trim().is_empty() {
+            return Err(AnthropicError::MissingApiKey);
+        }
+        Ok(Self::new(key))
+    }
+
+    pub fn generate(&self, cfg: &GenerateConfig) -> Result<GenerateResponse, AnthropicError> {
+        let url = format!("{}/messages", self.base_url);
+        let body = build_request(cfg);
+
+        let resp = self
+            .http
+            .post(&url)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .json(&body)
+            .send()?;
+        let status = resp.status();
+        let bytes = resp.bytes()?;
+
+        if !status.is_success() {
+            let message = parse_error_message(&bytes);
+            return Err(AnthropicError::Api { status: status.as_u16(), message });
+        }
+
+        let parsed: RawMessageResponse = serde_json::from_slice(&bytes)
+            .map_err(|e| AnthropicError::InvalidResponse(e.to_string()))?;
+
+        // Concatenate every `text` content block in order. Thinking blocks
+        // (if any) are skipped — we only want the assistant's actual reply.
+        let mut text = String::new();
+        for block in parsed.content {
+            if block.kind == "text" {
+                if let Some(t) = block.text {
+                    text.push_str(&t);
+                }
+            }
+        }
+        if text.trim().is_empty() {
+            return Err(AnthropicError::EmptyResponse);
+        }
+
+        let usage = parsed
+            .usage
+            .map(|u| {
+                let prompt = u.input_tokens;
+                let response = u.output_tokens;
+                let cached = u.cache_read_input_tokens.unwrap_or(0);
+                Usage {
+                    prompt_tokens: prompt,
+                    response_tokens: response,
+                    total_tokens: prompt + response,
+                    cached_tokens: cached,
+                }
+            })
+            .unwrap_or_default();
+
+        if let Some(budget) = cfg.budget_tokens {
+            if usage.total_tokens > budget {
+                return Err(AnthropicError::BudgetExceeded {
+                    used: usage.total_tokens,
+                    budget,
+                });
+            }
+        }
+
+        Ok(GenerateResponse { text, usage })
+    }
+}
+
+fn build_request(cfg: &GenerateConfig) -> serde_json::Value {
+    let mut messages: Vec<serde_json::Value> = Vec::new();
+    for turn in &cfg.history {
+        messages.push(serde_json::json!({
+            "role": turn.role.chat_str(),
+            "content": turn.text,
+        }));
+    }
+    messages.push(serde_json::json!({
+        "role": "user",
+        "content": cfg.user_prompt,
+    }));
+
+    let mut req = serde_json::json!({
+        "model": cfg.model,
+        "messages": messages,
+        "max_tokens": DEFAULT_MAX_TOKENS,
+    });
+
+    if let Some(sys) = &cfg.system_instruction {
+        req["system"] = serde_json::json!(sys);
+    }
+    if let Some(t) = cfg.temperature {
+        req["temperature"] = serde_json::json!(t);
+    }
+    if let Some(level) = cfg.thinking_level {
+        // Extended thinking requires `temperature = 1.0` server-side; quietly
+        // raise it so the call doesn't 400 out. Users who want deterministic-ish
+        // sampling should leave `thinking_level = None`.
+        let budget = level.budget();
+        // `max_tokens` must be greater than `thinking.budget_tokens`.
+        let needed = budget.saturating_add(2048);
+        if needed > DEFAULT_MAX_TOKENS {
+            req["max_tokens"] = serde_json::json!(needed);
+        }
+        req["thinking"] = serde_json::json!({
+            "type": "enabled",
+            "budget_tokens": budget,
+        });
+        req["temperature"] = serde_json::json!(1.0);
+    }
+    // Anthropic accepts neither `seed` (no determinism control) nor a
+    // top-level cache field on the wire — system-prompt caching is opt-in
+    // via per-block `cache_control: { "type": "ephemeral" }`. We attach that
+    // to the system block when one is present so repeated calls in the same
+    // session (e.g. the repair loop) reuse the input cache.
+    if let Some(sys) = &cfg.system_instruction {
+        req["system"] = serde_json::json!([{
+            "type": "text",
+            "text": sys,
+            "cache_control": { "type": "ephemeral" },
+        }]);
+    }
+    req
+}
+
+fn parse_error_message(bytes: &[u8]) -> String {
+    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(bytes) {
+        if let Some(msg) = v
+            .get("error")
+            .and_then(|e| e.get("message"))
+            .and_then(|m| m.as_str())
+        {
+            return msg.to_string();
+        }
+    }
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMessageResponse {
+    #[serde(default)]
+    content: Vec<RawContentBlock>,
+    #[serde(default)]
+    usage: Option<RawUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawContentBlock {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    text: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct RawUsage {
+    #[serde(default)]
+    input_tokens: u32,
+    #[serde(default)]
+    output_tokens: u32,
+    #[serde(default)]
+    cache_read_input_tokens: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ThinkingLevel;
+
+    #[test]
+    fn request_body_routes_system_to_top_level_field() {
+        let mut cfg = GenerateConfig::new("hello");
+        cfg.model = "claude-sonnet-4-5".into();
+        cfg.system_instruction = Some("be helpful".into());
+        let body = build_request(&cfg);
+        // System is wrapped in a cache_control'd text block.
+        assert_eq!(body["system"][0]["text"], "be helpful");
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "user");
+    }
+
+    #[test]
+    fn request_body_includes_max_tokens() {
+        let mut cfg = GenerateConfig::new("x");
+        cfg.model = "claude-sonnet-4-5".into();
+        cfg.thinking_level = None;
+        let body = build_request(&cfg);
+        assert_eq!(body["max_tokens"], DEFAULT_MAX_TOKENS);
+    }
+
+    #[test]
+    fn thinking_level_high_emits_extended_thinking_block() {
+        let mut cfg = GenerateConfig::new("x");
+        cfg.model = "claude-sonnet-4-5".into();
+        cfg.thinking_level = Some(ThinkingLevel::High);
+        let body = build_request(&cfg);
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert_eq!(body["thinking"]["budget_tokens"], ThinkingLevel::High.budget());
+        // Extended thinking demands temperature = 1.0; we override.
+        assert!((body["temperature"].as_f64().unwrap() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn thinking_xhigh_bumps_max_tokens_above_budget() {
+        let mut cfg = GenerateConfig::new("x");
+        cfg.model = "claude-sonnet-4-5".into();
+        cfg.thinking_level = Some(ThinkingLevel::XHigh);
+        let body = build_request(&cfg);
+        let cap = body["max_tokens"].as_u64().unwrap() as u32;
+        assert!(cap > ThinkingLevel::XHigh.budget());
+    }
+
+    #[test]
+    fn parse_error_message_extracts_nested_field() {
+        let raw = br#"{"type":"error","error":{"type":"auth","message":"bad key"}}"#;
+        assert_eq!(parse_error_message(raw), "bad key");
+    }
+}

--- a/crates/mogen-llm/src/gemini.rs
+++ b/crates/mogen-llm/src/gemini.rs
@@ -10,6 +10,14 @@ use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+// Re-export the shared types so existing callers using `mogen_llm::gemini::*`
+// keep compiling after the multi-provider refactor. New code should import
+// these directly from `mogen_llm`.
+pub use crate::types::{
+    GenerateConfig, GenerateResponse, ImageInput, Role, ThinkingLevel, Turn, Usage,
+    DEFAULT_TEMPERATURE,
+};
+
 /// Default model for `mogen generate`. Alias auto-rolls to the newest Pro tier.
 pub const DEFAULT_MODEL: &str = "gemini-pro-latest";
 
@@ -18,65 +26,7 @@ pub const DEFAULT_MODEL: &str = "gemini-pro-latest";
 /// use — callers that need the Pro tier can still override.
 pub const DEFAULT_FAST_MODEL: &str = "gemini-flash-latest";
 
-/// Default sampling temperature. Low because `mogen` DSL is a structured
-/// output task that compiles — creative variance costs repair iterations.
-pub const DEFAULT_TEMPERATURE: f32 = 0.3;
-
 const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
-
-/// Preset buckets for Gemini's `thinkingConfig.thinkingBudget`. Gemini 2.5 Pro
-/// enables reasoning by default and will happily spend 60–120 s "thinking"
-/// before emitting a token — bounding the budget is the biggest single lever
-/// on end-to-end latency for a structured-output task like DSL generation.
-///
-/// Concrete token counts are chosen to stay within both Pro (128–32768) and
-/// Flash (0–24576) ranges, so the same preset works across models.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ThinkingLevel {
-    /// 512 tokens — fast path. Usually enough for a well-specified DSL prompt.
-    Low,
-    /// 2048 tokens — modest reasoning for slightly ambiguous prompts.
-    Medium,
-    /// 8192 tokens — for complex scenes where the model benefits from planning.
-    High,
-    /// 24576 tokens — near-max; use when you're willing to trade 2 min for quality.
-    XHigh,
-}
-
-impl ThinkingLevel {
-    /// Token budget sent as `generationConfig.thinkingConfig.thinkingBudget`.
-    pub fn budget(self) -> u32 {
-        match self {
-            ThinkingLevel::Low => 512,
-            ThinkingLevel::Medium => 2048,
-            ThinkingLevel::High => 8192,
-            ThinkingLevel::XHigh => 24576,
-        }
-    }
-
-    /// Parse a case-insensitive label. Accepts `low`, `medium`, `high`, `xhigh`
-    /// (with an `x-high` / `x_high` alias for the last, since some shells mangle it).
-    pub fn parse(s: &str) -> Option<Self> {
-        match s.trim().to_ascii_lowercase().as_str() {
-            "low" => Some(Self::Low),
-            "medium" | "med" => Some(Self::Medium),
-            "high" => Some(Self::High),
-            "xhigh" | "x-high" | "x_high" => Some(Self::XHigh),
-            _ => None,
-        }
-    }
-
-    /// Canonical lowercase key; round-trips through [`Self::parse`]. Used when
-    /// writing the `// mogen-generate thinking=…` DSL header.
-    pub fn key(self) -> &'static str {
-        match self {
-            ThinkingLevel::Low => "low",
-            ThinkingLevel::Medium => "medium",
-            ThinkingLevel::High => "high",
-            ThinkingLevel::XHigh => "xhigh",
-        }
-    }
-}
 
 #[derive(Debug, Error)]
 pub enum GeminiError {
@@ -94,114 +44,6 @@ pub enum GeminiError {
     InvalidResponse(String),
 }
 
-/// One image attached to the user turn. Sent to Gemini as an `inline_data`
-/// part alongside the text prompt — vision-capable models (the Pro tier and
-/// the multimodal Flash variants) interpret these as visual context. Used by
-/// the Studio "New from Prompt" dialog to support image-to-3D generation.
-#[derive(Debug, Clone)]
-pub struct ImageInput {
-    /// MIME type, e.g. `"image/png"` or `"image/jpeg"`. Must start with
-    /// `image/` — Gemini rejects anything else on a vision turn.
-    pub mime_type: String,
-    /// Raw bytes of the image. Encoded as base64 in the request body; not
-    /// kept in memory after [`GeminiClient::generate`] returns.
-    pub data: Vec<u8>,
-}
-
-/// One full request to `generateContent`.
-#[derive(Debug, Clone)]
-pub struct GenerateConfig {
-    pub model: String,
-    /// Single-shot prompt from the user (e.g. `"a wooden stool"`). May be
-    /// empty when [`Self::user_images`] is non-empty — the image alone is a
-    /// valid input on vision-capable models.
-    pub user_prompt: String,
-    /// Optional images attached to the user turn (image-to-3D). Encoded as
-    /// `inline_data` parts on every call, including repair iterations, so the
-    /// model retains the visual reference while it fixes validation errors.
-    pub user_images: Vec<ImageInput>,
-    /// Prior turns (e.g. first attempt's DSL + diagnostic feedback for repair).
-    pub history: Vec<Turn>,
-    /// System instruction (grammar + stdlib). See [`crate::prompt`].
-    pub system_instruction: Option<String>,
-    /// Name of a `cachedContents` resource — if set, skips re-uploading
-    /// the system instruction. Overrides `system_instruction`.
-    pub cached_content: Option<String>,
-    /// Output cap enforced client-side after the response arrives.
-    /// `None` means no cap.
-    pub budget_tokens: Option<u32>,
-    /// Sampling temperature. `None` uses the API default (typically 1.0);
-    /// [`Self::new`] sets this to [`DEFAULT_TEMPERATURE`].
-    pub temperature: Option<f32>,
-    /// Server-side seed request — note that Gemini does not currently
-    /// guarantee determinism, so we also embed the seed in the DSL header.
-    pub seed: Option<u64>,
-    /// Cap on server-side reasoning. `None` lets the model use its default
-    /// (dynamic, up to ~32k tokens on Pro) — which is what produces the
-    /// 2-minute latencies. Library default is `Some(ThinkingLevel::High)` —
-    /// a middle ground that still bounds latency while leaving room for the
-    /// model to plan complex scenes.
-    pub thinking_level: Option<ThinkingLevel>,
-}
-
-impl GenerateConfig {
-    pub fn new(user_prompt: impl Into<String>) -> Self {
-        Self {
-            model: DEFAULT_MODEL.to_string(),
-            user_prompt: user_prompt.into(),
-            user_images: Vec::new(),
-            history: Vec::new(),
-            system_instruction: None,
-            cached_content: None,
-            budget_tokens: None,
-            temperature: Some(DEFAULT_TEMPERATURE),
-            seed: None,
-            thinking_level: Some(ThinkingLevel::High),
-        }
-    }
-}
-
-/// One turn of conversation, from either side.
-#[derive(Debug, Clone)]
-pub struct Turn {
-    pub role: Role,
-    pub text: String,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Role {
-    User,
-    Model,
-}
-
-impl Role {
-    fn as_str(self) -> &'static str {
-        match self {
-            Role::User => "user",
-            Role::Model => "model",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct Usage {
-    pub prompt_tokens: u32,
-    pub response_tokens: u32,
-    pub total_tokens: u32,
-    /// Portion of `prompt_tokens` served from a `cachedContents` resource —
-    /// billed at a reduced rate. Reported by the API when caching is used.
-    pub cached_tokens: u32,
-}
-
-impl Usage {
-    pub fn add(&mut self, other: &Usage) {
-        self.prompt_tokens += other.prompt_tokens;
-        self.response_tokens += other.response_tokens;
-        self.total_tokens += other.total_tokens;
-        self.cached_tokens += other.cached_tokens;
-    }
-}
-
 /// Handle returned after creating a `cachedContents` resource. The resource
 /// name is what you pass to [`GenerateConfig::cached_content`] on subsequent
 /// calls; `expires_at_unix` lets callers persist cache state locally and
@@ -211,12 +53,6 @@ pub struct CachedContent {
     pub name: String,
     pub expires_at_unix: u64,
     pub token_count: Option<u32>,
-}
-
-#[derive(Debug, Clone)]
-pub struct GenerateResponse {
-    pub text: String,
-    pub usage: Usage,
 }
 
 pub struct GeminiClient {
@@ -261,9 +97,10 @@ impl GeminiClient {
     }
 
     pub fn generate(&self, cfg: &GenerateConfig) -> Result<GenerateResponse, GeminiError> {
+        let model = if cfg.model.is_empty() { DEFAULT_MODEL } else { cfg.model.as_str() };
         let url = format!(
             "{}/models/{}:generateContent?key={}",
-            self.base_url, cfg.model, self.api_key
+            self.base_url, model, self.api_key
         );
 
         let body = build_request(cfg);
@@ -374,7 +211,7 @@ fn build_request(cfg: &GenerateConfig) -> serde_json::Value {
     let mut contents: Vec<serde_json::Value> = Vec::new();
     for turn in &cfg.history {
         contents.push(serde_json::json!({
-            "role": turn.role.as_str(),
+            "role": turn.role.gemini_str(),
             "parts": [{ "text": turn.text }],
         }));
     }

--- a/crates/mogen-llm/src/lib.rs
+++ b/crates/mogen-llm/src/lib.rs
@@ -1,34 +1,55 @@
-//! Natural-language → DSL generation via the Gemini API.
+//! Natural-language → DSL generation across multiple LLM providers.
 //!
-//! The crate exposes three concerns that compose into `mogen generate`:
+//! The crate exposes four concerns that compose into the `mogen generate`,
+//! `modify`, `animate`, `repair`, `bench`, and `textures` commands:
 //!
-//! - [`gemini`] — HTTP client for Google's `generateContent` endpoint.
-//! - [`prompt`] — assembles the system instruction (grammar + stdlib index + examples).
-//! - [`repair`] — drives parse → validate → feed JSON diagnostics back on error.
+//! - [`provider`] — the [`LlmClient`] enum dispatches to the right backend
+//!   (Gemini, OpenAI, Anthropic, Ollama). [`Provider`] describes the
+//!   selector and per-provider defaults; [`ProviderError`] is the unified
+//!   error returned by [`LlmClient::generate`].
+//! - [`gemini`] / [`openai`] / [`anthropic`] / [`ollama`] — per-backend
+//!   HTTP clients, each with its own request/response wire types.
+//! - [`prompt`] — assembles the system instruction (grammar + stdlib index +
+//!   examples). Provider-agnostic — the same string ships to all four.
+//! - [`repair`] — drives parse → validate → feed JSON diagnostics back on
+//!   error. Takes [`LlmClient`] so it works against any provider.
 //!
-//! The top-level [`generate`] function ties them together and returns DSL text
-//! plus usage metadata. Seed handling (for reproducibility) is the caller's
-//! responsibility — wrap the output in [`embed_seed_header`] before writing to disk.
+//! The top-level [`generate_with_repair`] function ties the provider client
+//! and the repair loop together. Seed handling (for reproducibility) is the
+//! caller's responsibility — wrap the output in [`embed_seed_header`] before
+//! writing to disk.
 
+pub mod anthropic;
 pub mod cache;
 pub mod gemini;
 pub mod image;
+pub mod ollama;
+pub mod openai;
 pub mod pbr_maps;
 pub mod prompt;
+pub mod provider;
 pub mod repair;
 pub mod textures;
+pub mod types;
 
 pub use cache::{default_cache_path, resolve_or_create as resolve_or_create_cache, DEFAULT_TTL_SECONDS};
-pub use gemini::{
-    CachedContent, GeminiClient, GeminiError, GenerateConfig, ImageInput, ThinkingLevel, Usage,
-    DEFAULT_FAST_MODEL,
-};
+pub use gemini::{CachedContent, GeminiClient, GeminiError};
 pub use image::{GeneratedImage, DEFAULT_IMAGE_MODEL};
 pub use prompt::{system_instruction, StdlibIndex};
+pub use provider::{LlmClient, Provider, ProviderError};
 pub use repair::{
     generate_with_repair, repair_message, validate_text, GenerateOutcome, RepairConfig,
 };
 pub use textures::parse_prompt_header;
+pub use types::{
+    GenerateConfig, GenerateResponse, ImageInput, Role, ThinkingLevel, Turn, Usage,
+    DEFAULT_TEMPERATURE,
+};
+
+/// Default heavy text model — kept as the legacy alias so existing callers
+/// (CLI clap defaults, Studio settings) keep compiling. New code should
+/// pick the per-provider default via [`Provider::default_model`].
+pub const DEFAULT_FAST_MODEL: &str = gemini::DEFAULT_FAST_MODEL;
 
 /// Prepend a seed comment to DSL text so rebuilds are reproducible.
 ///

--- a/crates/mogen-llm/src/ollama.rs
+++ b/crates/mogen-llm/src/ollama.rs
@@ -1,0 +1,216 @@
+//! Ollama local-LLM client.
+//!
+//! Talks to `POST {base_url}/api/chat` against a local Ollama server
+//! (default `http://localhost:11434`). The shape is similar to OpenAI but
+//! lives under `message.content` and reports usage as `prompt_eval_count` /
+//! `eval_count`.
+//!
+//! Ollama runs entirely on the user's machine and has no concept of
+//! `cachedContents`, extended thinking, or per-call API keys. The
+//! corresponding fields on [`GenerateConfig`] are silently ignored —
+//! `seed` and `temperature` ride through `options.{seed, temperature}`.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::types::{GenerateConfig, GenerateResponse, Usage};
+
+/// Default model. Pick a widely-available, mid-sized open weights model so
+/// `mogen generate --provider ollama` works the moment a user runs
+/// `ollama pull llama3.1`.
+pub const DEFAULT_MODEL: &str = "llama3.1";
+
+const DEFAULT_BASE_URL: &str = "http://localhost:11434";
+
+#[derive(Debug, Error)]
+pub enum OllamaError {
+    #[error("transport error: {0}")]
+    Transport(#[from] reqwest::Error),
+    #[error("API error ({status}): {message}")]
+    Api { status: u16, message: String },
+    #[error("empty response: model produced no message content")]
+    EmptyResponse,
+    #[error("budget exceeded: {used} input+output tokens exceeds --budget-tokens={budget}")]
+    BudgetExceeded { used: u32, budget: u32 },
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
+}
+
+pub struct OllamaClient {
+    http: reqwest::blocking::Client,
+    /// Optional bearer token. Empty for the common keyless local-only setup.
+    api_key: String,
+    base_url: String,
+}
+
+impl OllamaClient {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self::with_base_url(api_key, DEFAULT_BASE_URL)
+    }
+
+    pub fn with_base_url(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
+        // Local generation can take many minutes on small CPUs; give it the
+        // same headroom as the cloud paths.
+        let http = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(600))
+            .build()
+            .expect("reqwest client");
+        Self { http, api_key: api_key.into(), base_url: base_url.into() }
+    }
+
+    pub fn generate(&self, cfg: &GenerateConfig) -> Result<GenerateResponse, OllamaError> {
+        let url = format!("{}/api/chat", self.base_url);
+        let body = build_request(cfg);
+
+        let mut req = self.http.post(&url).json(&body);
+        if !self.api_key.trim().is_empty() {
+            req = req.bearer_auth(&self.api_key);
+        }
+        let resp = req.send()?;
+        let status = resp.status();
+        let bytes = resp.bytes()?;
+
+        if !status.is_success() {
+            let message = parse_error_message(&bytes);
+            return Err(OllamaError::Api { status: status.as_u16(), message });
+        }
+
+        let parsed: RawChatResponse = serde_json::from_slice(&bytes)
+            .map_err(|e| OllamaError::InvalidResponse(e.to_string()))?;
+
+        let text = parsed.message.and_then(|m| m.content).unwrap_or_default();
+        if text.trim().is_empty() {
+            return Err(OllamaError::EmptyResponse);
+        }
+
+        let prompt = parsed.prompt_eval_count.unwrap_or(0);
+        let response = parsed.eval_count.unwrap_or(0);
+        let usage = Usage {
+            prompt_tokens: prompt,
+            response_tokens: response,
+            total_tokens: prompt + response,
+            cached_tokens: 0,
+        };
+
+        if let Some(budget) = cfg.budget_tokens {
+            if usage.total_tokens > budget {
+                return Err(OllamaError::BudgetExceeded { used: usage.total_tokens, budget });
+            }
+        }
+
+        Ok(GenerateResponse { text, usage })
+    }
+}
+
+fn build_request(cfg: &GenerateConfig) -> serde_json::Value {
+    let mut messages: Vec<serde_json::Value> = Vec::new();
+    if let Some(sys) = &cfg.system_instruction {
+        messages.push(serde_json::json!({ "role": "system", "content": sys }));
+    }
+    for turn in &cfg.history {
+        messages.push(serde_json::json!({
+            "role": turn.role.chat_str(),
+            "content": turn.text,
+        }));
+    }
+    messages.push(serde_json::json!({
+        "role": "user",
+        "content": cfg.user_prompt,
+    }));
+
+    let mut options = serde_json::Map::new();
+    if let Some(t) = cfg.temperature {
+        options.insert("temperature".into(), serde_json::json!(t));
+    }
+    if let Some(s) = cfg.seed {
+        // Ollama's seed is an i32 — saturate.
+        let clipped = (s as i64) & 0x7FFF_FFFF;
+        options.insert("seed".into(), serde_json::json!(clipped));
+    }
+
+    let mut req = serde_json::json!({
+        "model": cfg.model,
+        "messages": messages,
+        // Streaming would interleave many partial JSON docs in the response
+        // body; the synchronous client only handles a single response.
+        "stream": false,
+    });
+    if !options.is_empty() {
+        req["options"] = serde_json::Value::Object(options);
+    }
+    req
+}
+
+fn parse_error_message(bytes: &[u8]) -> String {
+    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(bytes) {
+        if let Some(msg) = v.get("error").and_then(|m| m.as_str()) {
+            return msg.to_string();
+        }
+    }
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct RawChatResponse {
+    #[serde(default)]
+    message: Option<RawMessage>,
+    #[serde(default)]
+    prompt_eval_count: Option<u32>,
+    #[serde(default)]
+    eval_count: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMessage {
+    #[serde(default)]
+    content: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Role, Turn};
+
+    #[test]
+    fn request_body_includes_system_message() {
+        let mut cfg = GenerateConfig::new("hello");
+        cfg.model = "llama3.1".into();
+        cfg.system_instruction = Some("be helpful".into());
+        let body = build_request(&cfg);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "be helpful");
+    }
+
+    #[test]
+    fn request_body_threads_history_with_assistant_role() {
+        let mut cfg = GenerateConfig::new("again");
+        cfg.model = "llama3.1".into();
+        cfg.history.push(Turn { role: Role::Model, text: "scene { box }".into() });
+        let body = build_request(&cfg);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages[0]["role"], "assistant");
+    }
+
+    #[test]
+    fn options_carry_seed_and_temperature() {
+        let mut cfg = GenerateConfig::new("x");
+        cfg.model = "llama3.1".into();
+        cfg.seed = Some(7);
+        cfg.temperature = Some(0.42);
+        let body = build_request(&cfg);
+        assert_eq!(body["options"]["seed"], 7);
+        assert!((body["options"]["temperature"].as_f64().unwrap() - 0.42).abs() < 1e-6);
+    }
+
+    #[test]
+    fn streaming_is_disabled() {
+        let mut cfg = GenerateConfig::new("x");
+        cfg.model = "llama3.1".into();
+        let body = build_request(&cfg);
+        assert_eq!(body["stream"], false);
+    }
+}

--- a/crates/mogen-llm/src/openai.rs
+++ b/crates/mogen-llm/src/openai.rs
@@ -1,0 +1,266 @@
+//! OpenAI Chat Completions client.
+//!
+//! Talks to `POST {base_url}/chat/completions` with the standard
+//! `messages: [{role, content}]` shape. Supports the GPT-4/4o/4.1/5 line and
+//! the o-series reasoning models — the latter pick up [`ThinkingLevel`] via
+//! the `reasoning.effort` field, which non-reasoning models silently ignore.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::types::{GenerateConfig, GenerateResponse, ThinkingLevel, Usage};
+
+/// Default heavy text model. Picked for broad availability and a sensible
+/// quality/cost ratio for structured-output tasks like DSL generation.
+pub const DEFAULT_MODEL: &str = "gpt-4o";
+
+/// Default fast model used by the Studio Prompt Enhancer / Ask modal.
+pub const DEFAULT_FAST_MODEL: &str = "gpt-4o-mini";
+
+const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+
+#[derive(Debug, Error)]
+pub enum OpenAIError {
+    #[error("missing OPENAI_API_KEY (set env var or pass --api-key)")]
+    MissingApiKey,
+    #[error("transport error: {0}")]
+    Transport(#[from] reqwest::Error),
+    #[error("API error ({status}): {message}")]
+    Api { status: u16, message: String },
+    #[error("empty response: model produced no choices or text")]
+    EmptyResponse,
+    #[error("budget exceeded: {used} input+output tokens exceeds --budget-tokens={budget}")]
+    BudgetExceeded { used: u32, budget: u32 },
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
+}
+
+pub struct OpenAIClient {
+    http: reqwest::blocking::Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl OpenAIClient {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self::with_base_url(api_key, DEFAULT_BASE_URL)
+    }
+
+    pub fn with_base_url(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
+        let http = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(600))
+            .build()
+            .expect("reqwest client");
+        Self { http, api_key: api_key.into(), base_url: base_url.into() }
+    }
+
+    pub fn from_env() -> Result<Self, OpenAIError> {
+        let key = std::env::var("OPENAI_API_KEY").map_err(|_| OpenAIError::MissingApiKey)?;
+        if key.trim().is_empty() {
+            return Err(OpenAIError::MissingApiKey);
+        }
+        Ok(Self::new(key))
+    }
+
+    pub fn generate(&self, cfg: &GenerateConfig) -> Result<GenerateResponse, OpenAIError> {
+        let url = format!("{}/chat/completions", self.base_url);
+        let body = build_request(cfg);
+
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()?;
+        let status = resp.status();
+        let bytes = resp.bytes()?;
+
+        if !status.is_success() {
+            let message = parse_error_message(&bytes);
+            return Err(OpenAIError::Api { status: status.as_u16(), message });
+        }
+
+        let parsed: RawChatResponse = serde_json::from_slice(&bytes)
+            .map_err(|e| OpenAIError::InvalidResponse(e.to_string()))?;
+
+        let text = parsed
+            .choices
+            .into_iter()
+            .find_map(|c| c.message.content)
+            .ok_or(OpenAIError::EmptyResponse)?;
+
+        if text.trim().is_empty() {
+            return Err(OpenAIError::EmptyResponse);
+        }
+
+        let usage = parsed
+            .usage
+            .map(|u| Usage {
+                prompt_tokens: u.prompt_tokens,
+                response_tokens: u.completion_tokens,
+                total_tokens: u.total_tokens,
+                cached_tokens: u
+                    .prompt_tokens_details
+                    .and_then(|d| d.cached_tokens)
+                    .unwrap_or(0),
+            })
+            .unwrap_or_default();
+
+        if let Some(budget) = cfg.budget_tokens {
+            if usage.total_tokens > budget {
+                return Err(OpenAIError::BudgetExceeded { used: usage.total_tokens, budget });
+            }
+        }
+
+        Ok(GenerateResponse { text, usage })
+    }
+}
+
+fn build_request(cfg: &GenerateConfig) -> serde_json::Value {
+    let mut messages: Vec<serde_json::Value> = Vec::new();
+    if let Some(sys) = &cfg.system_instruction {
+        messages.push(serde_json::json!({ "role": "system", "content": sys }));
+    }
+    for turn in &cfg.history {
+        messages.push(serde_json::json!({
+            "role": turn.role.chat_str(),
+            "content": turn.text,
+        }));
+    }
+    messages.push(serde_json::json!({
+        "role": "user",
+        "content": cfg.user_prompt,
+    }));
+
+    let mut req = serde_json::json!({
+        "model": cfg.model,
+        "messages": messages,
+    });
+
+    if let Some(t) = cfg.temperature {
+        req["temperature"] = serde_json::json!(t);
+    }
+    if let Some(s) = cfg.seed {
+        // OpenAI accepts seed as a 64-bit signed integer.
+        req["seed"] = serde_json::json!(s as i64);
+    }
+    if let Some(level) = cfg.thinking_level {
+        // o-series and gpt-5 reasoning models accept this; non-reasoning
+        // models silently ignore unknown top-level fields. We send it
+        // unconditionally to keep the request shape uniform.
+        req["reasoning"] = serde_json::json!({ "effort": level.openai_effort() });
+    }
+    let _ = ThinkingLevel::Low; // keep ThinkingLevel imported even if pruned later
+    req
+}
+
+fn parse_error_message(bytes: &[u8]) -> String {
+    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(bytes) {
+        if let Some(msg) = v
+            .get("error")
+            .and_then(|e| e.get("message"))
+            .and_then(|m| m.as_str())
+        {
+            return msg.to_string();
+        }
+    }
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+#[derive(Debug, Deserialize)]
+struct RawChatResponse {
+    #[serde(default)]
+    choices: Vec<RawChoice>,
+    #[serde(default)]
+    usage: Option<RawUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawChoice {
+    message: RawMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMessage {
+    #[serde(default)]
+    content: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct RawUsage {
+    #[serde(default)]
+    prompt_tokens: u32,
+    #[serde(default)]
+    completion_tokens: u32,
+    #[serde(default)]
+    total_tokens: u32,
+    #[serde(default)]
+    prompt_tokens_details: Option<RawPromptDetails>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct RawPromptDetails {
+    #[serde(default)]
+    cached_tokens: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Role, Turn};
+
+    #[test]
+    fn request_body_includes_system_message() {
+        let mut cfg = GenerateConfig::new("hello");
+        cfg.model = "gpt-4o".into();
+        cfg.system_instruction = Some("be helpful".into());
+        let body = build_request(&cfg);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "be helpful");
+        assert_eq!(messages.last().unwrap()["role"], "user");
+        assert_eq!(messages.last().unwrap()["content"], "hello");
+    }
+
+    #[test]
+    fn request_body_threads_history_with_assistant_role() {
+        let mut cfg = GenerateConfig::new("again");
+        cfg.model = "gpt-4o".into();
+        cfg.history.push(Turn { role: Role::User, text: "make a chair".into() });
+        cfg.history.push(Turn { role: Role::Model, text: "scene { box }".into() });
+        let body = build_request(&cfg);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[1]["role"], "assistant");
+    }
+
+    #[test]
+    fn request_body_includes_seed_and_temperature() {
+        let mut cfg = GenerateConfig::new("x");
+        cfg.model = "gpt-4o".into();
+        cfg.seed = Some(7);
+        cfg.temperature = Some(0.42);
+        let body = build_request(&cfg);
+        assert_eq!(body["seed"], 7);
+        assert!((body["temperature"].as_f64().unwrap() - 0.42).abs() < 1e-6);
+    }
+
+    #[test]
+    fn request_body_emits_reasoning_effort_for_thinking_level() {
+        let mut cfg = GenerateConfig::new("x");
+        cfg.model = "gpt-4o".into();
+        cfg.thinking_level = Some(ThinkingLevel::High);
+        let body = build_request(&cfg);
+        assert_eq!(body["reasoning"]["effort"], "high");
+    }
+
+    #[test]
+    fn parse_error_message_extracts_nested_field() {
+        let raw = br#"{"error":{"message":"invalid api key","type":"auth"}}"#;
+        assert_eq!(parse_error_message(raw), "invalid api key");
+    }
+}

--- a/crates/mogen-llm/src/provider.rs
+++ b/crates/mogen-llm/src/provider.rs
@@ -1,0 +1,343 @@
+//! Provider selector + unified [`LlmClient`] used by every higher-level entry
+//! point in this crate (the repair loop, the textures pipeline's text calls,
+//! and the Studio Q&A modal).
+//!
+//! Adding a new provider means: drop a new module under `src/`, define a
+//! client struct that implements `generate(&GenerateConfig) ->
+//! Result<GenerateResponse, ProviderError>`, then wire it into [`Provider`]
+//! and [`LlmClient`] here.
+
+use std::fmt;
+
+use crate::anthropic::{AnthropicClient, AnthropicError};
+use crate::gemini::{GeminiClient, GeminiError};
+use crate::ollama::{OllamaClient, OllamaError};
+use crate::openai::{OpenAIClient, OpenAIError};
+use crate::types::{GenerateConfig, GenerateResponse};
+
+/// Closed set of LLM backends the CLI / Studio can talk to. Persisted as a
+/// lowercase label (see [`Provider::key`]) so adding new variants doesn't
+/// invalidate old settings files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Provider {
+    Gemini,
+    OpenAI,
+    Anthropic,
+    Ollama,
+}
+
+impl Provider {
+    /// Round-trip key. `gemini` is preserved as the legacy/default value so
+    /// old settings files keep working when the field is absent.
+    pub fn key(self) -> &'static str {
+        match self {
+            Provider::Gemini => "gemini",
+            Provider::OpenAI => "openai",
+            Provider::Anthropic => "anthropic",
+            Provider::Ollama => "ollama",
+        }
+    }
+
+    /// Human-friendly label for UI dropdowns.
+    pub fn label(self) -> &'static str {
+        match self {
+            Provider::Gemini => "Gemini",
+            Provider::OpenAI => "OpenAI",
+            Provider::Anthropic => "Anthropic",
+            Provider::Ollama => "Ollama (local)",
+        }
+    }
+
+    /// Parse a case-insensitive label / key. Accepts the canonical keys as
+    /// well as common spellings the user might pass on the CLI
+    /// (`google`, `gpt`, `claude`).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "gemini" | "google" => Some(Self::Gemini),
+            "openai" | "gpt" | "chatgpt" => Some(Self::OpenAI),
+            "anthropic" | "claude" => Some(Self::Anthropic),
+            "ollama" | "local" => Some(Self::Ollama),
+            _ => None,
+        }
+    }
+
+    /// Environment variable consulted for the API key by [`resolve_api_key`].
+    /// Ollama runs locally and has no key by default — `OLLAMA_API_KEY` is
+    /// still consulted for users who put a reverse proxy in front of it.
+    pub fn env_var(self) -> &'static str {
+        match self {
+            Provider::Gemini => "GEMINI_API_KEY",
+            Provider::OpenAI => "OPENAI_API_KEY",
+            Provider::Anthropic => "ANTHROPIC_API_KEY",
+            Provider::Ollama => "OLLAMA_API_KEY",
+        }
+    }
+
+    /// Default heavy / "thinking" model id for this provider. Surfaced as
+    /// the CLI default when `--model` is omitted.
+    pub fn default_model(self) -> &'static str {
+        match self {
+            Provider::Gemini => crate::gemini::DEFAULT_MODEL,
+            Provider::OpenAI => crate::openai::DEFAULT_MODEL,
+            Provider::Anthropic => crate::anthropic::DEFAULT_MODEL,
+            Provider::Ollama => crate::ollama::DEFAULT_MODEL,
+        }
+    }
+
+    /// Default fast / cheap model id (used by the Studio Prompt Enhancer
+    /// and Ask modal).
+    pub fn default_fast_model(self) -> &'static str {
+        match self {
+            Provider::Gemini => crate::gemini::DEFAULT_FAST_MODEL,
+            Provider::OpenAI => crate::openai::DEFAULT_FAST_MODEL,
+            Provider::Anthropic => crate::anthropic::DEFAULT_FAST_MODEL,
+            Provider::Ollama => crate::ollama::DEFAULT_MODEL,
+        }
+    }
+
+    /// Whether this provider supports image generation (used by the textures
+    /// pipeline). Today only Gemini does — non-Gemini providers fall back to
+    /// a clear error in that command.
+    pub fn supports_images(self) -> bool {
+        matches!(self, Provider::Gemini)
+    }
+
+    /// Whether this provider supports the persistent `cachedContents`-style
+    /// system-instruction cache. Only Gemini today.
+    pub fn supports_cached_content(self) -> bool {
+        matches!(self, Provider::Gemini)
+    }
+}
+
+impl Default for Provider {
+    fn default() -> Self {
+        Provider::Gemini
+    }
+}
+
+impl fmt::Display for Provider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// Provider-agnostic error type emitted by [`LlmClient::generate`]. Each
+/// per-provider error variant is mapped into one of these on the way out so
+/// callers (the repair loop, the Studio classifier) don't need to match on
+/// four error enums.
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderError {
+    #[error("missing {var} (set the environment variable or pass --api-key)")]
+    MissingApiKey { var: &'static str },
+    #[error("transport error: {0}")]
+    Transport(String),
+    #[error("API error ({status}): {message}")]
+    Api { status: u16, message: String },
+    #[error("empty response: no candidates or text parts")]
+    EmptyResponse,
+    #[error("budget exceeded: {used} input+output tokens exceeds --budget-tokens={budget}")]
+    BudgetExceeded { used: u32, budget: u32 },
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
+    #[error("provider {provider} does not support {feature}")]
+    Unsupported { provider: Provider, feature: &'static str },
+}
+
+impl From<GeminiError> for ProviderError {
+    fn from(e: GeminiError) -> Self {
+        match e {
+            GeminiError::MissingApiKey => Self::MissingApiKey { var: "GEMINI_API_KEY" },
+            GeminiError::Transport(err) => Self::Transport(format_reqwest(&err)),
+            GeminiError::Api { status, message } => Self::Api { status, message },
+            GeminiError::EmptyResponse => Self::EmptyResponse,
+            GeminiError::BudgetExceeded { used, budget } => Self::BudgetExceeded { used, budget },
+            GeminiError::InvalidResponse(s) => Self::InvalidResponse(s),
+        }
+    }
+}
+
+impl From<OpenAIError> for ProviderError {
+    fn from(e: OpenAIError) -> Self {
+        match e {
+            OpenAIError::MissingApiKey => Self::MissingApiKey { var: "OPENAI_API_KEY" },
+            OpenAIError::Transport(err) => Self::Transport(format_reqwest(&err)),
+            OpenAIError::Api { status, message } => Self::Api { status, message },
+            OpenAIError::EmptyResponse => Self::EmptyResponse,
+            OpenAIError::BudgetExceeded { used, budget } => Self::BudgetExceeded { used, budget },
+            OpenAIError::InvalidResponse(s) => Self::InvalidResponse(s),
+        }
+    }
+}
+
+impl From<AnthropicError> for ProviderError {
+    fn from(e: AnthropicError) -> Self {
+        match e {
+            AnthropicError::MissingApiKey => Self::MissingApiKey { var: "ANTHROPIC_API_KEY" },
+            AnthropicError::Transport(err) => Self::Transport(format_reqwest(&err)),
+            AnthropicError::Api { status, message } => Self::Api { status, message },
+            AnthropicError::EmptyResponse => Self::EmptyResponse,
+            AnthropicError::BudgetExceeded { used, budget } => Self::BudgetExceeded { used, budget },
+            AnthropicError::InvalidResponse(s) => Self::InvalidResponse(s),
+        }
+    }
+}
+
+impl From<OllamaError> for ProviderError {
+    fn from(e: OllamaError) -> Self {
+        match e {
+            OllamaError::Transport(err) => Self::Transport(format_reqwest(&err)),
+            OllamaError::Api { status, message } => Self::Api { status, message },
+            OllamaError::EmptyResponse => Self::EmptyResponse,
+            OllamaError::BudgetExceeded { used, budget } => Self::BudgetExceeded { used, budget },
+            OllamaError::InvalidResponse(s) => Self::InvalidResponse(s),
+        }
+    }
+}
+
+fn format_reqwest(err: &reqwest::Error) -> String {
+    use std::error::Error as _;
+    let mut out = err.to_string();
+    let mut src: Option<&dyn std::error::Error> = err.source();
+    while let Some(e) = src {
+        out.push_str(": ");
+        out.push_str(&e.to_string());
+        src = e.source();
+    }
+    out
+}
+
+/// Unified handle to any backend. Constructed via [`LlmClient::new`] or one of
+/// the per-provider `from_…` constructors.
+///
+/// Cloning is cheap (the underlying reqwest client uses an Arc-pool inside).
+pub enum LlmClient {
+    Gemini(GeminiClient),
+    OpenAI(OpenAIClient),
+    Anthropic(AnthropicClient),
+    Ollama(OllamaClient),
+}
+
+impl LlmClient {
+    /// Construct a client for `provider`. `api_key` is required for the cloud
+    /// providers; pass an empty string for Ollama (which is happy to talk to
+    /// `http://localhost:11434` unauthenticated).
+    pub fn new(provider: Provider, api_key: impl Into<String>) -> Self {
+        let api_key = api_key.into();
+        match provider {
+            Provider::Gemini => LlmClient::Gemini(GeminiClient::new(api_key)),
+            Provider::OpenAI => LlmClient::OpenAI(OpenAIClient::new(api_key)),
+            Provider::Anthropic => LlmClient::Anthropic(AnthropicClient::new(api_key)),
+            Provider::Ollama => LlmClient::Ollama(OllamaClient::new(api_key)),
+        }
+    }
+
+    /// Construct a client for `provider`, reading the API key from the
+    /// matching environment variable ([`Provider::env_var`]).
+    pub fn from_env(provider: Provider) -> Result<Self, ProviderError> {
+        let var = provider.env_var();
+        let key = std::env::var(var).unwrap_or_default();
+        if matches!(provider, Provider::Ollama) {
+            return Ok(Self::new(provider, key));
+        }
+        if key.trim().is_empty() {
+            return Err(ProviderError::MissingApiKey { var });
+        }
+        Ok(Self::new(provider, key))
+    }
+
+    /// Override the base URL — used by tests to point at a `tiny_http` mock
+    /// server. For Ollama this also lets users point at a non-default host.
+    pub fn with_base_url(
+        provider: Provider,
+        api_key: impl Into<String>,
+        base_url: impl Into<String>,
+    ) -> Self {
+        let api_key = api_key.into();
+        let base_url = base_url.into();
+        match provider {
+            Provider::Gemini => LlmClient::Gemini(GeminiClient::with_base_url(api_key, base_url)),
+            Provider::OpenAI => LlmClient::OpenAI(OpenAIClient::with_base_url(api_key, base_url)),
+            Provider::Anthropic => {
+                LlmClient::Anthropic(AnthropicClient::with_base_url(api_key, base_url))
+            }
+            Provider::Ollama => LlmClient::Ollama(OllamaClient::with_base_url(api_key, base_url)),
+        }
+    }
+
+    /// Which backend this client talks to.
+    pub fn provider(&self) -> Provider {
+        match self {
+            LlmClient::Gemini(_) => Provider::Gemini,
+            LlmClient::OpenAI(_) => Provider::OpenAI,
+            LlmClient::Anthropic(_) => Provider::Anthropic,
+            LlmClient::Ollama(_) => Provider::Ollama,
+        }
+    }
+
+    /// Borrow the underlying [`GeminiClient`] for image generation and the
+    /// `cachedContents` cache. Returns `None` for non-Gemini providers — the
+    /// caller decides whether to fall back or surface
+    /// [`ProviderError::Unsupported`].
+    pub fn as_gemini(&self) -> Option<&GeminiClient> {
+        match self {
+            LlmClient::Gemini(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    /// Issue a single text-completion call. Mapping is provider-specific;
+    /// see each module for the wire shape.
+    pub fn generate(&self, cfg: &GenerateConfig) -> Result<GenerateResponse, ProviderError> {
+        match self {
+            LlmClient::Gemini(c) => c.generate(cfg).map_err(Into::into),
+            LlmClient::OpenAI(c) => c.generate(cfg).map_err(Into::into),
+            LlmClient::Anthropic(c) => c.generate(cfg).map_err(Into::into),
+            LlmClient::Ollama(c) => c.generate(cfg).map_err(Into::into),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_keys_round_trip() {
+        for p in [Provider::Gemini, Provider::OpenAI, Provider::Anthropic, Provider::Ollama] {
+            assert_eq!(Provider::parse(p.key()), Some(p));
+        }
+    }
+
+    #[test]
+    fn provider_parse_accepts_aliases() {
+        assert_eq!(Provider::parse("Google"), Some(Provider::Gemini));
+        assert_eq!(Provider::parse("gpt"), Some(Provider::OpenAI));
+        assert_eq!(Provider::parse("CLAUDE"), Some(Provider::Anthropic));
+        assert_eq!(Provider::parse("local"), Some(Provider::Ollama));
+        assert_eq!(Provider::parse("wat"), None);
+    }
+
+    #[test]
+    fn from_env_returns_missing_key_for_blank_cloud_provider() {
+        // SAFETY: tests are single-threaded per file by default in cargo, but
+        // these env mutations could race under `--test-threads`. Using
+        // unique variable names per provider would be ideal; here we just
+        // unset and assert the error path.
+        std::env::remove_var("OPENAI_API_KEY");
+        match LlmClient::from_env(Provider::OpenAI) {
+            Err(ProviderError::MissingApiKey { var: "OPENAI_API_KEY" }) => {}
+            Err(other) => panic!("wrong error: {other}"),
+            Ok(_) => panic!("expected MissingApiKey but got Ok"),
+        }
+    }
+
+    #[test]
+    fn from_env_succeeds_for_ollama_without_key() {
+        // Ollama tolerates a blank key; this should construct a client.
+        std::env::remove_var("OLLAMA_API_KEY");
+        let c = LlmClient::from_env(Provider::Ollama).unwrap_or_else(|_| {
+            panic!("ollama should work keyless")
+        });
+        assert_eq!(c.provider(), Provider::Ollama);
+    }
+}

--- a/crates/mogen-llm/src/repair.rs
+++ b/crates/mogen-llm/src/repair.rs
@@ -20,7 +20,8 @@ use std::collections::BTreeSet;
 
 use mogen_core::{has_errors, Diagnostic, Severity, Span};
 
-use crate::gemini::{GeminiClient, GeminiError, GenerateConfig, Usage};
+use crate::provider::{LlmClient, ProviderError};
+use crate::types::{GenerateConfig, Usage};
 
 pub struct RepairConfig {
     /// How many follow-up calls we allow after the first one. Default 2.
@@ -54,7 +55,7 @@ pub struct GenerateOutcome {
     /// Validator diagnostics for `dsl`. If empty, the DSL parsed cleanly and
     /// validated with no errors.
     pub diagnostics: Vec<Diagnostic>,
-    /// Gemini usage summed across all calls in this session.
+    /// LLM usage summed across all calls in this session.
     pub usage: Usage,
     /// How many calls we actually made (initial + repair). Always `>= 1` on success.
     pub call_count: u32,
@@ -68,10 +69,10 @@ impl GenerateOutcome {
 
 /// Run `generate` then up to `repair.max_iters` repair passes.
 pub fn generate_with_repair(
-    client: &GeminiClient,
+    client: &LlmClient,
     cfg: GenerateConfig,
     repair: &RepairConfig,
-) -> Result<GenerateOutcome, GeminiError> {
+) -> Result<GenerateOutcome, ProviderError> {
     let mut cfg = cfg;
     let mut total_usage = Usage::default();
     let mut calls = 0u32;

--- a/crates/mogen-llm/src/types.rs
+++ b/crates/mogen-llm/src/types.rs
@@ -1,0 +1,216 @@
+//! Provider-agnostic request/response types shared by every LLM backend.
+//!
+//! Every provider implementation in this crate (`gemini`, `openai`,
+//! `anthropic`, `ollama`) consumes [`GenerateConfig`] and produces
+//! [`GenerateResponse`]. Provider-specific knobs that have no analogue across
+//! backends (e.g. Gemini's `cachedContents`) live on [`GenerateConfig`] as
+//! optional fields and are simply ignored by providers that don't honour them.
+
+/// Default sampling temperature. Low because `mogen` DSL is a structured
+/// output task that compiles — creative variance costs repair iterations.
+pub const DEFAULT_TEMPERATURE: f32 = 0.3;
+
+/// Cap on the total reasoning budget the model may spend before emitting a
+/// token. Each provider maps these buckets onto its own native control:
+///
+/// - Gemini: `generationConfig.thinkingConfig.thinkingBudget` (token count).
+/// - Anthropic: `thinking.budget_tokens` (token count, requires
+///   `thinking.type = "enabled"`).
+/// - OpenAI: `reasoning.effort` (`low`/`medium`/`high`/`high`).
+/// - Ollama: ignored (local models don't expose a separate reasoning budget).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThinkingLevel {
+    /// 512 tokens / `low` effort — fast path. Usually enough for a
+    /// well-specified DSL prompt.
+    Low,
+    /// 2048 tokens / `medium` effort — modest reasoning for slightly
+    /// ambiguous prompts.
+    Medium,
+    /// 8192 tokens / `high` effort — for complex scenes where the model
+    /// benefits from planning.
+    High,
+    /// 24576 tokens / `high` effort — near-max; use when you're willing to
+    /// trade ~2 min for quality. OpenAI tops out at `high`, so XHigh and
+    /// High collapse to the same setting there.
+    XHigh,
+}
+
+impl ThinkingLevel {
+    /// Token budget — used by providers that take a numeric cap (Gemini,
+    /// Anthropic). Concrete values stay within both Gemini Pro (128–32768)
+    /// and Flash (0–24576) ranges.
+    pub fn budget(self) -> u32 {
+        match self {
+            ThinkingLevel::Low => 512,
+            ThinkingLevel::Medium => 2048,
+            ThinkingLevel::High => 8192,
+            ThinkingLevel::XHigh => 24576,
+        }
+    }
+
+    /// OpenAI `reasoning.effort` mapping. OpenAI exposes `low`, `medium`,
+    /// `high` only — XHigh maps to `high`.
+    pub fn openai_effort(self) -> &'static str {
+        match self {
+            ThinkingLevel::Low => "low",
+            ThinkingLevel::Medium => "medium",
+            ThinkingLevel::High | ThinkingLevel::XHigh => "high",
+        }
+    }
+
+    /// Parse a case-insensitive label. Accepts `low`, `medium`, `high`,
+    /// `xhigh` (with `x-high` / `x_high` aliases for the last, since some
+    /// shells mangle it).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "low" => Some(Self::Low),
+            "medium" | "med" => Some(Self::Medium),
+            "high" => Some(Self::High),
+            "xhigh" | "x-high" | "x_high" => Some(Self::XHigh),
+            _ => None,
+        }
+    }
+
+    /// Canonical lowercase key; round-trips through [`Self::parse`]. Used
+    /// when writing the `// mogen-generate thinking=…` DSL header.
+    pub fn key(self) -> &'static str {
+        match self {
+            ThinkingLevel::Low => "low",
+            ThinkingLevel::Medium => "medium",
+            ThinkingLevel::High => "high",
+            ThinkingLevel::XHigh => "xhigh",
+        }
+    }
+}
+
+/// One image attached to the user turn. Sent to providers that support
+/// vision input (currently Gemini only) as a base64-encoded inline-data part
+/// alongside the text prompt; non-vision providers silently ignore the field.
+/// Used by Studio's "New from Prompt" dialog to enable image-to-3D generation.
+#[derive(Debug, Clone)]
+pub struct ImageInput {
+    /// MIME type, e.g. `"image/png"` or `"image/jpeg"`. Must start with
+    /// `image/` — Gemini rejects anything else on a vision turn.
+    pub mime_type: String,
+    /// Raw bytes of the image. Encoded as base64 by the provider client.
+    pub data: Vec<u8>,
+}
+
+/// One full request to a backend's chat-completion-style endpoint.
+///
+/// The same struct is consumed by every provider in this crate. Fields that
+/// only one provider understands (`cached_content` and `user_images` for
+/// Gemini, `seed` for some) are silently ignored elsewhere.
+#[derive(Debug, Clone)]
+pub struct GenerateConfig {
+    pub model: String,
+    /// Single-shot prompt from the user (e.g. `"a wooden stool"`). May be
+    /// empty when [`Self::user_images`] is non-empty — the image alone is a
+    /// valid input on vision-capable providers.
+    pub user_prompt: String,
+    /// Optional images attached to the user turn (image-to-3D). Vision-capable
+    /// providers re-send these on every call (including repair iterations) so
+    /// the model retains the visual reference while it fixes validator errors.
+    /// Non-vision providers ignore this field.
+    pub user_images: Vec<ImageInput>,
+    /// Prior turns (e.g. first attempt's DSL + diagnostic feedback for repair).
+    pub history: Vec<Turn>,
+    /// System instruction (grammar + stdlib). See [`crate::prompt`].
+    pub system_instruction: Option<String>,
+    /// **Gemini only.** Name of a `cachedContents` resource — if set, skips
+    /// re-uploading the system instruction. Overrides `system_instruction`.
+    /// Other providers ignore this field.
+    pub cached_content: Option<String>,
+    /// Output cap enforced client-side after the response arrives.
+    /// `None` means no cap.
+    pub budget_tokens: Option<u32>,
+    /// Sampling temperature. `None` uses the API default;
+    /// [`Self::new`] sets this to [`DEFAULT_TEMPERATURE`].
+    pub temperature: Option<f32>,
+    /// Server-side seed request — note that no provider currently
+    /// guarantees determinism, so callers also embed the seed in the DSL
+    /// header. Ollama and Gemini honour this; Anthropic and OpenAI partially.
+    pub seed: Option<u64>,
+    /// Cap on server-side reasoning. `None` lets the provider use its
+    /// default. Library default (set by [`Self::new`]) is
+    /// [`ThinkingLevel::High`] — a middle ground that bounds latency while
+    /// still leaving room for the model to plan complex scenes.
+    pub thinking_level: Option<ThinkingLevel>,
+}
+
+impl GenerateConfig {
+    pub fn new(user_prompt: impl Into<String>) -> Self {
+        Self {
+            model: String::new(),
+            user_prompt: user_prompt.into(),
+            user_images: Vec::new(),
+            history: Vec::new(),
+            system_instruction: None,
+            cached_content: None,
+            budget_tokens: None,
+            temperature: Some(DEFAULT_TEMPERATURE),
+            seed: None,
+            thinking_level: Some(ThinkingLevel::High),
+        }
+    }
+}
+
+/// One turn of conversation, from either side.
+#[derive(Debug, Clone)]
+pub struct Turn {
+    pub role: Role,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    User,
+    Model,
+}
+
+impl Role {
+    /// Wire string used by Gemini (`user`/`model`).
+    pub fn gemini_str(self) -> &'static str {
+        match self {
+            Role::User => "user",
+            Role::Model => "model",
+        }
+    }
+
+    /// Wire string used by OpenAI / Ollama / Anthropic (`user`/`assistant`).
+    pub fn chat_str(self) -> &'static str {
+        match self {
+            Role::User => "user",
+            Role::Model => "assistant",
+        }
+    }
+}
+
+/// Token usage reported by the provider for a single call. Fields are
+/// best-effort: providers that don't break out cached tokens leave that
+/// counter at 0.
+#[derive(Debug, Clone, Default)]
+pub struct Usage {
+    pub prompt_tokens: u32,
+    pub response_tokens: u32,
+    pub total_tokens: u32,
+    /// Portion of `prompt_tokens` served from a cached prefix — billed at a
+    /// reduced rate. Only Gemini reports this today.
+    pub cached_tokens: u32,
+}
+
+impl Usage {
+    pub fn add(&mut self, other: &Usage) {
+        self.prompt_tokens += other.prompt_tokens;
+        self.response_tokens += other.response_tokens;
+        self.total_tokens += other.total_tokens;
+        self.cached_tokens += other.cached_tokens;
+    }
+}
+
+/// Decoded text + telemetry from a single provider call.
+#[derive(Debug, Clone)]
+pub struct GenerateResponse {
+    pub text: String,
+    pub usage: Usage,
+}

--- a/crates/mogen-llm/tests/mock_server.rs
+++ b/crates/mogen-llm/tests/mock_server.rs
@@ -6,8 +6,10 @@ use std::io::Read;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use mogen_llm::gemini::{GeminiClient, GenerateConfig, ImageInput};
-use mogen_llm::{generate_with_repair, RepairConfig};
+use mogen_llm::gemini::GeminiClient;
+use mogen_llm::{
+    generate_with_repair, GenerateConfig, ImageInput, LlmClient, Provider, RepairConfig,
+};
 
 struct MockServer {
     port: u16,
@@ -80,7 +82,7 @@ fn candidate_body(text: &str) -> String {
 fn first_call_succeeds_when_dsl_is_valid() {
     let dsl = "scene { box \"b\" (size=[1,1,1]) }";
     let server = MockServer::start(vec![&candidate_body(dsl)]);
-    let client = GeminiClient::with_base_url("test-key", server.base_url());
+    let client = LlmClient::with_base_url(Provider::Gemini, "test-key", server.base_url());
 
     let outcome = generate_with_repair(
         &client,
@@ -103,7 +105,7 @@ fn repair_loop_succeeds_on_second_attempt() {
     let bad = "scene { wombat \"oops\" (size=[1,1,1]) }";
     let good = "scene { box \"b\" (size=[1,1,1]) }";
     let server = MockServer::start(vec![&candidate_body(bad), &candidate_body(good)]);
-    let client = GeminiClient::with_base_url("test-key", server.base_url());
+    let client = LlmClient::with_base_url(Provider::Gemini, "test-key", server.base_url());
 
     let outcome = generate_with_repair(
         &client,
@@ -137,7 +139,7 @@ fn repair_loop_respects_max_iters_and_returns_last_attempt() {
     // Both attempts bad; we cap at 1 repair iter so only 2 calls total.
     let bad = "scene { wombat \"oops\" (size=[1,1,1]) }";
     let server = MockServer::start(vec![&candidate_body(bad), &candidate_body(bad)]);
-    let client = GeminiClient::with_base_url("test-key", server.base_url());
+    let client = LlmClient::with_base_url(Provider::Gemini, "test-key", server.base_url());
 
     let outcome = generate_with_repair(
         &client,
@@ -155,7 +157,7 @@ fn repair_loop_respects_max_iters_and_returns_last_attempt() {
 fn fenced_markdown_output_is_stripped_before_validation() {
     let fenced = "```mogen\nscene { box \"b\" (size=[1,1,1]) }\n```";
     let server = MockServer::start(vec![&candidate_body(fenced)]);
-    let client = GeminiClient::with_base_url("test-key", server.base_url());
+    let client = LlmClient::with_base_url(Provider::Gemini, "test-key", server.base_url());
 
     let outcome = generate_with_repair(
         &client,
@@ -176,7 +178,7 @@ fn user_images_become_inline_data_parts_on_the_user_turn() {
     // is attached (covered by the other tests in this file).
     let dsl = "scene { box \"b\" (size=[1,1,1]) }";
     let server = MockServer::start(vec![&candidate_body(dsl)]);
-    let client = GeminiClient::with_base_url("test-key", server.base_url());
+    let client = LlmClient::with_base_url(Provider::Gemini, "test-key", server.base_url());
 
     let mut cfg = GenerateConfig::new("a box");
     cfg.user_images.push(ImageInput {

--- a/crates/mogen-studio/src/app/ask.rs
+++ b/crates/mogen-studio/src/app/ask.rs
@@ -13,7 +13,7 @@
 use std::sync::Arc;
 
 use eframe::egui;
-use mogen_llm::gemini::{GeminiClient, GenerateConfig, ThinkingLevel};
+use mogen_llm::{GenerateConfig, LlmClient, Provider, ThinkingLevel};
 
 use super::types::AskInFlight;
 use super::MogenStudioApp;
@@ -94,16 +94,18 @@ impl MogenStudioApp {
             self.ask_answer = Some(Err("type a question first".into()));
             return;
         }
+        let provider = self.settings.provider();
         let api_key = match self.resolve_api_key() {
             Some(k) => k,
             None => {
-                self.ask_answer = Some(Err(
-                    "no Gemini API key — set one in Edit → Preferences…".into(),
-                ));
+                self.ask_answer = Some(Err(format!(
+                    "no {} API key — set one in Edit → Preferences…",
+                    provider.label(),
+                )));
                 return;
             }
         };
-        let model = self.settings.gemini_fast_model();
+        let model = self.settings.provider_fast_model();
         let sys_instr = self.cached_system_instruction();
         let code = self.ask_code_context.clone();
         let context_label = self.ask_context_label.clone();
@@ -116,7 +118,15 @@ impl MogenStudioApp {
         self.ask_in_flight = Some(AskInFlight { rx });
 
         std::thread::spawn(move || {
-            let result = run_ask_question(question, code, context_label, api_key, model, sys_instr);
+            let result = run_ask_question(
+                question,
+                code,
+                context_label,
+                provider,
+                api_key,
+                model,
+                sys_instr,
+            );
             let _ = tx.send(result);
             ctx.request_repaint();
         });
@@ -141,19 +151,20 @@ impl MogenStudioApp {
     }
 }
 
-/// Synchronous worker that calls Gemini Flash with a teaching prompt about
-/// the captured code. The system instruction (cached, shared with the rest
-/// of the LLM paths) carries the full DSL grammar + stdlib so answers stay
-/// grounded.
+/// Synchronous worker that calls the active provider's fast model with a
+/// teaching prompt about the captured code. The system instruction (cached,
+/// shared with the rest of the LLM paths) carries the full DSL grammar +
+/// stdlib so answers stay grounded.
 fn run_ask_question(
     question: String,
     code: String,
     context_label: String,
+    provider: Provider,
     api_key: String,
     model: String,
     sys_instr: Arc<String>,
 ) -> Result<String, String> {
-    let client = GeminiClient::new(api_key);
+    let client = LlmClient::new(provider, api_key);
 
     // Tag the code so the model knows whether it's looking at a snippet or
     // the whole file. The "do not rewrite" guidance keeps replies pedagogical
@@ -197,7 +208,7 @@ fn run_ask_question(
         Ok(resp) => {
             let cleaned = resp.text.trim().to_string();
             if cleaned.is_empty() {
-                Err("empty response from Gemini".into())
+                Err(format!("empty response from {}", provider.label()))
             } else {
                 Ok(cleaned)
             }

--- a/crates/mogen-studio/src/app/error_class.rs
+++ b/crates/mogen-studio/src/app/error_class.rs
@@ -1,38 +1,42 @@
-//! Convert raw [`GeminiError`]s into a structured [`LlmErrorInfo`] so the UI
-//! can swap in a class-specific affordance ("Open Settings", "Retry") instead
-//! of dumping the error's `Display` output verbatim.
+//! Convert raw [`ProviderError`]s into a structured [`LlmErrorInfo`] so the
+//! UI can swap in a class-specific affordance ("Open Settings", "Retry")
+//! instead of dumping the error's `Display` output verbatim.
+//!
+//! The mapping is provider-agnostic — all four backends funnel into the same
+//! [`ProviderError`] variants in `mogen-llm`, so the studio doesn't need to
+//! match on per-provider error enums.
 
-use mogen_llm::gemini::GeminiError;
+use mogen_llm::ProviderError;
 
 use super::types::{LlmErrorClass, LlmErrorInfo};
 
-pub(super) fn classify(err: &GeminiError) -> LlmErrorInfo {
+pub(super) fn classify(err: &ProviderError) -> LlmErrorInfo {
     match err {
-        GeminiError::MissingApiKey => LlmErrorInfo {
-            headline: "No Gemini API key".into(),
-            detail:
-                "Paste a key in Edit → Preferences… or export GEMINI_API_KEY before trying again."
-                    .into(),
+        ProviderError::MissingApiKey { var } => LlmErrorInfo {
+            headline: format!("No {var} API key"),
+            detail: format!(
+                "Paste a key in Edit → Preferences… or export {var} before trying again.",
+            ),
             class: LlmErrorClass::MissingKey,
             retryable: false,
         },
-        GeminiError::Transport(e) => LlmErrorInfo {
+        ProviderError::Transport(s) => LlmErrorInfo {
             headline: "Network error".into(),
-            detail: format!("{e}. Check your connection and try again."),
+            detail: format!("{s}. Check your connection and try again."),
             class: LlmErrorClass::Network,
             retryable: true,
         },
-        GeminiError::Api { status, message } => classify_api(*status, message),
-        GeminiError::EmptyResponse => LlmErrorInfo {
+        ProviderError::Api { status, message } => classify_api(*status, message),
+        ProviderError::EmptyResponse => LlmErrorInfo {
             headline: "Model returned an empty response".into(),
             detail:
-                "Gemini produced no text. This usually means the prompt was blocked by a safety \
-                 or recitation filter — try rephrasing or simplifying the request."
+                "The provider produced no text. This usually means the prompt was blocked by a \
+                 safety or recitation filter — try rephrasing or simplifying the request."
                     .into(),
             class: LlmErrorClass::ContentBlocked,
             retryable: true,
         },
-        GeminiError::BudgetExceeded { used, budget } => LlmErrorInfo {
+        ProviderError::BudgetExceeded { used, budget } => LlmErrorInfo {
             headline: "Token budget exceeded".into(),
             detail: format!(
                 "Used {used} tokens but the per-call budget is {budget}. Raise the cap in \
@@ -41,16 +45,20 @@ pub(super) fn classify(err: &GeminiError) -> LlmErrorInfo {
             class: LlmErrorClass::BadRequest,
             retryable: false,
         },
-        GeminiError::InvalidResponse(msg) => {
+        ProviderError::InvalidResponse(msg) => {
+            // The recitation / safety string detection is Gemini-flavoured but
+            // the markers are passed through verbatim by `ProviderError::from`,
+            // so the same detection still fires for Gemini calls and falls
+            // through harmlessly for the other providers.
             let is_recitation = msg.contains("RECITATION") || msg.contains("IMAGE_RECITATION");
             let is_safety = msg.contains("SAFETY") || msg.contains("BLOCKED");
             if is_recitation {
                 LlmErrorInfo {
                     headline: "Model declined to produce content".into(),
                     detail:
-                        "Gemini's recitation filter rejected every attempt. Try a different \
-                         style description or rename/reword the material so the prompt does \
-                         not resemble training data."
+                        "The provider's recitation filter rejected every attempt. Try a \
+                         different style description or rename/reword the material so the \
+                         prompt does not resemble training data."
                             .into(),
                     class: LlmErrorClass::ContentBlocked,
                     retryable: true,
@@ -64,13 +72,19 @@ pub(super) fn classify(err: &GeminiError) -> LlmErrorInfo {
                 }
             } else {
                 LlmErrorInfo {
-                    headline: "Invalid response from Gemini".into(),
+                    headline: "Invalid response from API".into(),
                     detail: msg.clone(),
                     class: LlmErrorClass::Other,
                     retryable: true,
                 }
             }
         }
+        ProviderError::Unsupported { provider, feature } => LlmErrorInfo {
+            headline: format!("Feature not supported by {provider}"),
+            detail: format!("{feature} is not available on {provider}."),
+            class: LlmErrorClass::BadRequest,
+            retryable: false,
+        },
     }
 }
 
@@ -79,7 +93,7 @@ fn classify_api(status: u16, message: &str) -> LlmErrorInfo {
     match status {
         400 => LlmErrorInfo {
             headline: "Bad request".into(),
-            detail: format!("Gemini rejected the request: {message}"),
+            detail: format!("API rejected the request: {message}"),
             class: LlmErrorClass::BadRequest,
             retryable: false,
         },
@@ -87,8 +101,8 @@ fn classify_api(status: u16, message: &str) -> LlmErrorInfo {
             LlmErrorInfo {
                 headline: "API key rejected".into(),
                 detail:
-                    "Gemini refused the request as unauthenticated. Open Preferences… and paste \
-                     a valid key, or verify GEMINI_API_KEY is set."
+                    "The provider refused the request as unauthenticated. Open Preferences… \
+                     and paste a valid key, or verify the matching environment variable is set."
                         .into(),
                 class: LlmErrorClass::InvalidKey,
                 retryable: false,
@@ -97,22 +111,22 @@ fn classify_api(status: u16, message: &str) -> LlmErrorInfo {
         403 if msg_lower.contains("quota") => LlmErrorInfo {
             headline: "Quota exceeded".into(),
             detail:
-                "Your project has hit its daily or per-minute Gemini quota. Wait for the quota to \
-                 reset or request a higher limit in the Google Cloud console."
+                "The account has hit its daily or per-minute quota. Wait for the quota to reset \
+                 or request a higher limit on the provider's console."
                     .into(),
             class: LlmErrorClass::QuotaExceeded,
             retryable: false,
         },
         403 => LlmErrorInfo {
             headline: "Request forbidden".into(),
-            detail: format!("Gemini returned 403: {message}"),
+            detail: format!("API returned 403: {message}"),
             class: LlmErrorClass::InvalidKey,
             retryable: false,
         },
         404 => LlmErrorInfo {
             headline: "Model not found".into(),
             detail: format!(
-                "Gemini has no model matching the configured name. Check Preferences → \
+                "The provider has no model matching the configured name. Check Preferences → \
                  Advanced → Model. ({message})"
             ),
             class: LlmErrorClass::BadRequest,
@@ -128,7 +142,7 @@ fn classify_api(status: u16, message: &str) -> LlmErrorInfo {
             retryable: true,
         },
         s if (500..600).contains(&s) => LlmErrorInfo {
-            headline: "Gemini server error".into(),
+            headline: "Provider server error".into(),
             detail: format!("({s}) {message}. This is usually transient — try again."),
             class: LlmErrorClass::ServerError,
             retryable: true,
@@ -148,7 +162,7 @@ mod tests {
 
     #[test]
     fn classify_401_hints_open_settings() {
-        let err = GeminiError::Api {
+        let err = ProviderError::Api {
             status: 401,
             message: "API key not valid".into(),
         };
@@ -159,7 +173,7 @@ mod tests {
 
     #[test]
     fn classify_429_is_retryable() {
-        let err = GeminiError::Api { status: 429, message: "rate".into() };
+        let err = ProviderError::Api { status: 429, message: "rate".into() };
         let info = classify(&err);
         assert!(matches!(info.class, LlmErrorClass::RateLimited));
         assert!(info.retryable);
@@ -167,7 +181,7 @@ mod tests {
 
     #[test]
     fn classify_500_is_retryable() {
-        let err = GeminiError::Api { status: 503, message: "down".into() };
+        let err = ProviderError::Api { status: 503, message: "down".into() };
         let info = classify(&err);
         assert!(matches!(info.class, LlmErrorClass::ServerError));
         assert!(info.retryable);
@@ -175,15 +189,30 @@ mod tests {
 
     #[test]
     fn classify_missing_key_not_retryable() {
-        let info = classify(&GeminiError::MissingApiKey);
+        let info = classify(&ProviderError::MissingApiKey { var: "GEMINI_API_KEY" });
         assert!(!info.retryable);
         assert_eq!(info.class, LlmErrorClass::MissingKey);
+        assert!(info.headline.contains("GEMINI_API_KEY"));
     }
 
     #[test]
     fn classify_recitation_as_blocked() {
-        let err = GeminiError::InvalidResponse("no image returned (finishReason: IMAGE_RECITATION)".into());
+        let err = ProviderError::InvalidResponse(
+            "no image returned (finishReason: IMAGE_RECITATION)".into(),
+        );
         let info = classify(&err);
         assert_eq!(info.class, LlmErrorClass::ContentBlocked);
+    }
+
+    #[test]
+    fn classify_unsupported_feature_not_retryable() {
+        let err = ProviderError::Unsupported {
+            provider: mogen_llm::Provider::OpenAI,
+            feature: "image generation",
+        };
+        let info = classify(&err);
+        assert_eq!(info.class, LlmErrorClass::BadRequest);
+        assert!(!info.retryable);
+        assert!(info.detail.contains("image generation"));
     }
 }

--- a/crates/mogen-studio/src/app/llm.rs
+++ b/crates/mogen-studio/src/app/llm.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use eframe::egui;
 use mogen_core::Severity;
-use mogen_llm::{system_instruction, StdlibIndex};
+use mogen_llm::{system_instruction, Provider, StdlibIndex};
 
 use mogen_llm::textures::TextureStage;
 
@@ -137,7 +137,10 @@ impl MogenStudioApp {
                 "save the file first — textures writes PNGs next to it".into();
             return;
         };
-        let api_key = match self.resolve_api_key() {
+        // Texture generation is Gemini-only (no other backend has an image
+        // synthesis API in mogen-llm), so this path bypasses the active
+        // provider and reads `GEMINI_API_KEY` directly.
+        let api_key = match self.resolve_gemini_api_key() {
             Some(k) => k,
             None => {
                 self.active_mut().status =
@@ -246,17 +249,21 @@ impl MogenStudioApp {
                 Some((target, "enter a prompt first".into()));
             return;
         }
+        let provider = self.settings.provider();
         let api_key = match self.resolve_api_key() {
             Some(k) => k,
             None => {
                 self.enhance_error = Some((
                     target,
-                    "no Gemini API key — set one in Edit → Preferences…".into(),
+                    format!(
+                        "no {} API key — set one in Edit → Preferences…",
+                        provider.label(),
+                    ),
                 ));
                 return;
             }
         };
-        let model = self.settings.gemini_fast_model();
+        let model = self.settings.provider_fast_model();
         let file_index = self.active;
         // Clear any stale error for this target; a fresh attempt gets a fresh
         // error slot.
@@ -273,7 +280,7 @@ impl MogenStudioApp {
 
         let payload = trimmed.to_string();
         std::thread::spawn(move || {
-            let result = run_prompt_enhance(target, payload, api_key, model);
+            let result = run_prompt_enhance(target, payload, provider, api_key, model);
             let _ = tx.send(result);
             ctx.request_repaint();
         });
@@ -370,9 +377,34 @@ impl MogenStudioApp {
         f.status = "llm: cancelled (background call may still finish but result is dropped)".into();
     }
 
-    /// Prefer a key saved in Options; fall back to the `GEMINI_API_KEY` env
-    /// var so existing shell-exported setups keep working.
+    /// Prefer a key saved in Options for the active provider; fall back to the
+    /// matching environment variable so existing shell-exported setups keep
+    /// working. For Ollama (which is keyless by default), returns
+    /// `Some(String::new())` even when neither setting nor env var is set so
+    /// callers can construct a keyless `LlmClient`.
     pub(super) fn resolve_api_key(&self) -> Option<String> {
+        let provider = self.settings.provider();
+        if let Some(k) = self.settings.provider_api_key() {
+            return Some(k.to_string());
+        }
+        let env_key = std::env::var(provider.env_var())
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+        if env_key.is_some() {
+            return env_key;
+        }
+        if matches!(provider, Provider::Ollama) {
+            return Some(String::new());
+        }
+        None
+    }
+
+    /// Provider-agnostic Gemini key resolution for paths that hard-require
+    /// Gemini regardless of the active provider — currently just texture
+    /// image generation. Mirrors [`Self::resolve_api_key`] but always reads
+    /// the persisted `gemini_api_key` and the `GEMINI_API_KEY` env var.
+    pub(super) fn resolve_gemini_api_key(&self) -> Option<String> {
         if let Some(k) = self.settings.gemini_api_key() {
             return Some(k.to_string());
         }
@@ -399,7 +431,7 @@ impl MogenStudioApp {
     /// Settings) so defaulting logic lives next to the worker.
     pub(super) fn build_run_config(&self) -> LlmRunConfig {
         LlmRunConfig {
-            model: self.settings.gemini_model(),
+            model: self.settings.provider_model(),
             thinking: self.settings.thinking_level(),
             temperature: self.settings.temperature(),
             max_repair_iters: self.settings.max_repair_iters(),
@@ -415,11 +447,15 @@ impl MogenStudioApp {
         existing: Option<String>,
         image: Option<crate::app::types::GenImageInput>,
     ) {
+        let provider = self.settings.provider();
         let api_key = match self.resolve_api_key() {
             Some(k) => k,
             None => {
-                self.active_mut().status =
-                    "no Gemini API key — set one in Options… or export GEMINI_API_KEY".into();
+                self.active_mut().status = format!(
+                    "no {} API key — set one in Options… or export {}",
+                    provider.label(),
+                    provider.env_var(),
+                );
                 return;
             }
         };
@@ -432,15 +468,16 @@ impl MogenStudioApp {
         }
         let sys_instr = self.cached_system_instruction();
 
+        let provider_label = provider.label();
         let (tx, rx) = std::sync::mpsc::channel();
         let f = self.active_mut();
         f.llm_rx = Some(rx);
         f.llm_in_flight = Some(kind);
         f.llm_progress = Some(LlmProgress::Status(match kind {
-            LlmKind::Generate => "calling Gemini (generate)…".into(),
-            LlmKind::Modify => "calling Gemini (modify)…".into(),
-            LlmKind::Animate => "calling Gemini (animate)…".into(),
-            LlmKind::Repair => "calling Gemini (repair)…".into(),
+            LlmKind::Generate => format!("calling {provider_label} (generate)…"),
+            LlmKind::Modify => format!("calling {provider_label} (modify)…"),
+            LlmKind::Animate => format!("calling {provider_label} (animate)…"),
+            LlmKind::Repair => format!("calling {provider_label} (repair)…"),
             LlmKind::Textures => unreachable!("spawn_llm is text-only"),
         }));
         f.llm_started_at = Some(Instant::now());
@@ -459,10 +496,10 @@ impl MogenStudioApp {
         f.llm_error = None;
         f.llm_last_prompt = Some((kind, prompt.clone()));
         f.status = match kind {
-            LlmKind::Generate => "calling Gemini (generate)…".into(),
-            LlmKind::Modify => "calling Gemini (modify)…".into(),
-            LlmKind::Animate => "calling Gemini (animate)…".into(),
-            LlmKind::Repair => "calling Gemini (repair)…".into(),
+            LlmKind::Generate => format!("calling {provider_label} (generate)…"),
+            LlmKind::Modify => format!("calling {provider_label} (modify)…"),
+            LlmKind::Animate => format!("calling {provider_label} (animate)…"),
+            LlmKind::Repair => format!("calling {provider_label} (repair)…"),
             // Textures takes its own path via `start_llm_textures` and never
             // reaches spawn_llm.
             LlmKind::Textures => unreachable!("spawn_llm is text-only"),
@@ -477,7 +514,15 @@ impl MogenStudioApp {
         });
         std::thread::spawn(move || {
             let outcome = run_llm(
-                kind, prompt, existing, llm_image, api_key, run_cfg, sys_instr, worker_tx,
+                kind,
+                prompt,
+                existing,
+                provider,
+                llm_image,
+                api_key,
+                run_cfg,
+                sys_instr,
+                worker_tx,
             );
             let _ = tx.send(LlmMessage::Done(outcome));
             ctx.request_repaint();

--- a/crates/mogen-studio/src/app/ui_dialogs.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs.rs
@@ -1,9 +1,11 @@
 use std::path::Path;
 
 use eframe::egui;
+use mogen_llm::Provider;
 
 use crate::settings::{
-    thinking_level_key, thinking_level_label, DEFAULT_MAX_REPAIR_ITERS, THINKING_LEVELS,
+    thinking_level_key, thinking_level_label, DEFAULT_MAX_REPAIR_ITERS, PROVIDERS,
+    THINKING_LEVELS,
 };
 use crate::theme::{apply_theme, theme_label, Theme, THEMES};
 
@@ -95,17 +97,70 @@ impl MogenStudioApp {
             .default_width(420.0)
             .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
             .show(ctx, |ui| {
-                ui.heading("Gemini API key");
+                ui.heading("LLM provider");
                 ui.label(
-                    "Used by Generate / Modify / Animate / Textures. Stored in your user \
-                     config directory and persists between sessions.",
+                    "Backend used for Generate / Modify / Animate / Ask / Prompt \
+                     Enhance. Texture image generation is always Gemini regardless \
+                     of this setting (no other backend has an image API).",
                 );
                 ui.add_space(6.0);
-                let key_id = egui::Id::new("opts_api_key");
+                let current_provider = self.settings.provider();
+                egui::ComboBox::from_id_salt("opts_provider")
+                    .selected_text(current_provider.label())
+                    .show_ui(ui, |ui| {
+                        for p in PROVIDERS {
+                            let selected = p == current_provider;
+                            if ui
+                                .selectable_label(selected, p.label())
+                                .clicked()
+                                && !selected
+                            {
+                                self.settings.set_provider(p);
+                            }
+                        }
+                    });
+
+                ui.add_space(12.0);
+                let active_provider = self.settings.provider();
+                let key_heading = match active_provider {
+                    Provider::Gemini => "Gemini API key",
+                    Provider::OpenAI => "OpenAI API key",
+                    Provider::Anthropic => "Anthropic API key",
+                    Provider::Ollama => "Ollama API key (optional)",
+                };
+                ui.heading(key_heading);
+                ui.label(match active_provider {
+                    Provider::Gemini => {
+                        "Used by Generate / Modify / Animate / Textures. Stored in your \
+                         user config directory and persists between sessions."
+                    }
+                    Provider::OpenAI => {
+                        "Used by Generate / Modify / Animate / Ask. Stored in your \
+                         user config directory and persists between sessions."
+                    }
+                    Provider::Anthropic => {
+                        "Used by Generate / Modify / Animate / Ask. Stored in your \
+                         user config directory and persists between sessions."
+                    }
+                    Provider::Ollama => {
+                        "Optional bearer token for an Ollama endpoint behind an \
+                         authenticating proxy. Leave blank for a local install."
+                    }
+                });
+                ui.add_space(6.0);
+                // Show only the field for the active provider to reduce clutter.
+                // Switching providers above swaps which field is visible here.
+                let key_id = egui::Id::new(("opts_api_key", active_provider.key()));
+                let key_buf: &mut String = match active_provider {
+                    Provider::Gemini => &mut self.options_api_key_draft,
+                    Provider::OpenAI => &mut self.settings.openai_api_key,
+                    Provider::Anthropic => &mut self.settings.anthropic_api_key,
+                    Provider::Ollama => &mut self.settings.ollama_api_key,
+                };
                 super::text_menu::text_edit_with_menu(
                     ui,
                     key_id,
-                    &mut self.options_api_key_draft,
+                    key_buf,
                     |ui, text| {
                         ui.add(
                             egui::TextEdit::singleline(text)
@@ -116,15 +171,32 @@ impl MogenStudioApp {
                         )
                     },
                 );
-                if std::env::var("GEMINI_API_KEY")
+
+                if matches!(active_provider, Provider::Ollama) {
+                    ui.add_space(6.0);
+                    ui.label("Ollama base URL (optional)").on_hover_text(
+                        "Override for self-hosted Ollama. Leave blank for the \
+                         library default (http://localhost:11434).",
+                    );
+                    ui.add(
+                        egui::TextEdit::singleline(&mut self.settings.ollama_base_url)
+                            .hint_text("http://localhost:11434")
+                            .desired_width(f32::INFINITY),
+                    );
+                }
+
+                let env_var = active_provider.env_var();
+                if std::env::var(env_var)
                     .map(|v| !v.trim().is_empty())
                     .unwrap_or(false)
                 {
                     ui.add_space(4.0);
                     ui.colored_label(
                         egui::Color32::from_rgb(150, 180, 230),
-                        "GEMINI_API_KEY is also set in your environment — \
-                         the saved key here takes precedence when non-empty.",
+                        format!(
+                            "{env_var} is also set in your environment — \
+                             the saved key here takes precedence when non-empty.",
+                        ),
                     );
                 }
 
@@ -350,14 +422,31 @@ impl MogenStudioApp {
                 ui.add_space(12.0);
                 ui.horizontal(|ui| {
                     if ui.button("Save").clicked() {
+                        // The Gemini key uses an editor-buffered draft so the
+                        // user can clear/re-paste without instantly mutating
+                        // settings; commit it on Save. Other providers' keys
+                        // are written directly into settings as the user
+                        // types because they don't share that legacy draft.
                         self.settings.gemini_api_key =
                             self.options_api_key_draft.trim().to_string();
+                        // Trim whitespace from per-provider keys / URL on
+                        // save so users can paste with surrounding spaces.
+                        self.settings.openai_api_key =
+                            self.settings.openai_api_key.trim().to_string();
+                        self.settings.anthropic_api_key =
+                            self.settings.anthropic_api_key.trim().to_string();
+                        self.settings.ollama_api_key =
+                            self.settings.ollama_api_key.trim().to_string();
+                        self.settings.ollama_base_url =
+                            self.settings.ollama_base_url.trim().to_string();
                         match self.settings.save() {
                             Ok(()) => {
-                                let msg = if self.settings.gemini_api_key.is_empty() {
-                                    "options: cleared saved Gemini API key".to_string()
-                                } else {
-                                    "options: settings saved".to_string()
+                                let active = self.settings.provider();
+                                let msg = match active {
+                                    Provider::Gemini if self.settings.gemini_api_key.is_empty() => {
+                                        "options: cleared saved Gemini API key".to_string()
+                                    }
+                                    _ => "options: settings saved".to_string(),
                                 };
                                 self.active_mut().status = msg;
                                 close_after = true;

--- a/crates/mogen-studio/src/app/util.rs
+++ b/crates/mogen-studio/src/app/util.rs
@@ -5,14 +5,15 @@ use std::sync::{Arc, Mutex};
 
 use mogen_core::SceneGraph;
 use mogen_export::ExportOptions;
-use mogen_llm::gemini::{GeminiClient, GenerateConfig, ImageInput, Usage};
+use mogen_llm::gemini::GeminiClient;
 use mogen_llm::textures::{
     build_plan, default_textures_dir, run_plan, splice_textures, PlanAction,
     TextureProgress, TexturesArgs,
 };
 use mogen_llm::{
     embed_seed_header, generate_with_repair, parse_prompt_header, parse_seed_header,
-    repair_message, validate_text, RepairConfig, ThinkingLevel, DEFAULT_IMAGE_MODEL,
+    repair_message, validate_text, GenerateConfig, ImageInput, LlmClient, Provider, RepairConfig,
+    ThinkingLevel, Usage, DEFAULT_IMAGE_MODEL,
 };
 
 use crate::pipeline::write_glb_with_source_and_options;
@@ -462,6 +463,7 @@ pub(super) fn run_llm(
     kind: LlmKind,
     prompt: String,
     existing: Option<String>,
+    provider: Provider,
     image: Option<ImageInput>,
     api_key: String,
     run_cfg: LlmRunConfig,
@@ -475,7 +477,7 @@ pub(super) fn run_llm(
         let _ = tx.send(LlmMessage::Progress(p));
     };
 
-    let client = GeminiClient::new(api_key);
+    let client = LlmClient::new(provider, api_key);
     let seed = run_cfg.seed_override.unwrap_or_else(|| {
         existing
             .as_deref()
@@ -636,7 +638,8 @@ pub(super) fn run_llm(
     }
 
     send_progress(LlmProgress::Status(format!(
-        "calling Gemini ({}) — thinking={:?}",
+        "calling {} ({}) — thinking={:?}",
+        provider.label(),
         kind.label(),
         run_cfg.thinking,
     )));
@@ -806,6 +809,11 @@ pub(super) fn run_llm_textures(
         .filter(|p| matches!(p.action, PlanAction::Generate))
         .count() as u32;
 
+    // Image generation is Gemini-only — `LlmClient::new(provider, …)` doesn't
+    // expose a synthesis API for the other backends. Callers MUST pass the
+    // `GEMINI_API_KEY` here regardless of `settings.provider()` so this path
+    // keeps working even when the user has selected OpenAI/Anthropic/Ollama
+    // for the text DSL.
     let client = GeminiClient::new(api_key);
     let base_dir = mg_path
         .parent()
@@ -903,10 +911,11 @@ pub(super) fn run_llm_textures(
 pub(super) fn run_prompt_enhance(
     target: EnhanceTarget,
     raw_prompt: String,
+    provider: Provider,
     api_key: String,
     model: String,
 ) -> Result<String, String> {
-    let client = GeminiClient::new(api_key);
+    let client = LlmClient::new(provider, api_key);
     let raw = raw_prompt.trim();
     // Templates focus the rewrite on enriching the user's high-level
     // description — what the object looks like or how a part should change —
@@ -977,7 +986,7 @@ pub(super) fn run_prompt_enhance(
                 .trim_end_matches("```")
                 .trim();
             if cleaned.is_empty() {
-                Err("empty response from Gemini".into())
+                Err(format!("empty response from {}", provider.label()))
             } else {
                 Ok(cleaned.to_string())
             }

--- a/crates/mogen-studio/src/settings.rs
+++ b/crates/mogen-studio/src/settings.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use mogen_llm::gemini::{DEFAULT_FAST_MODEL, DEFAULT_MODEL, DEFAULT_TEMPERATURE};
-use mogen_llm::ThinkingLevel;
+use mogen_llm::{Provider, ThinkingLevel};
 use serde::{Deserialize, Serialize};
 
 use crate::preview_shader::{
@@ -84,6 +84,33 @@ pub struct Settings {
     /// flow again.
     #[serde(default)]
     pub onboarded: bool,
+
+    /// Selected LLM provider, persisted as a lowercase [`Provider::key`]
+    /// (`"gemini"`, `"openai"`, `"anthropic"`, `"ollama"`). Empty / unknown
+    /// falls back to [`Provider::default`] at read time so adding new
+    /// providers later doesn't invalidate old settings files.
+    #[serde(default)]
+    pub provider: String,
+
+    /// API key for the OpenAI provider. Stored alongside the Gemini key so
+    /// switching providers in Options doesn't require re-pasting credentials.
+    #[serde(default)]
+    pub openai_api_key: String,
+
+    /// API key for the Anthropic (Claude) provider.
+    #[serde(default)]
+    pub anthropic_api_key: String,
+
+    /// Optional bearer token for an Ollama endpoint sitting behind an
+    /// authenticating reverse proxy. Usually empty — local Ollama is keyless.
+    #[serde(default)]
+    pub ollama_api_key: String,
+
+    /// Optional override for the Ollama base URL. Empty → library default
+    /// (`http://localhost:11434`). Set this to point at a self-hosted
+    /// instance.
+    #[serde(default)]
+    pub ollama_base_url: String,
 }
 
 impl Settings {
@@ -186,6 +213,58 @@ impl Settings {
         self.seed_override
     }
 
+    /// Resolve the persisted provider key to a [`Provider`], falling back to
+    /// [`Provider::default`] when the field is empty or unknown. Stable
+    /// across upgrades — old settings files (pre-multi-provider) read as the
+    /// default Gemini.
+    pub fn provider(&self) -> Provider {
+        Provider::parse(&self.provider).unwrap_or_default()
+    }
+
+    /// API key for the currently-selected provider. Returns `None` for an
+    /// empty value (including for Ollama — callers that need a keyless
+    /// Ollama client construct one directly with an empty string).
+    pub fn provider_api_key(&self) -> Option<&str> {
+        let raw = match self.provider() {
+            Provider::Gemini => self.gemini_api_key.as_str(),
+            Provider::OpenAI => self.openai_api_key.as_str(),
+            Provider::Anthropic => self.anthropic_api_key.as_str(),
+            Provider::Ollama => self.ollama_api_key.as_str(),
+        };
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    }
+
+    /// Heavy / "thinking" model id for the active provider. For Gemini this
+    /// reuses [`Self::gemini_model`] for backwards compat; other providers
+    /// fall back to [`Provider::default_model`] (no per-provider override
+    /// fields yet).
+    pub fn provider_model(&self) -> String {
+        match self.provider() {
+            Provider::Gemini => self.gemini_model(),
+            other => other.default_model().to_string(),
+        }
+    }
+
+    /// Fast / cheap model id for the active provider. Symmetric with
+    /// [`Self::provider_model`] — Gemini reuses [`Self::gemini_fast_model`],
+    /// the rest fall back to [`Provider::default_fast_model`].
+    pub fn provider_fast_model(&self) -> String {
+        match self.provider() {
+            Provider::Gemini => self.gemini_fast_model(),
+            other => other.default_fast_model().to_string(),
+        }
+    }
+
+    /// Persist a fresh provider selection.
+    pub fn set_provider(&mut self, p: Provider) {
+        self.provider = p.key().to_string();
+    }
+
     /// Promote `path` to the front of [`Self::recent_files`], dedup'ing any
     /// previous occurrence and trimming the list to [`Self::MAX_RECENT`].
     pub fn push_recent(&mut self, path: &str) {
@@ -226,6 +305,15 @@ pub const THINKING_LEVELS: [ThinkingLevel; 4] = [
     ThinkingLevel::Medium,
     ThinkingLevel::High,
     ThinkingLevel::XHigh,
+];
+
+/// Order in which providers appear in the Options dropdown. Gemini is first
+/// because it's the historical default and the only image-capable backend.
+pub const PROVIDERS: [Provider; 4] = [
+    Provider::Gemini,
+    Provider::OpenAI,
+    Provider::Anthropic,
+    Provider::Ollama,
 ];
 
 fn settings_path() -> Option<PathBuf> {

--- a/crates/mogen/src/commands/animate.rs
+++ b/crates/mogen/src/commands/animate.rs
@@ -2,18 +2,17 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, bail, Context, Result};
-use mogen_llm::gemini::{GeminiClient, GenerateConfig};
 use mogen_llm::{
     embed_seed_header, generate_with_repair, parse_prompt_header, parse_seed_header,
-    parse_thinking_header, RepairConfig, ThinkingLevel,
+    parse_thinking_header, GenerateConfig, Provider, RepairConfig, ThinkingLevel,
 };
 
 use crate::commands::build::build;
 use crate::common::{
-    attach_system_instruction, ensure_parent_dir, format_cached_tokens, pick_default_seed,
-    resolve_api_key, summarize_repair_errors,
+    attach_system_instruction, build_client, ensure_parent_dir, format_cached_tokens,
+    pick_default_seed, resolve_api_key, resolve_model, summarize_repair_errors,
 };
-use crate::spinner::{Spinner, GEMINI_FLAVORS};
+use crate::spinner::{Spinner, LLM_FLAVORS};
 
 pub(crate) struct AnimateArgs {
     pub input: PathBuf,
@@ -21,7 +20,9 @@ pub(crate) struct AnimateArgs {
     pub out: Option<PathBuf>,
     pub dsl_out: Option<PathBuf>,
     pub seed: Option<u64>,
-    pub model: String,
+    pub provider: Provider,
+    /// `None` -> use the provider's default model.
+    pub model: Option<String>,
     pub dry_run: bool,
     pub budget_tokens: Option<u32>,
     pub max_repair_iters: u32,
@@ -63,8 +64,10 @@ pub(crate) fn animate(args: AnimateArgs) -> Result<()> {
         ensure_parent_dir(&resolved_out)?;
     }
 
-    let api_key = resolve_api_key(args.api_key)?;
-    let client = GeminiClient::new(api_key);
+    let api_key = resolve_api_key(args.provider, args.api_key)?;
+    let client = build_client(args.provider, api_key);
+    let model = resolve_model(args.provider, args.model);
+    let provider_label = args.provider.label();
 
     let user_prompt = format!(
         "You are editing an existing mogen DSL file. Add or update ONLY animation \
@@ -101,7 +104,7 @@ Existing file:\n\n{existing}",
     );
 
     let mut cfg = GenerateConfig::new(user_prompt);
-    cfg.model = args.model;
+    cfg.model = model;
     cfg.budget_tokens = args.budget_tokens;
     if let Some(t) = args.temperature {
         cfg.temperature = Some(t);
@@ -112,8 +115,8 @@ Existing file:\n\n{existing}",
 
     let total_attempts = args.max_repair_iters + 1;
     let mut pb = Spinner::new(
-        &format!("animate: calling Gemini (attempt 1/{total_attempts})"),
-        GEMINI_FLAVORS,
+        &format!("animate: calling {provider_label} (attempt 1/{total_attempts})"),
+        LLM_FLAVORS,
     );
 
     let pb_cb = pb.handle();
@@ -131,8 +134,8 @@ Existing file:\n\n{existing}",
     let outcome = match generate_with_repair(&client, cfg, &repair) {
         Ok(o) => o,
         Err(e) => {
-            pb.abandon_with_message(format!("animate: Gemini error — {e}"));
-            return Err(anyhow!("gemini: {e}"));
+            pb.abandon_with_message(format!("animate: {provider_label} error — {e}"));
+            return Err(anyhow!("{}: {e}", provider_label.to_lowercase()));
         }
     };
 

--- a/crates/mogen/src/commands/bench.rs
+++ b/crates/mogen/src/commands/bench.rs
@@ -2,25 +2,27 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
-use mogen_llm::gemini::{GeminiClient, GenerateConfig};
 use mogen_llm::{
     default_cache_path, generate_with_repair, resolve_or_create_cache, system_instruction,
-    RepairConfig, StdlibIndex, ThinkingLevel, DEFAULT_TTL_SECONDS,
+    GenerateConfig, LlmClient, Provider, RepairConfig, StdlibIndex, ThinkingLevel,
+    DEFAULT_TTL_SECONDS,
 };
 
-use crate::common::resolve_api_key;
+use crate::common::{resolve_api_key, resolve_model};
 
 pub(crate) fn bench(
     prompts_path: PathBuf,
-    model: String,
+    provider: Provider,
+    model: Option<String>,
     max_repair_iters: u32,
     budget_tokens: Option<u32>,
     api_key: Option<String>,
     no_cache: bool,
     thinking: ThinkingLevel,
 ) -> Result<()> {
-    let api_key = resolve_api_key(api_key)?;
-    let client = GeminiClient::new(api_key);
+    let api_key = resolve_api_key(provider, api_key)?;
+    let client = LlmClient::new(provider, api_key);
+    let model = resolve_model(provider, model);
 
     let content = fs::read_to_string(&prompts_path)
         .with_context(|| format!("reading {}", prompts_path.display()))?;
@@ -36,20 +38,32 @@ pub(crate) fn bench(
 
     // Resolve the cache once up front — every prompt in the batch shares the
     // same system instruction, so a single cache entry serves the whole run.
+    // Only Gemini honours `cachedContents`; on other providers we fall back
+    // to inline.
     let system = system_instruction(&StdlibIndex::from_registry(
         mogen_dsl::stdlib_registry(),
     ));
     let cached_name: Option<String> = if no_cache {
         None
-    } else if let Some(cache_path) = default_cache_path() {
-        match resolve_or_create_cache(&client, &model, &system, &cache_path, DEFAULT_TTL_SECONDS) {
-            Ok(name) => Some(name),
-            Err(e) => {
-                eprintln!(
-                    "mogen bench: cache unavailable ({e}); sending system instruction inline"
-                );
-                None
+    } else if let Some(gemini) = client.as_gemini() {
+        if let Some(cache_path) = default_cache_path() {
+            match resolve_or_create_cache(
+                gemini,
+                &model,
+                &system,
+                &cache_path,
+                DEFAULT_TTL_SECONDS,
+            ) {
+                Ok(name) => Some(name),
+                Err(e) => {
+                    eprintln!(
+                        "mogen bench: cache unavailable ({e}); sending system instruction inline"
+                    );
+                    None
+                }
             }
+        } else {
+            None
         }
     } else {
         None
@@ -60,8 +74,9 @@ pub(crate) fn bench(
     let mut total_calls = 0u32;
 
     println!(
-        "# mogen bench — {} prompts, model={}, max_repair_iters={}, cache={}",
+        "# mogen bench — {} prompts, provider={}, model={}, max_repair_iters={}, cache={}",
         prompts.len(),
+        provider.key(),
         model,
         max_repair_iters,
         if cached_name.is_some() { "on" } else { "off" },

--- a/crates/mogen/src/commands/generate.rs
+++ b/crates/mogen/src/commands/generate.rs
@@ -2,22 +2,25 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, bail, Context, Result};
-use mogen_llm::gemini::{GeminiClient, GenerateConfig};
-use mogen_llm::{embed_seed_header, generate_with_repair, RepairConfig, ThinkingLevel};
+use mogen_llm::{
+    embed_seed_header, generate_with_repair, GenerateConfig, Provider, RepairConfig, ThinkingLevel,
+};
 
 use crate::commands::build::build;
 use crate::common::{
-    attach_system_instruction, ensure_parent_dir, format_cached_tokens, pick_default_seed,
-    resolve_api_key, summarize_repair_errors,
+    attach_system_instruction, build_client, ensure_parent_dir, format_cached_tokens,
+    pick_default_seed, resolve_api_key, resolve_model, summarize_repair_errors,
 };
-use crate::spinner::{Spinner, GEMINI_FLAVORS};
+use crate::spinner::{Spinner, LLM_FLAVORS};
 
 pub(crate) struct GenerateArgs {
     pub prompt: String,
     pub out: Option<PathBuf>,
     pub dsl_out: Option<PathBuf>,
     pub seed: Option<u64>,
-    pub model: String,
+    pub provider: Provider,
+    /// `None` -> use the provider's default model.
+    pub model: Option<String>,
     pub dry_run: bool,
     pub budget_tokens: Option<u32>,
     pub max_repair_iters: u32,
@@ -53,13 +56,14 @@ pub(crate) fn generate(args: GenerateArgs) -> Result<()> {
         ensure_parent_dir(p)?;
     }
 
-    let api_key = resolve_api_key(args.api_key)?;
-    let client = GeminiClient::new(api_key);
+    let api_key = resolve_api_key(args.provider, args.api_key)?;
+    let client = build_client(args.provider, api_key);
+    let model = resolve_model(args.provider, args.model);
 
     let seed = args.seed.unwrap_or_else(pick_default_seed);
 
     let mut cfg = GenerateConfig::new(&args.prompt);
-    cfg.model = args.model;
+    cfg.model = model.clone();
     cfg.budget_tokens = args.budget_tokens;
     if let Some(t) = args.temperature {
         cfg.temperature = Some(t);
@@ -70,10 +74,11 @@ pub(crate) fn generate(args: GenerateArgs) -> Result<()> {
     cfg.thinking_level = Some(effective_thinking);
     attach_system_instruction(&mut cfg, &client, args.cached_content, args.no_cache, "generate");
 
+    let provider_label = args.provider.label();
     let total_attempts = args.max_repair_iters + 1;
     let mut pb = Spinner::new(
-        &format!("generate: calling Gemini (attempt 1/{total_attempts})"),
-        GEMINI_FLAVORS,
+        &format!("generate: calling {provider_label} (attempt 1/{total_attempts})"),
+        LLM_FLAVORS,
     );
 
     let pb_cb = pb.handle();
@@ -91,8 +96,8 @@ pub(crate) fn generate(args: GenerateArgs) -> Result<()> {
     let outcome = match generate_with_repair(&client, cfg, &repair) {
         Ok(o) => o,
         Err(e) => {
-            pb.abandon_with_message(format!("generate: Gemini error — {e}"));
-            return Err(anyhow!("gemini: {e}"));
+            pb.abandon_with_message(format!("generate: {provider_label} error — {e}"));
+            return Err(anyhow!("{}: {e}", provider_label.to_lowercase()));
         }
     };
 

--- a/crates/mogen/src/commands/modify.rs
+++ b/crates/mogen/src/commands/modify.rs
@@ -2,18 +2,17 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, bail, Context, Result};
-use mogen_llm::gemini::{GeminiClient, GenerateConfig};
 use mogen_llm::{
     embed_seed_header, generate_with_repair, parse_prompt_header, parse_seed_header,
-    parse_thinking_header, RepairConfig, ThinkingLevel,
+    parse_thinking_header, GenerateConfig, Provider, RepairConfig, ThinkingLevel,
 };
 
 use crate::commands::build::build;
 use crate::common::{
-    attach_system_instruction, ensure_parent_dir, format_cached_tokens, pick_default_seed,
-    resolve_api_key, summarize_repair_errors,
+    attach_system_instruction, build_client, ensure_parent_dir, format_cached_tokens,
+    pick_default_seed, resolve_api_key, resolve_model, summarize_repair_errors,
 };
-use crate::spinner::{Spinner, GEMINI_FLAVORS};
+use crate::spinner::{Spinner, LLM_FLAVORS};
 
 pub(crate) struct ModifyArgs {
     pub input: PathBuf,
@@ -21,7 +20,9 @@ pub(crate) struct ModifyArgs {
     pub out: Option<PathBuf>,
     pub dsl_out: Option<PathBuf>,
     pub seed: Option<u64>,
-    pub model: String,
+    pub provider: Provider,
+    /// `None` -> use the provider's default model.
+    pub model: Option<String>,
     pub dry_run: bool,
     pub budget_tokens: Option<u32>,
     pub max_repair_iters: u32,
@@ -65,8 +66,10 @@ pub(crate) fn modify(args: ModifyArgs) -> Result<()> {
         ensure_parent_dir(&resolved_out)?;
     }
 
-    let api_key = resolve_api_key(args.api_key)?;
-    let client = GeminiClient::new(api_key);
+    let api_key = resolve_api_key(args.provider, args.api_key)?;
+    let client = build_client(args.provider, api_key);
+    let model = resolve_model(args.provider, args.model);
+    let provider_label = args.provider.label();
 
     let user_prompt = format!(
         "You are editing an existing mogen DSL file. Apply this modification:\n\n\
@@ -91,7 +94,7 @@ Existing file:\n\n{existing}",
     );
 
     let mut cfg = GenerateConfig::new(user_prompt);
-    cfg.model = args.model;
+    cfg.model = model;
     cfg.budget_tokens = args.budget_tokens;
     if let Some(t) = args.temperature {
         cfg.temperature = Some(t);
@@ -102,8 +105,8 @@ Existing file:\n\n{existing}",
 
     let total_attempts = args.max_repair_iters + 1;
     let mut pb = Spinner::new(
-        &format!("modify: calling Gemini (attempt 1/{total_attempts})"),
-        GEMINI_FLAVORS,
+        &format!("modify: calling {provider_label} (attempt 1/{total_attempts})"),
+        LLM_FLAVORS,
     );
 
     let pb_cb = pb.handle();
@@ -121,8 +124,8 @@ Existing file:\n\n{existing}",
     let outcome = match generate_with_repair(&client, cfg, &repair) {
         Ok(o) => o,
         Err(e) => {
-            pb.abandon_with_message(format!("modify: Gemini error — {e}"));
-            return Err(anyhow!("gemini: {e}"));
+            pb.abandon_with_message(format!("modify: {provider_label} error — {e}"));
+            return Err(anyhow!("{}: {e}", provider_label.to_lowercase()));
         }
     };
 

--- a/crates/mogen/src/commands/repair.rs
+++ b/crates/mogen/src/commands/repair.rs
@@ -3,25 +3,27 @@ use std::path::PathBuf;
 
 use anyhow::{anyhow, bail, Context, Result};
 use mogen_core::has_errors;
-use mogen_llm::gemini::{GeminiClient, GenerateConfig};
 use mogen_llm::{
     embed_seed_header, generate_with_repair, parse_prompt_header, parse_seed_header,
-    parse_thinking_header, repair_message, validate_text, RepairConfig, ThinkingLevel,
+    parse_thinking_header, repair_message, validate_text, GenerateConfig, Provider, RepairConfig,
+    ThinkingLevel,
 };
 
 use crate::commands::build::build;
 use crate::common::{
-    attach_system_instruction, ensure_parent_dir, format_cached_tokens, pick_default_seed,
-    resolve_api_key, summarize_repair_errors,
+    attach_system_instruction, build_client, ensure_parent_dir, format_cached_tokens,
+    pick_default_seed, resolve_api_key, resolve_model, summarize_repair_errors,
 };
-use crate::spinner::{Spinner, GEMINI_FLAVORS};
+use crate::spinner::{Spinner, LLM_FLAVORS};
 
 pub(crate) struct RepairArgs {
     pub input: PathBuf,
     pub out: Option<PathBuf>,
     pub dsl_out: Option<PathBuf>,
     pub seed: Option<u64>,
-    pub model: String,
+    pub provider: Provider,
+    /// `None` -> use the provider's default model.
+    pub model: Option<String>,
     pub dry_run: bool,
     pub no_build: bool,
     pub budget_tokens: Option<u32>,
@@ -93,8 +95,10 @@ pub(crate) fn repair(args: RepairArgs) -> Result<()> {
         }
     }
 
-    let api_key = resolve_api_key(args.api_key)?;
-    let client = GeminiClient::new(api_key);
+    let api_key = resolve_api_key(args.provider, args.api_key)?;
+    let client = build_client(args.provider, api_key);
+    let model = resolve_model(args.provider, args.model);
+    let provider_label = args.provider.label();
 
     // The repair message already contains the previous DSL, every diagnostic
     // (with caret excerpts), and each code's fix hint — exactly the shape the
@@ -104,7 +108,7 @@ pub(crate) fn repair(args: RepairArgs) -> Result<()> {
     let user_prompt = repair_message(&header_prompt, &existing, &diags, &[]);
 
     let mut cfg = GenerateConfig::new(user_prompt);
-    cfg.model = args.model;
+    cfg.model = model;
     cfg.budget_tokens = args.budget_tokens;
     if let Some(t) = args.temperature {
         cfg.temperature = Some(t);
@@ -117,9 +121,9 @@ pub(crate) fn repair(args: RepairArgs) -> Result<()> {
     let starting_summary = summarize_repair_errors(&diags);
     let mut pb = Spinner::new(
         &format!(
-            "repair: calling Gemini (attempt 1/{total_attempts}) — fixing {starting_summary}"
+            "repair: calling {provider_label} (attempt 1/{total_attempts}) — fixing {starting_summary}"
         ),
-        GEMINI_FLAVORS,
+        LLM_FLAVORS,
     );
 
     let pb_cb = pb.handle();
@@ -137,8 +141,8 @@ pub(crate) fn repair(args: RepairArgs) -> Result<()> {
     let outcome = match generate_with_repair(&client, cfg, &repair_cfg) {
         Ok(o) => o,
         Err(e) => {
-            pb.abandon_with_message(format!("repair: Gemini error — {e}"));
-            return Err(anyhow!("gemini: {e}"));
+            pb.abandon_with_message(format!("repair: {provider_label} error — {e}"));
+            return Err(anyhow!("{}: {e}", provider_label.to_lowercase()));
         }
     };
 

--- a/crates/mogen/src/commands/textures.rs
+++ b/crates/mogen/src/commands/textures.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 use anyhow::{Context, Result};
 use mogen_llm::gemini::GeminiClient;
+use mogen_llm::Provider;
 
 use crate::commands::build::build;
 use crate::common::{ensure_parent_dir, resolve_api_key};
@@ -65,8 +66,13 @@ pub(crate) fn textures_cmd(args: mogen_llm::textures::TexturesArgs) -> Result<()
 
     // Only bring up a client if we'll actually need one. Cache-only and
     // derive-only runs don't need a key.
+    // Image generation only ships against Gemini today — non-Gemini providers
+    // would need a separate image endpoint that doesn't exist in OpenAI's
+    // chat-completions or Anthropic's messages APIs (and Ollama has no
+    // image-out path at all). Always read GEMINI_API_KEY here regardless of
+    // any `--provider` selection on the parent command.
     let client = if to_gen > 0 {
-        let api_key = resolve_api_key(args.api_key.clone())?;
+        let api_key = resolve_api_key(Provider::Gemini, args.api_key.clone())?;
         Some(GeminiClient::new(api_key))
     } else {
         None

--- a/crates/mogen/src/common.rs
+++ b/crates/mogen/src/common.rs
@@ -4,10 +4,9 @@ use std::path::Path;
 
 use anyhow::{bail, Context, Result};
 use mogen_core::{Diagnostic, Severity};
-use mogen_llm::gemini::{GeminiClient, GenerateConfig};
 use mogen_llm::{
-    default_cache_path, resolve_or_create_cache, system_instruction, StdlibIndex,
-    DEFAULT_TTL_SECONDS,
+    default_cache_path, resolve_or_create_cache, system_instruction, GenerateConfig, LlmClient,
+    Provider, StdlibIndex, DEFAULT_TTL_SECONDS,
 };
 
 /// Group error diagnostics by category (derived from the code prefix) so the
@@ -47,18 +46,40 @@ pub(crate) fn diag_category(code: &str) -> &'static str {
     }
 }
 
-pub(crate) fn resolve_api_key(flag: Option<String>) -> Result<String> {
+/// Resolve the API key for `provider`. Precedence: explicit `--api-key` flag,
+/// then the provider's environment variable ([`Provider::env_var`]). Ollama
+/// is allowed to start with a blank key — most local installs don't require
+/// auth.
+pub(crate) fn resolve_api_key(provider: Provider, flag: Option<String>) -> Result<String> {
     if let Some(k) = flag {
         if k.trim().is_empty() {
             bail!("--api-key is empty");
         }
         return Ok(k);
     }
-    let from_env = std::env::var("GEMINI_API_KEY").ok();
-    match from_env {
-        Some(k) if !k.trim().is_empty() => Ok(k),
-        _ => bail!("missing GEMINI_API_KEY (set env var or pass --api-key)"),
+    let var = provider.env_var();
+    let from_env = std::env::var(var).unwrap_or_default();
+    if from_env.trim().is_empty() {
+        if matches!(provider, Provider::Ollama) {
+            // Ollama is keyless by default — fall through with empty string
+            // so the client constructs without auth.
+            return Ok(String::new());
+        }
+        bail!("missing {var} (set env var or pass --api-key)");
     }
+    Ok(from_env)
+}
+
+/// Resolve the model id for the call. Falls back to the provider-specific
+/// default when the user passed nothing.
+pub(crate) fn resolve_model(provider: Provider, flag: Option<String>) -> String {
+    flag.filter(|m| !m.trim().is_empty())
+        .unwrap_or_else(|| provider.default_model().to_string())
+}
+
+/// Construct the right [`LlmClient`] for `provider` with `api_key`.
+pub(crate) fn build_client(provider: Provider, api_key: String) -> LlmClient {
+    LlmClient::new(provider, api_key)
 }
 
 /// Create the parent directory for `path` if it doesn't already exist. Called
@@ -77,14 +98,17 @@ pub(crate) fn ensure_parent_dir(path: &Path) -> Result<()> {
 /// Set `cfg.cached_content` or `cfg.system_instruction` based on flags.
 ///
 /// Precedence:
-///   1. `--cached-content <name>` — use that resource name verbatim (no local cache read/write).
-///   2. `--no-cache` — send the system instruction inline.
-///   3. Default — try to resolve or create a persistent cache entry under
-///      `$MOGEN_CACHE_DIR` / `$HOME/.cache/mogen/`, falling back to inline on
-///      any failure (printed to stderr so the user notices repeat failures).
+///   1. `--cached-content <name>` — use that resource name verbatim (Gemini
+///      only; ignored on other providers).
+///   2. `--no-cache`, or non-Gemini provider — send the system instruction
+///      inline.
+///   3. Default (Gemini only) — try to resolve or create a persistent cache
+///      entry under `$MOGEN_CACHE_DIR` / `$HOME/.cache/mogen/`, falling back
+///      to inline on any failure (printed to stderr so the user notices
+///      repeat failures).
 pub(crate) fn attach_system_instruction(
     cfg: &mut GenerateConfig,
-    client: &GeminiClient,
+    client: &LlmClient,
     pinned: Option<String>,
     no_cache: bool,
     label: &str,
@@ -93,22 +117,38 @@ pub(crate) fn attach_system_instruction(
         mogen_dsl::stdlib_registry(),
     ));
 
+    // Non-Gemini providers don't honour `cachedContents`. Force inline.
+    let gemini = match client {
+        LlmClient::Gemini(c) => Some(c),
+        _ => None,
+    };
+
     if let Some(name) = pinned {
-        cfg.cached_content = Some(name);
+        if gemini.is_some() {
+            cfg.cached_content = Some(name);
+        } else {
+            // Politely warn and fall through — the flag is silently ignored
+            // on backends that have no equivalent feature.
+            eprintln!(
+                "mogen {label}: --cached-content is Gemini-only; sending system instruction inline"
+            );
+            cfg.system_instruction = Some(system_text);
+        }
         return;
     }
-    if no_cache {
+    if no_cache || gemini.is_none() {
         cfg.system_instruction = Some(system_text);
         return;
     }
 
+    let gemini = gemini.expect("matched above");
     let Some(cache_path) = default_cache_path() else {
         cfg.system_instruction = Some(system_text);
         return;
     };
 
     match resolve_or_create_cache(
-        client,
+        gemini,
         &cfg.model,
         &system_text,
         &cache_path,
@@ -126,7 +166,7 @@ pub(crate) fn attach_system_instruction(
     }
 }
 
-/// Render the cached-token portion of a Gemini usage record. Returns an empty
+/// Render the cached-token portion of a usage record. Returns an empty
 /// string when the call didn't hit a cache, so the summary doesn't grow a
 /// noisy "cached=0" suffix for inline runs.
 pub(crate) fn format_cached_tokens(usage: &mogen_llm::Usage) -> String {

--- a/crates/mogen/src/main.rs
+++ b/crates/mogen/src/main.rs
@@ -7,8 +7,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand, ValueEnum};
-use mogen_llm::gemini::DEFAULT_MODEL;
-use mogen_llm::{ThinkingLevel, DEFAULT_IMAGE_MODEL};
+use mogen_llm::{Provider, ThinkingLevel, DEFAULT_IMAGE_MODEL};
 
 use commands::animate::{animate, AnimateArgs};
 use commands::bench::bench;
@@ -36,6 +35,27 @@ impl From<ThinkingArg> for ThinkingLevel {
             ThinkingArg::Medium => ThinkingLevel::Medium,
             ThinkingArg::High => ThinkingLevel::High,
             ThinkingArg::Xhigh => ThinkingLevel::XHigh,
+        }
+    }
+}
+
+/// CLI-facing mirror of [`Provider`]. Same separation as `ThinkingArg` —
+/// keeps `clap::ValueEnum` out of the library crate.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ProviderArg {
+    Gemini,
+    Openai,
+    Anthropic,
+    Ollama,
+}
+
+impl From<ProviderArg> for Provider {
+    fn from(p: ProviderArg) -> Self {
+        match p {
+            ProviderArg::Gemini => Provider::Gemini,
+            ProviderArg::Openai => Provider::OpenAI,
+            ProviderArg::Anthropic => Provider::Anthropic,
+            ProviderArg::Ollama => Provider::Ollama,
         }
     }
 }
@@ -73,8 +93,8 @@ enum Cmd {
     },
     /// Read a GLB and print its structure.
     Inspect { input: PathBuf },
-    /// Generate a DSL file from a natural-language prompt via Gemini, then
-    /// validate and compile it.
+    /// Generate a DSL file from a natural-language prompt via the configured
+    /// LLM provider, then validate and compile it.
     Generate {
         /// Natural-language description of the asset, e.g. "a wooden stool".
         prompt: String,
@@ -88,9 +108,15 @@ enum Cmd {
         /// Seed embedded in the DSL header for reproducibility. Randomized if omitted.
         #[arg(long)]
         seed: Option<u64>,
-        /// Gemini model name.
-        #[arg(long, default_value = DEFAULT_MODEL)]
-        model: String,
+        /// LLM provider. The matching API key env var is read for the call
+        /// (`GEMINI_API_KEY` / `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` /
+        /// `OLLAMA_API_KEY`). Ollama runs locally and is keyless by default.
+        #[arg(long, value_enum, default_value_t = ProviderArg::Gemini)]
+        provider: ProviderArg,
+        /// Model name. When omitted, falls back to the provider's default
+        /// (Gemini Pro / GPT-4o / Claude Sonnet / llama3.1).
+        #[arg(long)]
+        model: Option<String>,
         /// Print the generated DSL but skip compilation and GLB output.
         #[arg(long)]
         dry_run: bool,
@@ -100,30 +126,31 @@ enum Cmd {
         /// Max number of repair iterations after the first attempt.
         #[arg(long, default_value_t = 2)]
         max_repair_iters: u32,
-        /// Override GEMINI_API_KEY.
+        /// Override the provider's API key env var.
         #[arg(long)]
         api_key: Option<String>,
         /// `cachedContents/...` resource name to use for the system instruction.
-        /// If set, we skip uploading the grammar/stdlib reference on each call.
+        /// **Gemini only** — silently ignored for other providers.
         #[arg(long)]
         cached_content: Option<String>,
         /// Disable the automatic system-instruction cache (see `MOGEN_CACHE_DIR`).
-        /// By default, mogen creates and reuses a `cachedContents` resource so
-        /// repeated calls skip re-uploading the grammar reference.
+        /// Cache is Gemini-only; other providers always send the system
+        /// instruction inline.
         #[arg(long)]
         no_cache: bool,
-        /// Sampling temperature. Gemini default is used when omitted.
+        /// Sampling temperature. Provider default is used when omitted.
         #[arg(long)]
         temperature: Option<f32>,
-        /// Cap on server-side reasoning. `low` is fastest; `xhigh` near-maximises
-        /// quality but can take ~2 minutes on Pro. If omitted, falls back to the
+        /// Cap on server-side reasoning. Maps to Gemini's `thinkingBudget`,
+        /// Anthropic's `thinking.budget_tokens`, and OpenAI's
+        /// `reasoning.effort`. Ignored by Ollama. Falls back to the
         /// `// mogen-generate thinking=…` header (modify/animate/repair only)
         /// and then to `high`.
         #[arg(long, value_enum)]
         thinking: Option<ThinkingArg>,
     },
-    /// Modify an existing DSL file with a natural-language prompt via Gemini,
-    /// then validate and recompile the GLB.
+    /// Modify an existing DSL file with a natural-language prompt via the
+    /// configured LLM provider, then validate and recompile the GLB.
     Modify {
         /// Existing .mog file to modify.
         input: PathBuf,
@@ -139,9 +166,12 @@ enum Cmd {
         /// the input's header, or a random seed if absent.
         #[arg(long)]
         seed: Option<u64>,
-        /// Gemini model name.
-        #[arg(long, default_value = DEFAULT_MODEL)]
-        model: String,
+        /// LLM provider. See `generate --provider`.
+        #[arg(long, value_enum, default_value_t = ProviderArg::Gemini)]
+        provider: ProviderArg,
+        /// Model name. When omitted, falls back to the provider's default.
+        #[arg(long)]
+        model: Option<String>,
         /// Print the modified DSL but skip compilation and file writes.
         #[arg(long)]
         dry_run: bool,
@@ -151,27 +181,28 @@ enum Cmd {
         /// Max number of repair iterations after the first attempt.
         #[arg(long, default_value_t = 2)]
         max_repair_iters: u32,
-        /// Override GEMINI_API_KEY.
+        /// Override the provider's API key env var.
         #[arg(long)]
         api_key: Option<String>,
         /// `cachedContents/...` resource name to use for the system instruction.
+        /// **Gemini only.**
         #[arg(long)]
         cached_content: Option<String>,
         /// Disable the automatic system-instruction cache (see `--no-cache`
         /// on `generate` for details).
         #[arg(long)]
         no_cache: bool,
-        /// Sampling temperature. Gemini default is used when omitted.
+        /// Sampling temperature. Provider default is used when omitted.
         #[arg(long)]
         temperature: Option<f32>,
         /// Cap on server-side reasoning. See `generate --thinking`.
         #[arg(long, value_enum)]
         thinking: Option<ThinkingArg>,
     },
-    /// Add or edit animations on an existing DSL file via Gemini, then
-    /// validate and recompile the GLB. The LLM is restricted to animation
-    /// top-level declarations (`joint`, `clip`/`track`, and the procedural
-    /// templates `spin`, `open_close`, `wave`, `flap`, `idle`).
+    /// Add or edit animations on an existing DSL file via the configured LLM
+    /// provider, then validate and recompile the GLB. The LLM is restricted
+    /// to animation top-level declarations (`joint`, `clip`/`track`, and the
+    /// procedural templates `spin`, `open_close`, `wave`, `flap`, `idle`).
     Animate {
         /// Existing .mog file whose animations should be edited.
         input: PathBuf,
@@ -188,9 +219,12 @@ enum Cmd {
         /// the input's header, or a random seed if absent.
         #[arg(long)]
         seed: Option<u64>,
-        /// Gemini model name.
-        #[arg(long, default_value = DEFAULT_MODEL)]
-        model: String,
+        /// LLM provider. See `generate --provider`.
+        #[arg(long, value_enum, default_value_t = ProviderArg::Gemini)]
+        provider: ProviderArg,
+        /// Model name. When omitted, falls back to the provider's default.
+        #[arg(long)]
+        model: Option<String>,
         /// Print the updated DSL but skip compilation and file writes.
         #[arg(long)]
         dry_run: bool,
@@ -200,27 +234,29 @@ enum Cmd {
         /// Max number of repair iterations after the first attempt.
         #[arg(long, default_value_t = 2)]
         max_repair_iters: u32,
-        /// Override GEMINI_API_KEY.
+        /// Override the provider's API key env var.
         #[arg(long)]
         api_key: Option<String>,
         /// `cachedContents/...` resource name to use for the system instruction.
+        /// **Gemini only.**
         #[arg(long)]
         cached_content: Option<String>,
         /// Disable the automatic system-instruction cache (see `--no-cache`
         /// on `generate` for details).
         #[arg(long)]
         no_cache: bool,
-        /// Sampling temperature. Gemini default is used when omitted.
+        /// Sampling temperature. Provider default is used when omitted.
         #[arg(long)]
         temperature: Option<f32>,
         /// Cap on server-side reasoning. See `generate --thinking`.
         #[arg(long, value_enum)]
         thinking: Option<ThinkingArg>,
     },
-    /// Repair validation errors in an existing .mog file via Gemini. Runs the
-    /// validator first and passes each diagnostic (with source excerpt, caret,
-    /// and fix hint) back to the model, then re-validates. Exits successfully
-    /// as a no-op if the file already validates.
+    /// Repair validation errors in an existing .mog file via the configured
+    /// LLM provider. Runs the validator first and passes each diagnostic
+    /// (with source excerpt, caret, and fix hint) back to the model, then
+    /// re-validates. Exits successfully as a no-op if the file already
+    /// validates.
     Repair {
         /// Existing .mog file to repair.
         input: PathBuf,
@@ -234,9 +270,12 @@ enum Cmd {
         /// the input's header, or a random seed if absent.
         #[arg(long)]
         seed: Option<u64>,
-        /// Gemini model name.
-        #[arg(long, default_value = DEFAULT_MODEL)]
-        model: String,
+        /// LLM provider. See `generate --provider`.
+        #[arg(long, value_enum, default_value_t = ProviderArg::Gemini)]
+        provider: ProviderArg,
+        /// Model name. When omitted, falls back to the provider's default.
+        #[arg(long)]
+        model: Option<String>,
         /// Print the repaired DSL but skip compilation and file writes.
         #[arg(long)]
         dry_run: bool,
@@ -249,17 +288,18 @@ enum Cmd {
         /// Max number of repair iterations after the first attempt.
         #[arg(long, default_value_t = 2)]
         max_repair_iters: u32,
-        /// Override GEMINI_API_KEY.
+        /// Override the provider's API key env var.
         #[arg(long)]
         api_key: Option<String>,
         /// `cachedContents/...` resource name to use for the system instruction.
+        /// **Gemini only.**
         #[arg(long)]
         cached_content: Option<String>,
         /// Disable the automatic system-instruction cache (see `--no-cache`
         /// on `generate` for details).
         #[arg(long)]
         no_cache: bool,
-        /// Sampling temperature. Gemini default is used when omitted.
+        /// Sampling temperature. Provider default is used when omitted.
         #[arg(long)]
         temperature: Option<f32>,
         /// Cap on server-side reasoning. See `generate --thinking`.
@@ -272,8 +312,10 @@ enum Cmd {
     /// variance-based, cavity-based). PNGs are written next to the .mog and
     /// the matching `*_texture="…"` attrs are spliced into each material.
     ///
-    /// Per-slot, materials that already declare a given `*_texture` attr — or
-    /// whose target PNG already exists at the planned path on disk — are
+    /// **This command is Gemini-only** — image generation isn't part of the
+    /// abstraction, so OpenAI / Anthropic / Ollama are not selectable here.
+    /// Per-slot, materials that already declare a given `*_texture` attr —
+    /// or whose target PNG already exists at the planned path on disk — are
     /// skipped unless `--force` is passed. Existing on-disk PNGs still get
     /// their `*_texture` attr spliced into the source, just without an API
     /// call or local re-derivation.
@@ -337,8 +379,12 @@ enum Cmd {
         /// `benches/prompts.txt` in the project root.
         #[arg(long, default_value = "benches/prompts.txt")]
         prompts: PathBuf,
-        #[arg(long, default_value = DEFAULT_MODEL)]
-        model: String,
+        /// LLM provider. See `generate --provider`.
+        #[arg(long, value_enum, default_value_t = ProviderArg::Gemini)]
+        provider: ProviderArg,
+        /// Model name. When omitted, falls back to the provider's default.
+        #[arg(long)]
+        model: Option<String>,
         #[arg(long, default_value_t = 2)]
         max_repair_iters: u32,
         #[arg(long)]
@@ -370,6 +416,7 @@ fn main() -> ExitCode {
             out,
             dsl_out,
             seed,
+            provider,
             model,
             dry_run,
             budget_tokens,
@@ -384,6 +431,7 @@ fn main() -> ExitCode {
             out,
             dsl_out,
             seed,
+            provider: provider.into(),
             model,
             dry_run,
             budget_tokens,
@@ -400,6 +448,7 @@ fn main() -> ExitCode {
             out,
             dsl_out,
             seed,
+            provider,
             model,
             dry_run,
             budget_tokens,
@@ -415,6 +464,7 @@ fn main() -> ExitCode {
             out,
             dsl_out,
             seed,
+            provider: provider.into(),
             model,
             dry_run,
             budget_tokens,
@@ -431,6 +481,7 @@ fn main() -> ExitCode {
             out,
             dsl_out,
             seed,
+            provider,
             model,
             dry_run,
             budget_tokens,
@@ -446,6 +497,7 @@ fn main() -> ExitCode {
             out,
             dsl_out,
             seed,
+            provider: provider.into(),
             model,
             dry_run,
             budget_tokens,
@@ -461,6 +513,7 @@ fn main() -> ExitCode {
             out,
             dsl_out,
             seed,
+            provider,
             model,
             dry_run,
             no_build,
@@ -476,6 +529,7 @@ fn main() -> ExitCode {
             out,
             dsl_out,
             seed,
+            provider: provider.into(),
             model,
             dry_run,
             no_build,
@@ -523,6 +577,7 @@ fn main() -> ExitCode {
         }),
         Cmd::Bench {
             prompts,
+            provider,
             model,
             max_repair_iters,
             budget_tokens,
@@ -531,6 +586,7 @@ fn main() -> ExitCode {
             thinking,
         } => bench(
             prompts,
+            provider.into(),
             model,
             max_repair_iters,
             budget_tokens,

--- a/crates/mogen/src/spinner.rs
+++ b/crates/mogen/src/spinner.rs
@@ -5,10 +5,10 @@ use std::time::{Duration, Instant};
 
 use indicatif::{ProgressBar, ProgressStyle};
 
-/// Rotating "still working" lines shown after a Gemini call has been running
+/// Rotating "still working" lines shown after an LLM call has been running
 /// for more than 10s. They're deliberately vague — we don't actually know
 /// what the model is doing, we just want the wait to feel less dead.
-pub(crate) const GEMINI_FLAVORS: &[&str] = &[
+pub(crate) const LLM_FLAVORS: &[&str] = &[
     "still thinking",
     "reasoning about geometry",
     "planning the scene",


### PR DESCRIPTION
Introduces a `Provider` enum and `LlmClient` dispatch wrapper in
mogen-llm so the same `generate_with_repair` / repair loop can drive any
backend. Provider-specific knobs (Gemini `cachedContents`, Anthropic
extended thinking, OpenAI `reasoning.effort`, Ollama `options.seed`) are
mapped from the shared `GenerateConfig` / `ThinkingLevel`.

CLI gains `--provider {gemini|openai|anthropic|ollama}` on generate,
modify, animate, repair, and bench (default Gemini for backwards
compat). The matching env var is consulted for the API key
(`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.). The textures command
remains Gemini-only since image generation isn't part of the
abstraction.

Studio settings persist the provider plus per-provider API keys and an
optional Ollama base URL; the rest of the GUI (run_llm, ask modal,
prompt enhancer, error classifier) routes through `LlmClient`.

https://claude.ai/code/session_01Xa4DJF1roWtLsvgzkq59Kg