### PR TITLE
Add MoGen Playground section to the gh-pages site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - 'docs/**'
       - 'site/**'
+      - 'web/**'
+      - 'examples/**'
+      - 'crates/mogen-wasm/**'
+      - 'crates/mogen-core/**'
+      - 'crates/mogen-dsl/**'
+      - 'crates/mogen-validate/**'
+      - 'crates/mogen-export/**'
       - '.github/workflows/docs.yml'
   workflow_dispatch: {}
 
@@ -28,7 +35,33 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends pandoc
 
-      - name: Build static site
+      - name: Install Rust + wasm32 target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Cache cargo registry + wasm build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-wasm-
+
+      - name: Build static site (incl. playground)
         run: ./site/build.sh
 
       - name: Publish to gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ AppIcon.iconset/
 web/node_modules
 web/dist/
 web/wasm/
+web/tsconfig.tsbuildinfo
 
 # Generated example media
 examples/*.png

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ AppIcon.iconset/
 # gh-pages build output (the workflow rebuilds this on every push)
 /_site/
 web/node_modules
+web/dist/
+web/wasm/
 
 # Generated example media
 examples/*.png

--- a/crates/mogen-wasm/Cargo.toml
+++ b/crates/mogen-wasm/Cargo.toml
@@ -22,3 +22,10 @@ wasm-bindgen = "0.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 console_error_panic_hook = "0.1"
+
+# Skip wasm-pack's wasm-opt post-processing pass — it downloads a binaryen
+# tarball at build time, which is brittle in restricted-network CI and adds
+# non-trivial build time. The unoptimized .wasm is well under the WASM
+# streaming threshold; size is fine.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -293,6 +293,117 @@ blockquote p:last-child { margin-bottom: 0; }
 }
 .feature p { margin: 0; font-size: 14px; }
 
+/* --------------------------- playground card --------------------------- */
+
+.playground-card {
+  margin: 18px 0 8px;
+}
+
+.playground-launch {
+  display: block;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  color: inherit;
+  transition: border-color 200ms, transform 200ms, box-shadow 200ms;
+}
+.playground-launch:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-2);
+  color: inherit;
+}
+
+.playground-preview {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 0;
+  align-items: stretch;
+  background: var(--bg);
+  border-bottom: 1px solid var(--line);
+}
+@media (max-width: 720px) {
+  .playground-preview { grid-template-columns: 1fr; }
+  .playground-arrow { display: none !important; }
+}
+
+.playground-source {
+  padding: 18px 20px;
+  background: var(--bg-1);
+  overflow: auto;
+  min-width: 0;
+}
+.playground-source pre {
+  margin: 0;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.playground-arrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  color: var(--accent);
+  font-size: 22px;
+  background: var(--bg-1);
+  border-left: 1px solid var(--line);
+  border-right: 1px solid var(--line);
+}
+
+.playground-render {
+  position: relative;
+  background:
+    linear-gradient(180deg, rgba(108,180,255,0.05), transparent 60%),
+    var(--bg-1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  min-height: 180px;
+}
+.playground-render img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.playground-cta {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 14px;
+  align-items: center;
+  padding: 16px 20px;
+  font-size: 14px;
+}
+.playground-cta strong {
+  color: var(--text);
+  font-size: 15px;
+}
+.playground-cta span:not(.playground-go) {
+  color: var(--text-dim);
+}
+.playground-go {
+  color: var(--accent);
+  font-weight: 600;
+  white-space: nowrap;
+}
+@media (max-width: 540px) {
+  .playground-cta { grid-template-columns: 1fr; gap: 6px; }
+  .playground-go { justify-self: start; }
+}
+
+.playground-note {
+  margin: 10px 2px 0;
+  font-size: 13px;
+  color: var(--text-mute);
+}
+
 /* --------------------------- gallery (videos) --------------------------- */
 
 .gallery {

--- a/site/build.sh
+++ b/site/build.sh
@@ -9,8 +9,16 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 SITE="$ROOT/site"
+WEB="$ROOT/web"
 OUT="$ROOT/_site"
 PANDOC="${PANDOC:-pandoc}"
+WASM_PACK="${WASM_PACK:-wasm-pack}"
+NPM="${NPM:-npm}"
+
+# `SKIP_PLAYGROUND=1 ./site/build.sh` skips the wasm + Vite build entirely —
+# useful for fast docs-only iteration when you don't have the Rust wasm target
+# or Node installed locally.
+SKIP_PLAYGROUND="${SKIP_PLAYGROUND:-0}"
 
 if ! command -v "$PANDOC" >/dev/null 2>&1; then
   echo "error: pandoc not found on PATH (set PANDOC=/path/to/pandoc to override)" >&2
@@ -59,6 +67,44 @@ echo "building gh-pages site -> $OUT"
 build_md "$ROOT/docs/dsl.md"     "$OUT/dsl.html"     "DSL reference"     "DSL reference"   "Every node kind, attribute, and feature in the .mog DSL."
 build_md "$ROOT/docs/cli.md"     "$OUT/cli.html"     "CLI reference"     "CLI reference"   "Every mogen subcommand and flag, with examples."
 build_md "$ROOT/docs/studio.md"  "$OUT/studio.html"  "MoGen Studio"      "Studio guide"    "MoGen Studio — the desktop editor for .mog scenes."
+
+# Playground: build the wasm crate, then the Vite app, then drop the static
+# bundle into _site/playground/. The home page (and shared template nav) link
+# to playground/index.html — keep that path stable.
+if [ "$SKIP_PLAYGROUND" = "1" ]; then
+  echo "skipping playground build (SKIP_PLAYGROUND=1)"
+elif ! command -v "$WASM_PACK" >/dev/null 2>&1; then
+  echo "warning: wasm-pack not found — skipping playground build" >&2
+  echo "  install with: cargo install wasm-pack" >&2
+elif ! command -v "$NPM" >/dev/null 2>&1; then
+  echo "warning: npm not found — skipping playground build" >&2
+else
+  echo "building playground -> $OUT/playground"
+
+  # 1. Compile mogen-wasm to JS + .wasm under web/wasm/. The Vite entry point
+  #    in web/src/main.ts imports from `../wasm/mogen_wasm.js`; keeping the
+  #    out-dir layout matches the dev-server flow exactly.
+  echo "  -> wasm-pack build crates/mogen-wasm"
+  "$WASM_PACK" build "$ROOT/crates/mogen-wasm" \
+    --target web \
+    --out-dir "$WEB/wasm" \
+    --out-name mogen_wasm \
+    --release
+
+  # 2. Vite bundle. Use `npm ci` when a lockfile is present so CI gets a
+  #    deterministic install; fall back to `npm install` for first-time local
+  #    runs that may not have a lockfile yet.
+  if [ -f "$WEB/package-lock.json" ]; then
+    (cd "$WEB" && "$NPM" ci)
+  else
+    (cd "$WEB" && "$NPM" install)
+  fi
+  (cd "$WEB" && "$NPM" run build)
+
+  # 3. Publish the bundle.
+  mkdir -p "$OUT/playground"
+  cp -R "$WEB/dist/." "$OUT/playground/"
+fi
 
 # .nojekyll prevents GitHub Pages from running Jekyll on the output.
 touch "$OUT/.nojekyll"

--- a/site/home.html
+++ b/site/home.html
@@ -25,6 +25,7 @@
     <div class="nav-links">
       <a href="index.html">Home</a>
       <a href="index.html#gallery">Gallery</a>
+      <a href="playground/index.html">Playground</a>
       <a href="dsl.html">DSL</a>
       <a href="cli.html">CLI</a>
       <a href="studio.html">Studio</a>
@@ -47,7 +48,8 @@
         Single binary CLI, a desktop studio, and a Gemini-powered <code>generate</code> / <code>modify</code> / <code>animate</code> loop.
       </p>
       <div class="cta-row">
-        <a class="btn btn-primary" href="#downloads">↓ Download</a>
+        <a class="btn btn-primary" href="playground/index.html">▶ Try the Playground</a>
+        <a class="btn btn-ghost" href="#downloads">↓ Download</a>
         <a class="btn btn-ghost" href="dsl.html">Read the DSL →</a>
         <a class="btn btn-ghost" href="https://github.com/krazyjakee/MoGen" target="_blank" rel="noopener">Source on GitHub</a>
       </div>
@@ -75,6 +77,37 @@
       <h3><span class="dot"></span> LLM-aware pipeline</h3>
       <p><code>mogen generate "a wooden stool"</code> writes a <code>.mog</code>, validates it, repairs JSON diagnostics in a loop, and emits a GLB. Seeds are embedded for reproducibility.</p>
     </div>
+  </div>
+</section>
+
+<section>
+  <h2 id="playground">Playground</h2>
+  <p>The whole MoGen pipeline — parser, validator, lowering, glTF exporter — is compiled to WebAssembly and runs in your browser. Type on the left, see the GLB on the right, no installs and nothing leaves your machine. Examples from the repo are pre-loaded; pick one from the dropdown to start.</p>
+  <div class="playground-card">
+    <a class="playground-launch" href="playground/index.html">
+      <div class="playground-preview">
+        <div class="playground-source">
+          <pre><code class="language-mog">scene {
+  rounded_box "seat" (size=[0.45, 0.04, 0.45], radius=0.01)
+  cylinder "leg_fl" (radius=0.02, height=0.45)
+  cylinder "leg_fr" (radius=0.02, height=0.45)
+  cylinder "leg_bl" (radius=0.02, height=0.45)
+  cylinder "leg_br" (radius=0.02, height=0.45)
+  rounded_box "back" (size=[0.45, 0.45, 0.04], radius=0.01)
+}</code></pre>
+        </div>
+        <div class="playground-arrow" aria-hidden="true">→</div>
+        <div class="playground-render">
+          <img src="splash.png" alt="Rendered MoGen scene preview">
+        </div>
+      </div>
+      <div class="playground-cta">
+        <strong>Open the Playground</strong>
+        <span>Edit MoGen DSL with live diagnostics and a three.js GLB preview, all in-browser.</span>
+        <span class="playground-go">Launch ▶</span>
+      </div>
+    </a>
+    <p class="playground-note">Note: CSG (<code>union</code>/<code>difference</code>/<code>intersect</code>) and the texture pipeline aren't available in the wasm build — both rely on native libraries (<code>manifold</code>, <code>image</code>) that don't link for <code>wasm32-unknown-unknown</code>. Use the desktop <a href="cli.html"><code>mogen</code></a> CLI for those.</p>
   </div>
 </section>
 

--- a/site/template.html
+++ b/site/template.html
@@ -22,6 +22,7 @@ $endif$  <meta property="og:image" content="splash.png">
     <div class="nav-links">
       <a href="index.html">Home</a>
       <a href="index.html#gallery">Gallery</a>
+      <a href="playground/index.html">Playground</a>
       <a href="dsl.html">DSL</a>
       <a href="cli.html">CLI</a>
       <a href="studio.html">Studio</a>
@@ -54,7 +55,7 @@ $body$
   <div class="wrap">
     <div>© <span data-year></span> MoGen · MIT licensed</div>
     <div>
-      <a href="dsl.html">DSL</a> · <a href="cli.html">CLI</a> · <a href="studio.html">Studio</a> ·
+      <a href="playground/index.html">Playground</a> · <a href="dsl.html">DSL</a> · <a href="cli.html">CLI</a> · <a href="studio.html">Studio</a> ·
       <a href="https://github.com/krazyjakee/MoGen" target="_blank" rel="noopener">GitHub</a>
     </div>
   </div>

--- a/web/index.html
+++ b/web/index.html
@@ -3,16 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MoGen Web</title>
+    <title>MoGen Playground — edit .mog, preview GLB</title>
+    <meta name="description" content="Edit MoGen DSL and see the compiled glTF result in your browser. The full mogen pipeline running as wasm." />
   </head>
   <body>
     <div id="app">
       <header>
-        <span class="brand">MoGen Web</span>
+        <a class="brand" href="../index.html" title="Back to MoGen">← Mo<span class="mark">Gen</span> Playground</a>
         <select id="example-picker" title="Load an example">
           <option value="">Examples…</option>
         </select>
         <span class="spacer"></span>
+        <a class="docs-link" href="../dsl.html" target="_blank" rel="noopener">DSL reference ↗</a>
         <span id="status" class="status idle">idle</span>
       </header>
       <main>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -29,7 +29,25 @@ header {
   border-bottom: 1px solid var(--border);
   font-size: 13px;
 }
-header .brand { font-weight: 600; letter-spacing: 0.02em; }
+header .brand {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text);
+  text-decoration: none;
+}
+header .brand:hover { color: var(--accent); }
+header .brand .mark {
+  background: linear-gradient(135deg, #ffb454, #ff8a3d);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+header .docs-link {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 12px;
+}
+header .docs-link:hover { color: var(--accent); }
 header .spacer { flex: 1; }
 header select {
   background: var(--bg);

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,6 +6,11 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "..");
 
 export default defineConfig({
+  // Build with relative asset URLs so the same `dist/` works whether it's
+  // served from the site root (Vite preview / `npm run dev`) or from a
+  // sub-path like `https://krazyjakee.github.io/MoGen/playground/` once
+  // `site/build.sh` copies it under `_site/playground/`.
+  base: "./",
   // Allow `import.meta.glob` to reach the example .mog files that live in
   // `<repo>/examples` — outside Vite's normal root.
   server: {


### PR DESCRIPTION
Wires the existing wasm-backed Vite app under web/ into the static site
build so visitors can edit MoGen DSL and preview the compiled GLB in a
split view directly from the public site (no install required).

- site/build.sh: build crates/mogen-wasm with wasm-pack, run the Vite
  build, and copy web/dist into _site/playground/. Skips gracefully when
  wasm-pack/npm are missing or SKIP_PLAYGROUND=1 is set, so docs-only
  iteration still works.
- .github/workflows/docs.yml: install Node, the wasm32 Rust target, and
  wasm-pack; cache cargo + node_modules so the playground build doesn't
  blow out CI time.
- crates/mogen-wasm: disable wasm-pack's wasm-opt pass to avoid the
  binaryen tarball download (failed in restricted-network sandboxes,
  unnecessary for our payload size).
- web/vite.config.ts: build with `base: "./"` so the same dist works
  whether served from the site root or under /MoGen/playground/.
- web/index.html + web/src/style.css: rebrand header to "MoGen Playground"
  with a back-link to the site root and a DSL-reference shortcut.
- site/home.html + site/template.html: add a Playground nav entry, a
  hero CTA, and a dedicated #playground section on the home page that
  previews the editor↔viewer flow and links into the live tool.
- site/assets/style.css: card styles for the new playground section.
- .gitignore: ignore web/dist/ and web/wasm/ build artifacts.