### PR TITLE
Add GitHub release auto-update for the CLI and Studio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,6 +1254,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2343,7 @@ dependencies = [
  "mogen-dsl",
  "mogen-export",
  "mogen-llm",
+ "mogen-update",
  "mogen-validate",
  "serde_json",
 ]
@@ -2427,11 +2439,27 @@ dependencies = [
  "mogen-dsl",
  "mogen-export",
  "mogen-llm",
+ "mogen-update",
  "mogen-validate",
  "rfd",
  "sentry",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "mogen-update"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "flate2",
+ "self-replace",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "ureq",
+ "zip",
 ]
 
 [[package]]
@@ -3783,6 +3811,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4197,6 +4236,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4563,10 +4612,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64 0.22.1",
+ "flate2",
  "log",
  "once_cell",
  "rustls 0.23.39",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "url",
  "webpki-roots 0.26.11",
 ]
@@ -5743,6 +5795,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/mogen-llm",
     "crates/mogen",
     "crates/mogen-studio",
+    "crates/mogen-update",
     "crates/mogen-wasm",
 ]
 
@@ -45,3 +46,4 @@ mogen-validate = { path = "crates/mogen-validate", default-features = false }
 mogen-anim = { path = "crates/mogen-anim" }
 mogen-export = { path = "crates/mogen-export", default-features = false }
 mogen-llm = { path = "crates/mogen-llm" }
+mogen-update = { path = "crates/mogen-update" }

--- a/crates/mogen-studio/Cargo.toml
+++ b/crates/mogen-studio/Cargo.toml
@@ -41,6 +41,7 @@ mogen-dsl = { workspace = true, features = ["csg"] }
 mogen-validate = { workspace = true, features = ["csg"] }
 mogen-export = { workspace = true, features = ["textures", "merge"] }
 mogen-llm = { workspace = true }
+mogen-update = { workspace = true }
 anyhow = { workspace = true }
 glam = { workspace = true }
 serde = { workspace = true }

--- a/crates/mogen-studio/src/app.rs
+++ b/crates/mogen-studio/src/app.rs
@@ -34,6 +34,7 @@ mod ui_llm;
 mod ui_menu;
 mod ui_panels;
 mod undo;
+mod update;
 mod util;
 mod watcher;
 
@@ -171,6 +172,15 @@ pub struct MogenStudioApp {
 
     /// Help → About modal visibility.
     show_about: bool,
+
+    /// Help → Check for Updates modal visibility. Independent of
+    /// `update_state` so the user can close the modal mid-install and the
+    /// worker keeps running in the background.
+    show_update: bool,
+    /// Self-updater state machine. `None` means nothing has been kicked off
+    /// (or the user closed the dialog while idle); a `Some(_)` survives modal
+    /// closes when an install is in flight so the worker isn't orphaned.
+    update_state: Option<self::update::UpdateState>,
 
     /// "Build GLB" modal visibility. Also acts as the ui gate on the export
     /// toggles while a build is in flight — the worker writes status through
@@ -397,6 +407,8 @@ impl MogenStudioApp {
             recently_closed: VecDeque::new(),
             last_viewport_rect: None,
             show_about: false,
+            show_update: false,
+            update_state: None,
             show_export: false,
             export_opts_draft: ExportOptions::default(),
             build_rx: None,
@@ -599,6 +611,7 @@ impl eframe::App for MogenStudioApp {
         self.poll_prompt_enhance();
         self.poll_ask();
         self.poll_build();
+        self.poll_update();
         self.poll_generate(ctx);
         self.drive_compile_debounce(ctx);
         self.check_external_changes(ctx);
@@ -743,6 +756,7 @@ impl eframe::App for MogenStudioApp {
         self.ui_export_dialog(ctx);
         self.ui_external_conflict(ctx);
         self.ui_about(ctx);
+        self.ui_update_dialog(ctx);
         self.ui_ask(ctx);
         self.ui_spotlight(ctx);
         self.ui_video_options(ctx);
@@ -763,6 +777,7 @@ impl eframe::App for MogenStudioApp {
             || self.any_enhance_in_flight()
             || self.any_ask_in_flight()
             || self.build_rx.is_some()
+            || self.update_in_flight()
         {
             ctx.request_repaint_after(std::time::Duration::from_millis(120));
         }

--- a/crates/mogen-studio/src/app/types.rs
+++ b/crates/mogen-studio/src/app/types.rs
@@ -294,6 +294,9 @@ pub(super) enum MenuAction {
     OpenOptions,
     Frame,
     OpenAbout,
+    /// Open the Help → Check for Updates… modal. The actual GitHub query is
+    /// kicked off by the user clicking "Check now" inside the dialog.
+    OpenUpdate,
     GenerateThumbnail,
     GenerateVideo,
     /// VS Code–style line / selection ops dispatched against the active

--- a/crates/mogen-studio/src/app/ui_dialogs.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs.rs
@@ -18,6 +18,7 @@ mod external;
 mod new_prompt;
 mod prefs;
 mod quit;
+mod update;
 mod video;
 
 pub use prefs::PrefsTab;

--- a/crates/mogen-studio/src/app/ui_dialogs/update.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/update.rs
@@ -1,0 +1,315 @@
+use eframe::egui;
+
+use crate::app::update::UpdateState;
+use crate::app::MogenStudioApp;
+
+impl MogenStudioApp {
+    /// Help → Check for Updates… modal. State machine lives on the app
+    /// (`MogenStudioApp::update_state`) and is advanced each frame by
+    /// `poll_update`. This function is purely presentational — every
+    /// non-trivial action is deferred via small intent flags so the borrow on
+    /// `self.update_state` ends before any mutation runs.
+    pub(in crate::app) fn ui_update_dialog(&mut self, ctx: &egui::Context) {
+        if !self.show_update {
+            return;
+        }
+        let mut open = true;
+        let mut start_check = false;
+        let mut start_install: Option<mogen_update::UpdateInfo> = None;
+        let mut close = false;
+
+        egui::Window::new("Check for Updates")
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(false)
+            .default_width(440.0)
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .show(ctx, |ui| {
+                ui.label(format!(
+                    "Current version: {}",
+                    env!("CARGO_PKG_VERSION")
+                ));
+                ui.label(format!(
+                    "Source: github.com/{}/{}",
+                    mogen_update::REPO_OWNER,
+                    mogen_update::REPO_NAME,
+                ));
+                ui.add_space(10.0);
+
+                // Snapshot the variant so the closures below don't need to
+                // hold a mutable borrow into `self.update_state`.
+                let state = self
+                    .update_state
+                    .as_ref()
+                    .map(state_kind)
+                    .unwrap_or(StateKind::Idle);
+
+                match state {
+                    StateKind::Idle => {
+                        ui.label(
+                            "Click \"Check now\" to look for a newer release on \
+                             GitHub. Nothing is downloaded until you confirm.",
+                        );
+                        ui.add_space(8.0);
+                        ui.horizontal(|ui| {
+                            if ui.button("Check now").clicked() {
+                                start_check = true;
+                            }
+                            if ui.button("Close").clicked() {
+                                close = true;
+                            }
+                        });
+                    }
+                    StateKind::Checking => {
+                        ui.horizontal(|ui| {
+                            ui.spinner();
+                            ui.label("checking github releases…");
+                        });
+                        ui.add_space(8.0);
+                        if ui.button("Cancel").clicked() {
+                            // Drop the receiver and reset to Idle. The worker
+                            // thread keeps running but its result is discarded.
+                            close = true;
+                        }
+                    }
+                    StateKind::Ready => {
+                        if let Some(UpdateState::Ready(res)) = self.update_state.as_ref() {
+                            let info = &res.info;
+                            ui.label(format!("Latest release: {}", info.tag));
+                            ui.label(format!(
+                                "Asset: {} ({})",
+                                info.asset_name,
+                                format_bytes(info.asset_size),
+                            ));
+                            if !info.html_url.is_empty() {
+                                ui.hyperlink_to("Release notes on GitHub", &info.html_url);
+                            }
+                            ui.add_space(8.0);
+                            if res.newer {
+                                ui.colored_label(
+                                    egui::Color32::from_rgb(120, 200, 140),
+                                    format!(
+                                        "An update is available: {} → {}.",
+                                        env!("CARGO_PKG_VERSION"),
+                                        info.version,
+                                    ),
+                                );
+                                ui.add_space(6.0);
+                                if !info.body.trim().is_empty() {
+                                    egui::CollapsingHeader::new("What's new")
+                                        .default_open(false)
+                                        .show(ui, |ui| {
+                                            egui::ScrollArea::vertical()
+                                                .max_height(160.0)
+                                                .show(ui, |ui| {
+                                                    ui.label(&info.body);
+                                                });
+                                        });
+                                    ui.add_space(6.0);
+                                }
+                                ui.label(
+                                    "Installing replaces the running mogen-studio (and the \
+                                     bundled mogen CLI if present alongside it). You'll need \
+                                     to restart the app once the swap completes.",
+                                );
+                                ui.add_space(8.0);
+                                ui.horizontal(|ui| {
+                                    if ui
+                                        .button("Download and install")
+                                        .on_hover_text(
+                                            "Download the matching release archive for your \
+                                             platform and replace the running binaries in place.",
+                                        )
+                                        .clicked()
+                                    {
+                                        start_install = Some(info.clone());
+                                    }
+                                    if ui.button("Close").clicked() {
+                                        close = true;
+                                    }
+                                });
+                            } else {
+                                ui.colored_label(
+                                    egui::Color32::from_rgb(180, 200, 220),
+                                    "You're already running the latest release.",
+                                );
+                                ui.add_space(8.0);
+                                ui.horizontal(|ui| {
+                                    if ui
+                                        .button("Reinstall")
+                                        .on_hover_text(
+                                            "Re-download and reinstall the current release. \
+                                             Useful for repairing a corrupted install.",
+                                        )
+                                        .clicked()
+                                    {
+                                        start_install = Some(info.clone());
+                                    }
+                                    if ui.button("Close").clicked() {
+                                        close = true;
+                                    }
+                                });
+                            }
+                        }
+                    }
+                    StateKind::CheckFailed => {
+                        if let Some(UpdateState::CheckFailed(e)) = self.update_state.as_ref() {
+                            ui.colored_label(
+                                egui::Color32::from_rgb(220, 120, 120),
+                                "Update check failed.",
+                            );
+                            ui.add_space(4.0);
+                            ui.label(e);
+                            ui.add_space(8.0);
+                            ui.horizontal(|ui| {
+                                if ui.button("Try again").clicked() {
+                                    start_check = true;
+                                }
+                                if ui.button("Close").clicked() {
+                                    close = true;
+                                }
+                            });
+                        }
+                    }
+                    StateKind::Installing => {
+                        if let Some(UpdateState::Installing {
+                            stage,
+                            downloaded,
+                            total,
+                            info,
+                            ..
+                        }) = self.update_state.as_ref()
+                        {
+                            ui.label(format!("Installing {}…", info.tag));
+                            ui.add_space(6.0);
+                            ui.horizontal(|ui| {
+                                ui.spinner();
+                                let label = if stage.is_empty() {
+                                    "working".to_string()
+                                } else {
+                                    format!("{stage}…")
+                                };
+                                ui.label(label);
+                            });
+                            ui.add_space(6.0);
+                            let denom = (*total).max(1);
+                            let frac = (*downloaded as f32 / denom as f32).clamp(0.0, 1.0);
+                            ui.add(
+                                egui::ProgressBar::new(frac)
+                                    .show_percentage()
+                                    .desired_width(360.0),
+                            );
+                            ui.add_space(2.0);
+                            ui.label(format!(
+                                "{} / {}",
+                                format_bytes(*downloaded),
+                                format_bytes(*total),
+                            ));
+                            ui.add_space(8.0);
+                            ui.label(
+                                "The new binary is being placed on disk. Don't quit the app \
+                                 until this completes.",
+                            );
+                        }
+                    }
+                    StateKind::Installed => {
+                        if let Some(UpdateState::Installed { tag }) = self.update_state.as_ref() {
+                            ui.colored_label(
+                                egui::Color32::from_rgb(120, 200, 140),
+                                format!("Updated to {tag}."),
+                            );
+                            ui.add_space(6.0);
+                            ui.label(
+                                "Quit and relaunch MoGen Studio to start running the new \
+                                 version.",
+                            );
+                            ui.add_space(8.0);
+                            if ui.button("Close").clicked() {
+                                close = true;
+                            }
+                        }
+                    }
+                    StateKind::InstallFailed => {
+                        if let Some(UpdateState::InstallFailed(e)) = self.update_state.as_ref() {
+                            ui.colored_label(
+                                egui::Color32::from_rgb(220, 120, 120),
+                                "Install failed.",
+                            );
+                            ui.add_space(4.0);
+                            ui.label(e);
+                            ui.add_space(8.0);
+                            ui.horizontal(|ui| {
+                                if ui.button("Check again").clicked() {
+                                    start_check = true;
+                                }
+                                if ui.button("Close").clicked() {
+                                    close = true;
+                                }
+                            });
+                        }
+                    }
+                }
+            });
+
+        if !open || close {
+            self.show_update = false;
+            // Drop any in-flight check. An installing worker is left running:
+            // killing it mid-write would leave the binary half-replaced, and
+            // there is no safe way to abort the file swap once it has started.
+            match self.update_state.as_ref() {
+                Some(UpdateState::Installing { .. }) => {
+                    // Keep the state so reopening the dialog reattaches.
+                }
+                _ => {
+                    self.update_state = None;
+                }
+            }
+            return;
+        }
+        if start_check {
+            self.spawn_update_check(ctx);
+        }
+        if let Some(info) = start_install {
+            self.spawn_update_install(ctx, info);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum StateKind {
+    Idle,
+    Checking,
+    Ready,
+    CheckFailed,
+    Installing,
+    Installed,
+    InstallFailed,
+}
+
+fn state_kind(s: &UpdateState) -> StateKind {
+    match s {
+        UpdateState::Idle => StateKind::Idle,
+        UpdateState::Checking { .. } => StateKind::Checking,
+        UpdateState::Ready(_) => StateKind::Ready,
+        UpdateState::CheckFailed(_) => StateKind::CheckFailed,
+        UpdateState::Installing { .. } => StateKind::Installing,
+        UpdateState::Installed { .. } => StateKind::Installed,
+        UpdateState::InstallFailed(_) => StateKind::InstallFailed,
+    }
+}
+
+fn format_bytes(n: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = 1024.0 * 1024.0;
+    const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+    let f = n as f64;
+    if f >= GIB {
+        format!("{:.2} GiB", f / GIB)
+    } else if f >= MIB {
+        format!("{:.2} MiB", f / MIB)
+    } else if f >= KIB {
+        format!("{:.1} KiB", f / KIB)
+    } else {
+        format!("{n} B")
+    }
+}

--- a/crates/mogen-studio/src/app/ui_menu.rs
+++ b/crates/mogen-studio/src/app/ui_menu.rs
@@ -508,6 +508,17 @@ impl MogenStudioApp {
                 ui.hyperlink_to("License (MIT)", LICENSE_URL);
                 ui.separator();
                 if ui
+                    .button("Check for Updates…")
+                    .on_hover_text(
+                        "Look for a newer release on GitHub and optionally \
+                         download and install it in place",
+                    )
+                    .clicked()
+                {
+                    action = MenuAction::OpenUpdate;
+                    ui.close_menu();
+                }
+                if ui
                     .button("About MoGen Studio…")
                     .on_hover_text("Version and credits")
                     .clicked()
@@ -599,6 +610,9 @@ impl MogenStudioApp {
             MenuAction::Frame => self.viewer.frame_view(),
             MenuAction::OpenAbout => {
                 self.show_about = true;
+            }
+            MenuAction::OpenUpdate => {
+                self.open_update_dialog();
             }
             MenuAction::GenerateThumbnail => self.generate_thumbnail(ctx),
             MenuAction::GenerateVideo => {

--- a/crates/mogen-studio/src/app/update.rs
+++ b/crates/mogen-studio/src/app/update.rs
@@ -1,0 +1,194 @@
+//! Auto-update worker plumbing for MoGen Studio.
+//!
+//! Two background phases live behind one `Help → Check for Updates…` modal:
+//!
+//! 1. **Check.** Hit the GitHub Releases API and report whether a newer tag
+//!    is available. Cheap (one HTTPS call); always runs on a worker thread
+//!    so the UI never stalls.
+//! 2. **Install.** Stream the matching archive to disk, extract it, and swap
+//!    the running `mogen-studio` (and sibling `mogen` CLI) in place. Reports
+//!    download / install progress through an `mpsc` so the dialog can show
+//!    a live status line and bar.
+//!
+//! Both stages mirror the channel-based pattern used by `build.rs`: the worker
+//! sends events on a sender and the UI thread polls a receiver each frame in
+//! `MogenStudioApp::poll_update`. The state machine is intentionally tiny —
+//! one optional state struct on the app, transitioned by user clicks.
+
+use std::sync::mpsc::{channel, Receiver};
+use std::thread;
+
+use eframe::egui;
+
+use mogen_update::{check, download_and_apply, CheckResult, Progress, UpdateInfo};
+
+use super::MogenStudioApp;
+
+/// Where the update dialog is in its lifecycle. Drives both the modal's
+/// content and which buttons are enabled.
+pub(super) enum UpdateState {
+    /// Initial render before the user clicks "Check". Holds nothing — kept as
+    /// its own variant so the dialog can show an explanatory blurb before the
+    /// first network call instead of an empty spinner.
+    Idle,
+    /// Background check running. The receiver carries the eventual result.
+    Checking { rx: Receiver<CheckResultMsg> },
+    /// Check returned successfully; we know the latest version. The user
+    /// decides whether to download.
+    Ready(CheckResult),
+    /// Check failed. Carries a human-readable error message; user can retry.
+    CheckFailed(String),
+    /// Download / install in flight. Status text and bar fed by `rx`.
+    Installing {
+        info: UpdateInfo,
+        rx: Receiver<InstallMsg>,
+        stage: String,
+        downloaded: u64,
+        total: u64,
+    },
+    /// Install finished successfully — user just needs to restart.
+    Installed { tag: String },
+    /// Install failed mid-stream. Carries the error message; user can retry
+    /// (which falls back to a fresh check).
+    InstallFailed(String),
+}
+
+/// Messages from the check worker. Single-shot — sent once and the channel
+/// hangs up.
+pub(super) enum CheckResultMsg {
+    Ok(CheckResult),
+    Err(String),
+}
+
+/// Streamed messages from the install worker. The worker emits zero or more
+/// `Progress` followed by exactly one `Done`.
+pub(super) enum InstallMsg {
+    Progress(Progress),
+    Done(Result<String, String>),
+}
+
+impl MogenStudioApp {
+    /// Open the update dialog. If a check or install is already in flight,
+    /// reuses that state (so re-clicking the menu item just brings the modal
+    /// back rather than starting fresh).
+    pub(super) fn open_update_dialog(&mut self) {
+        self.show_update = true;
+        if self.update_state.is_none() {
+            self.update_state = Some(UpdateState::Idle);
+        }
+    }
+
+    /// Spawn the GitHub release lookup on a worker. Cheap call — one HTTPS
+    /// request — but threaded so the UI never blocks on DNS or a slow
+    /// connection.
+    pub(super) fn spawn_update_check(&mut self, ctx: &egui::Context) {
+        let (tx, rx) = channel();
+        self.update_state = Some(UpdateState::Checking { rx });
+        let ctx = ctx.clone();
+        let current = env!("CARGO_PKG_VERSION").to_string();
+        thread::spawn(move || {
+            let msg = match check(&current) {
+                Ok(r) => CheckResultMsg::Ok(r),
+                Err(e) => CheckResultMsg::Err(format!("{e:#}")),
+            };
+            let _ = tx.send(msg);
+            ctx.request_repaint();
+        });
+    }
+
+    /// Spawn the download + install worker for the given release. The
+    /// `Progress` events are forwarded onto an `mpsc` so the UI thread can
+    /// paint them without holding any locks.
+    pub(super) fn spawn_update_install(&mut self, ctx: &egui::Context, info: UpdateInfo) {
+        let (tx, rx) = channel();
+        let total = info.asset_size;
+        self.update_state = Some(UpdateState::Installing {
+            info: info.clone(),
+            rx,
+            stage: "starting".into(),
+            downloaded: 0,
+            total,
+        });
+        let ctx_for_thread = ctx.clone();
+        thread::spawn(move || {
+            let tx_progress = tx.clone();
+            let ctx_for_progress = ctx_for_thread.clone();
+            let outcome = download_and_apply(&info, move |evt| {
+                let _ = tx_progress.send(InstallMsg::Progress(evt));
+                ctx_for_progress.request_repaint();
+            });
+            let done = match outcome {
+                Ok(applied) => InstallMsg::Done(Ok(applied.tag)),
+                Err(e) => InstallMsg::Done(Err(format!("{e:#}"))),
+            };
+            let _ = tx.send(done);
+            ctx_for_thread.request_repaint();
+        });
+    }
+
+    /// True when a check or install worker is producing events. Used by the
+    /// repaint heartbeat so the progress bar keeps moving without the user
+    /// having to nudge the window.
+    pub(super) fn update_in_flight(&self) -> bool {
+        matches!(
+            self.update_state,
+            Some(UpdateState::Checking { .. }) | Some(UpdateState::Installing { .. })
+        )
+    }
+
+    /// Drain whatever the in-flight worker has produced this frame and
+    /// transition the state machine. Idempotent — a no-op when nothing is in
+    /// flight.
+    pub(super) fn poll_update(&mut self) {
+        // Step 1: extract whatever update we want to apply, then mutate the
+        // field. This dance avoids holding a borrow on `self.update_state`
+        // while we reassign it.
+        let next = match self.update_state.as_mut() {
+            Some(UpdateState::Checking { rx }) => match rx.try_recv() {
+                Ok(CheckResultMsg::Ok(res)) => Some(UpdateState::Ready(res)),
+                Ok(CheckResultMsg::Err(e)) => Some(UpdateState::CheckFailed(e)),
+                Err(_) => None,
+            },
+            Some(UpdateState::Installing {
+                rx,
+                stage,
+                downloaded,
+                total,
+                info: _,
+            }) => {
+                // Drain every queued progress message in one frame so the bar
+                // catches up instead of moving one tick per repaint.
+                let mut done_with: Option<Result<String, String>> = None;
+                loop {
+                    match rx.try_recv() {
+                        Ok(InstallMsg::Progress(Progress::Stage(s))) => {
+                            *stage = s;
+                        }
+                        Ok(InstallMsg::Progress(Progress::Download {
+                            downloaded: d,
+                            total: t,
+                        })) => {
+                            *downloaded = d;
+                            if t > 0 {
+                                *total = t;
+                            }
+                        }
+                        Ok(InstallMsg::Done(r)) => {
+                            done_with = Some(r);
+                            break;
+                        }
+                        Err(_) => break,
+                    }
+                }
+                done_with.map(|r| match r {
+                    Ok(tag) => UpdateState::Installed { tag },
+                    Err(e) => UpdateState::InstallFailed(e),
+                })
+            }
+            _ => None,
+        };
+        if let Some(s) = next {
+            self.update_state = Some(s);
+        }
+    }
+}

--- a/crates/mogen-update/Cargo.toml
+++ b/crates/mogen-update/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "mogen-update"
+version.workspace = true
+edition.workspace = true
+description = "GitHub release self-updater for the MoGen CLI and Studio."
+license = "MIT"
+
+[dependencies]
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+# `tls` here picks rustls so we don't drag OpenSSL onto Linux just to talk to
+# api.github.com. ureq is sync and short-circuits the need for a tokio runtime
+# inside the worker thread that drives the download.
+ureq = { version = "2.12", default-features = false, features = ["tls", "json", "gzip"] }
+semver = "1"
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
+tar = { version = "0.4", default-features = false }
+self-replace = "1"
+
+[target.'cfg(windows)'.dependencies]
+zip = { version = "0.6", default-features = false, features = ["deflate"] }

--- a/crates/mogen-update/src/archive.rs
+++ b/crates/mogen-update/src/archive.rs
@@ -1,0 +1,77 @@
+//! Archive extraction for downloaded release assets.
+//!
+//! `tar.gz` is decoded with `flate2` + `tar` (Unix releases); `.zip` with the
+//! `zip` crate (Windows). The branching is on filename rather than host OS so
+//! a future switch to a uniform format only changes one place.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+
+/// Extract `archive` into `dest`. Caller is responsible for ensuring `dest`
+/// exists and is empty.
+pub(crate) fn extract(archive: &Path, dest: &Path) -> Result<()> {
+    let lname = archive
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+    if lname.ends_with(".tar.gz") || lname.ends_with(".tgz") {
+        extract_tar_gz(archive, dest)
+    } else if lname.ends_with(".zip") {
+        extract_zip(archive, dest)
+    } else {
+        Err(anyhow!(
+            "unsupported release archive format: {}",
+            archive.display()
+        ))
+    }
+}
+
+fn extract_tar_gz(archive: &Path, dest: &Path) -> Result<()> {
+    let f = fs::File::open(archive)
+        .with_context(|| format!("open archive {}", archive.display()))?;
+    let gz = flate2::read::GzDecoder::new(f);
+    let mut tar = tar::Archive::new(gz);
+    tar.set_preserve_permissions(true);
+    tar.unpack(dest)
+        .with_context(|| format!("extract tar.gz into {}", dest.display()))?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn extract_zip(archive: &Path, dest: &Path) -> Result<()> {
+    let f = fs::File::open(archive)
+        .with_context(|| format!("open archive {}", archive.display()))?;
+    let mut zip = zip::ZipArchive::new(f)
+        .with_context(|| format!("read zip {}", archive.display()))?;
+    for i in 0..zip.len() {
+        let mut entry = zip.by_index(i).context("read zip entry")?;
+        let rel = match entry.enclosed_name() {
+            Some(p) => p.to_path_buf(),
+            None => continue,
+        };
+        let out_path = dest.join(rel);
+        if entry.is_dir() {
+            fs::create_dir_all(&out_path).ok();
+            continue;
+        }
+        if let Some(parent) = out_path.parent() {
+            fs::create_dir_all(parent).ok();
+        }
+        let mut out = fs::File::create(&out_path)
+            .with_context(|| format!("create {}", out_path.display()))?;
+        std::io::copy(&mut entry, &mut out)
+            .with_context(|| format!("write {}", out_path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn extract_zip(_archive: &Path, _dest: &Path) -> Result<()> {
+    // The release pipeline doesn't ship .zip on non-Windows hosts (they get
+    // .tar.gz), so this path is unreachable in practice. Kept as an explicit
+    // error so a future change doesn't silently fail.
+    Err(anyhow!("zip extraction is only enabled on Windows builds"))
+}

--- a/crates/mogen-update/src/lib.rs
+++ b/crates/mogen-update/src/lib.rs
@@ -1,0 +1,505 @@
+//! Self-updater for the MoGen CLI and Studio.
+//!
+//! Checks the GitHub Releases API for a newer tagged release, downloads the
+//! matching archive for the current host triple, extracts the bundled binaries
+//! (`mogen` + `mogen-studio`), and atomically replaces them on disk. The
+//! release artifact naming follows `release.yml`:
+//!
+//! - Unix:    `mogen-<tag>-<target>.tar.gz`  containing `mogen` and `mogen-studio`
+//! - Windows: `mogen-<tag>-<target>.zip`     containing `mogen.exe` and `mogen-studio.exe`
+//!
+//! The crate exposes a small two-step API so both surfaces (CLI subcommand
+//! and Studio dialog) can share the heavy lifting:
+//!
+//! 1. [`check`]                   — query the GitHub API, return the latest tag.
+//! 2. [`download_and_apply`]      — download, extract, and replace binaries.
+//!
+//! Both functions are synchronous and block; callers that need a UI thread
+//! (Studio) run them on a worker and forward [`Progress`] events through a
+//! channel.
+
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Deserialize;
+
+mod archive;
+
+/// GitHub repo the updater talks to. Hardcoded — auto-update can only point at
+/// one canonical release feed.
+pub const REPO_OWNER: &str = "krazyjakee";
+pub const REPO_NAME: &str = "MoGen";
+
+const USER_AGENT: &str = concat!("mogen-update/", env!("CARGO_PKG_VERSION"));
+
+/// Description of a release we found on GitHub. Returned by [`check`] so the
+/// caller can decide whether to confirm with the user before downloading.
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    /// The release tag (e.g. `v0.2.0`). Used in the asset filename.
+    pub tag: String,
+    /// Tag with any leading `v` stripped, for human-friendly version compare.
+    pub version: String,
+    /// HTML release page on GitHub, surfaced in the "What's new" link.
+    pub html_url: String,
+    /// Direct download URL of the archive that matches this host's target
+    /// triple. `tar.gz` on Unix, `zip` on Windows.
+    pub asset_url: String,
+    /// Filename of `asset_url`, kept so the temp file can carry a recognisable
+    /// extension (the extractor branches on `.zip` vs `.tar.gz`).
+    pub asset_name: String,
+    /// Compressed download size in bytes, taken from the GitHub asset record.
+    /// Drives the progress bar denominator.
+    pub asset_size: u64,
+    /// Markdown-ish release notes from the GitHub release. May be empty.
+    pub body: String,
+}
+
+/// Streaming progress events emitted while [`download_and_apply`] runs.
+#[derive(Debug, Clone)]
+pub enum Progress {
+    /// The current stage label (e.g. "downloading", "extracting", "installing").
+    /// Sent at every stage transition so a UI can update its caption.
+    Stage(String),
+    /// Bytes downloaded so far / total expected. `total` mirrors
+    /// [`UpdateInfo::asset_size`] and is repeated for callers that throw away
+    /// the original info.
+    Download { downloaded: u64, total: u64 },
+}
+
+/// Outcome of a successful [`download_and_apply`] run.
+#[derive(Debug, Clone)]
+pub struct Applied {
+    /// Path of the now-replaced binary that was running when the update
+    /// started (i.e. the result of `current_exe()`).
+    pub replaced_self: PathBuf,
+    /// Path of the sibling binary that was replaced alongside, if it lived in
+    /// the same directory. `None` when the sibling wasn't found on disk
+    /// (custom installs, single-binary distributions).
+    pub replaced_sibling: Option<PathBuf>,
+    /// The tag we installed.
+    pub tag: String,
+}
+
+/// Compare a release tag against the running version. `tag` may be `v0.2.0`
+/// or `0.2.0`; both parse the same. Returns true when `tag` strictly newer.
+pub fn is_newer(tag: &str, current: &str) -> bool {
+    let strip = |s: &str| s.trim().trim_start_matches('v').to_string();
+    let lhs = match semver::Version::parse(&strip(tag)) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let rhs = match semver::Version::parse(&strip(current)) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    lhs > rhs
+}
+
+/// Query the GitHub Releases API for the latest published release and pick
+/// the asset matching this host. `current_version` is the version the running
+/// binary was built with (caller passes `env!("CARGO_PKG_VERSION")`).
+pub fn check(current_version: &str) -> Result<CheckResult> {
+    let url =
+        format!("https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/releases/latest");
+    let resp = ureq::get(&url)
+        .set("User-Agent", USER_AGENT)
+        .set("Accept", "application/vnd.github+json")
+        .timeout(std::time::Duration::from_secs(20))
+        .call()
+        .with_context(|| format!("GET {url}"))?;
+    let release: GhRelease = resp
+        .into_json()
+        .context("parse GitHub releases JSON")?;
+
+    let target = host_target()?;
+    let asset = pick_asset(&release.assets, &target)
+        .ok_or_else(|| anyhow!(
+            "no release asset matches host target `{target}` in release {}",
+            release.tag_name
+        ))?;
+
+    let info = UpdateInfo {
+        tag: release.tag_name.clone(),
+        version: release.tag_name.trim_start_matches('v').to_string(),
+        html_url: release.html_url,
+        asset_url: asset.browser_download_url.clone(),
+        asset_name: asset.name.clone(),
+        asset_size: asset.size,
+        body: release.body.unwrap_or_default(),
+    };
+    let newer = is_newer(&info.tag, current_version);
+    Ok(CheckResult { info, newer })
+}
+
+/// Wraps an [`UpdateInfo`] with a flag indicating whether the running binary
+/// is older than what the release advertises.
+#[derive(Debug, Clone)]
+pub struct CheckResult {
+    pub info: UpdateInfo,
+    /// True when [`UpdateInfo::tag`] parses to a strictly higher semver than
+    /// the version the caller passed to [`check`]. UIs gate the "Install"
+    /// button on this so users aren't tempted to "downgrade" to the current
+    /// version.
+    pub newer: bool,
+}
+
+/// Download the asset described by `info`, extract it, and replace the
+/// running binary plus any sibling MoGen binary in the same directory.
+///
+/// `on_progress` is invoked from the calling thread inline with the download
+/// and stage transitions; it's expected to be cheap (sending on an mpsc
+/// channel is the canonical use). It can be a no-op for headless callers.
+pub fn download_and_apply(
+    info: &UpdateInfo,
+    mut on_progress: impl FnMut(Progress),
+) -> Result<Applied> {
+    let current_exe =
+        std::env::current_exe().context("locate current executable")?;
+    // Canonicalise so the sibling lookup below compares apples to apples
+    // (Windows symlinked /Program Files paths in particular).
+    let current_exe = current_exe
+        .canonicalize()
+        .unwrap_or(current_exe);
+
+    on_progress(Progress::Stage("downloading".into()));
+    let tmp_dir = tempdir_for_update()?;
+    let archive_path = tmp_dir.join(&info.asset_name);
+    download_to(&info.asset_url, &archive_path, info.asset_size, |downloaded| {
+        on_progress(Progress::Download {
+            downloaded,
+            total: info.asset_size,
+        })
+    })?;
+
+    on_progress(Progress::Stage("extracting".into()));
+    let extract_dir = tmp_dir.join("extract");
+    fs::create_dir_all(&extract_dir).context("create extract dir")?;
+    archive::extract(&archive_path, &extract_dir)?;
+
+    let new_self =
+        find_binary(&extract_dir, binary_basename_for_path(&current_exe))
+            .ok_or_else(|| {
+                anyhow!(
+                    "release archive did not contain `{}`",
+                    binary_basename_for_path(&current_exe)
+                )
+            })?;
+
+    // Sibling: if we are `mogen`, look for `mogen-studio` next to us; vice
+    // versa. The CLI and Studio ship together so updating one without the
+    // other leaves the install in a half-upgraded state.
+    let sibling_basename = sibling_basename(&current_exe);
+    let sibling_on_disk = current_exe
+        .parent()
+        .map(|d| d.join(&sibling_basename))
+        .filter(|p| p.is_file());
+    let new_sibling = sibling_on_disk
+        .as_ref()
+        .and_then(|_| find_binary(&extract_dir, &sibling_basename));
+
+    on_progress(Progress::Stage("installing".into()));
+
+    // Install the sibling FIRST. It's not the running process, so a plain
+    // rename works on every platform — and if it fails we haven't touched
+    // the binary that's keeping the user's current process alive.
+    if let (Some(target), Some(source)) = (sibling_on_disk.as_ref(), new_sibling.as_ref()) {
+        replace_sibling(source, target).with_context(|| {
+            format!("replace sibling binary at {}", target.display())
+        })?;
+    }
+
+    // Replace ourselves last. `self_replace` handles the platform-specific
+    // dance: on Unix it relies on the kernel keeping the open inode alive so
+    // a plain rename works; on Windows it renames the running .exe to .old
+    // so the new file can take its place in the same directory.
+    self_replace::self_replace(&new_self).context("replace self")?;
+    // self_replace doesn't preserve mode bits on Unix when the source is a
+    // freshly-extracted file with the wrong permissions. Re-mark the
+    // installed binary executable to be safe.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = fs::metadata(&current_exe) {
+            let mut perm = meta.permissions();
+            let mode = perm.mode() | 0o755;
+            perm.set_mode(mode);
+            let _ = fs::set_permissions(&current_exe, perm);
+        }
+    }
+
+    Ok(Applied {
+        replaced_self: current_exe,
+        replaced_sibling: sibling_on_disk,
+        tag: info.tag.clone(),
+    })
+}
+
+/// Stream a remote URL into `dest`, calling `on_chunk` after each network read
+/// with the running byte total so the caller can drive a progress bar.
+fn download_to(
+    url: &str,
+    dest: &Path,
+    expected_size: u64,
+    mut on_chunk: impl FnMut(u64),
+) -> Result<()> {
+    let resp = ureq::get(url)
+        .set("User-Agent", USER_AGENT)
+        .set("Accept", "application/octet-stream")
+        .timeout(std::time::Duration::from_secs(60))
+        .call()
+        .with_context(|| format!("GET {url}"))?;
+    let mut reader = resp.into_reader();
+    let mut file = fs::File::create(dest)
+        .with_context(|| format!("create {}", dest.display()))?;
+    let mut buf = [0u8; 64 * 1024];
+    let mut total: u64 = 0;
+    loop {
+        let n = reader.read(&mut buf).context("read chunk from server")?;
+        if n == 0 {
+            break;
+        }
+        file.write_all(&buf[..n]).context("write chunk to disk")?;
+        total += n as u64;
+        on_chunk(total);
+    }
+    file.flush().ok();
+    if expected_size > 0 && total != expected_size {
+        // Not fatal — GitHub sometimes serves a slightly different
+        // content-length when assets are re-encoded — but worth surfacing
+        // when it disagrees materially. We let extraction validate the bytes.
+    }
+    Ok(())
+}
+
+/// Walk `root` for a regular file whose basename equals `name`. Releases nest
+/// the binaries one or two directories deep depending on packaging, so a
+/// shallow recursive scan keeps us robust to layout changes.
+fn find_binary(root: &Path, name: &str) -> Option<PathBuf> {
+    fn walk(dir: &Path, name: &str, out: &mut Option<PathBuf>) -> io::Result<()> {
+        if out.is_some() {
+            return Ok(());
+        }
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let ft = entry.file_type()?;
+            if ft.is_dir() {
+                walk(&path, name, out)?;
+            } else if ft.is_file()
+                && path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.eq_ignore_ascii_case(name))
+                    .unwrap_or(false)
+            {
+                *out = Some(path);
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
+    let mut found = None;
+    let _ = walk(root, name, &mut found);
+    found
+}
+
+/// Move `source` over `dest`, falling back to copy+remove when a cross-device
+/// rename fails (the temp dir may live on a different filesystem than the
+/// install root). Used for the sibling binary; the running binary uses
+/// `self_replace::self_replace` instead.
+fn replace_sibling(source: &Path, dest: &Path) -> Result<()> {
+    // Try a rename first — atomic when source and dest are on the same fs.
+    if fs::rename(source, dest).is_ok() {
+        #[cfg(unix)]
+        ensure_executable(dest);
+        return Ok(());
+    }
+    // Cross-device fallback: copy with a `.new` suffix, then atomic rename
+    // over the destination so we never leave a half-written binary visible.
+    let staging = dest.with_extension("mogen-update.new");
+    fs::copy(source, &staging)
+        .with_context(|| format!("copy to staging {}", staging.display()))?;
+    #[cfg(unix)]
+    ensure_executable(&staging);
+    fs::rename(&staging, dest)
+        .with_context(|| format!("rename staging onto {}", dest.display()))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn ensure_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(meta) = fs::metadata(path) {
+        let mut perm = meta.permissions();
+        let mode = perm.mode() | 0o755;
+        perm.set_mode(mode);
+        let _ = fs::set_permissions(path, perm);
+    }
+}
+
+/// Returns the basename a current binary should be matched against in the
+/// extracted archive, preserving the platform-specific `.exe` suffix on
+/// Windows.
+fn binary_basename_for_path(path: &Path) -> &str {
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("mogen")
+}
+
+/// Compute the basename of the *other* MoGen binary that should be replaced
+/// alongside the running one. CLI ↔ Studio.
+fn sibling_basename(current_exe: &Path) -> String {
+    // We can't rely on `Path::file_name` here in cross-platform tests:
+    // a Windows-style path passed to a Linux build won't see `\` as a
+    // separator. Strip both separators manually so the same code matches
+    // `/usr/bin/mogen` and `C:\bin\mogen.exe` regardless of host OS.
+    let name = binary_basename_for_path(current_exe);
+    let trimmed: &str = name
+        .rsplit(|c| c == '/' || c == '\\')
+        .next()
+        .unwrap_or(name);
+    let (stem, ext) = match trimmed.rsplit_once('.') {
+        Some((s, "exe")) => (s, ".exe"),
+        _ => (trimmed, ""),
+    };
+    let other = if stem == "mogen-studio" {
+        "mogen"
+    } else {
+        // Default: assume CLI, sibling is Studio. Covers `mogen` and any
+        // unexpected name (better to try and miss than to silently skip).
+        "mogen-studio"
+    };
+    format!("{other}{ext}")
+}
+
+/// Detect the Rust target triple this binary was built for. The release
+/// archives embed the triple in their filename, so this is what we match
+/// against in [`pick_asset`].
+fn host_target() -> Result<&'static str> {
+    // Compile-time selection is the only way to know the triple — there's no
+    // standard runtime API. The list mirrors the `release.yml` matrix.
+    #[cfg(all(target_os = "linux", target_arch = "x86_64", target_env = "gnu"))]
+    return Ok("x86_64-unknown-linux-gnu");
+    #[cfg(all(target_os = "linux", target_arch = "aarch64", target_env = "gnu"))]
+    return Ok("aarch64-unknown-linux-gnu");
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    return Ok("x86_64-apple-darwin");
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    return Ok("aarch64-apple-darwin");
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    return Ok("x86_64-pc-windows-msvc");
+    #[allow(unreachable_code)]
+    {
+        bail!("auto-update is not supported on this host")
+    }
+}
+
+/// Choose the asset whose name embeds `target` and whose extension matches
+/// what the extractor knows how to handle on this platform. `.tar.gz` and
+/// `.tgz` are accepted on Unix; `.zip` on Windows.
+fn pick_asset<'a>(assets: &'a [GhAsset], target: &str) -> Option<&'a GhAsset> {
+    let prefer_zip = cfg!(windows);
+    assets.iter().find(|a| {
+        if !a.name.contains(target) {
+            return false;
+        }
+        let lname = a.name.to_ascii_lowercase();
+        if prefer_zip {
+            lname.ends_with(".zip")
+        } else {
+            lname.ends_with(".tar.gz") || lname.ends_with(".tgz")
+        }
+    })
+}
+
+/// Make a fresh per-process temp directory under the system tempdir. Avoids
+/// pulling in the `tempfile` crate — we just need a unique name, and we own
+/// the cleanup window.
+fn tempdir_for_update() -> Result<PathBuf> {
+    let base = std::env::temp_dir();
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    let dir = base.join(format!("mogen-update-{pid}-{nanos}"));
+    fs::create_dir_all(&dir)
+        .with_context(|| format!("create temp dir {}", dir.display()))?;
+    Ok(dir)
+}
+
+// --- GitHub release wire types --------------------------------------------
+
+#[derive(Deserialize, Debug)]
+struct GhRelease {
+    tag_name: String,
+    html_url: String,
+    body: Option<String>,
+    assets: Vec<GhAsset>,
+}
+
+#[derive(Deserialize, Debug)]
+struct GhAsset {
+    name: String,
+    size: u64,
+    browser_download_url: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn newer_strips_v_prefix() {
+        assert!(is_newer("v0.2.0", "0.1.0"));
+        assert!(is_newer("0.2.0", "v0.1.0"));
+        assert!(!is_newer("v0.1.0", "0.1.0"));
+        assert!(!is_newer("v0.1.0", "0.2.0"));
+    }
+
+    #[test]
+    fn newer_rejects_garbage() {
+        assert!(!is_newer("not-a-version", "0.1.0"));
+        assert!(!is_newer("v0.1.0", "not-a-version"));
+    }
+
+    #[test]
+    fn pick_asset_prefers_format_per_os() {
+        let assets = vec![
+            GhAsset {
+                name: "mogen-v0.2.0-x86_64-unknown-linux-gnu.tar.gz".into(),
+                size: 1,
+                browser_download_url: "u1".into(),
+            },
+            GhAsset {
+                name: "mogen-v0.2.0-x86_64-pc-windows-msvc.zip".into(),
+                size: 1,
+                browser_download_url: "u2".into(),
+            },
+        ];
+        let triple = if cfg!(windows) {
+            "x86_64-pc-windows-msvc"
+        } else {
+            "x86_64-unknown-linux-gnu"
+        };
+        let pick = pick_asset(&assets, triple).expect("asset");
+        assert!(pick.name.contains(triple));
+    }
+
+    #[test]
+    fn sibling_swap() {
+        assert_eq!(sibling_basename(Path::new("/usr/bin/mogen")), "mogen-studio");
+        assert_eq!(sibling_basename(Path::new("/x/mogen-studio")), "mogen");
+        assert_eq!(
+            sibling_basename(Path::new(r"C:\bin\mogen.exe")),
+            "mogen-studio.exe"
+        );
+        assert_eq!(
+            sibling_basename(Path::new(r"C:\bin\mogen-studio.exe")),
+            "mogen.exe"
+        );
+    }
+}

--- a/crates/mogen/Cargo.toml
+++ b/crates/mogen/Cargo.toml
@@ -15,6 +15,7 @@ mogen-dsl = { workspace = true, features = ["csg"] }
 mogen-validate = { workspace = true, features = ["csg"] }
 mogen-export = { workspace = true, features = ["textures", "merge"] }
 mogen-llm = { workspace = true }
+mogen-update = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/mogen/src/commands/mod.rs
+++ b/crates/mogen/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub(crate) mod inspect;
 pub(crate) mod modify;
 pub(crate) mod repair;
 pub(crate) mod textures;
+pub(crate) mod update;

--- a/crates/mogen/src/commands/update.rs
+++ b/crates/mogen/src/commands/update.rs
@@ -1,0 +1,105 @@
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Result};
+use indicatif::{ProgressBar, ProgressStyle};
+
+use mogen_update::{check, download_and_apply, Progress};
+
+pub(crate) struct UpdateArgs {
+    /// Don't prompt — install the latest release if it's newer than the
+    /// running binary. Off prints what would happen and exits successfully
+    /// without writing anything.
+    pub(crate) yes: bool,
+    /// Just print the latest release tag and exit. Skips the download.
+    pub(crate) check_only: bool,
+    /// Re-download and reinstall even if the running binary already matches
+    /// the latest release. Useful for repairing a botched install.
+    pub(crate) force: bool,
+}
+
+pub(crate) fn update(args: UpdateArgs) -> Result<()> {
+    let current = env!("CARGO_PKG_VERSION");
+    println!("mogen {current}");
+    println!("checking for updates from github.com/{}/{}…",
+        mogen_update::REPO_OWNER, mogen_update::REPO_NAME);
+
+    let result = check(current).map_err(|e| {
+        anyhow!("update check failed: {e:#}")
+    })?;
+    let info = &result.info;
+    println!("latest release: {} ({} bytes)", info.tag, info.asset_size);
+    if !info.html_url.is_empty() {
+        println!("release page: {}", info.html_url);
+    }
+
+    if args.check_only {
+        if result.newer {
+            println!(
+                "an update is available: {current} -> {}. Run `mogen update --yes` to install.",
+                info.version
+            );
+        } else {
+            println!("you are up to date.");
+        }
+        return Ok(());
+    }
+
+    if !result.newer && !args.force {
+        println!("already running the latest version ({current}). Pass --force to reinstall.");
+        return Ok(());
+    }
+
+    if !args.yes {
+        println!(
+            "an update is available: {current} -> {}. Re-run with --yes to install \
+             (`mogen update --yes`).",
+            info.version
+        );
+        return Ok(());
+    }
+
+    let total = info.asset_size.max(1);
+    let pb = ProgressBar::new(total);
+    pb.set_style(
+        ProgressStyle::with_template(
+            "{spinner:.cyan.bold} [{elapsed:>3}] {msg:>14} {bar:30.cyan/blue} {bytes}/{total_bytes} ({eta})",
+        )
+        .expect("static template")
+        .progress_chars("=> "),
+    );
+    pb.enable_steady_tick(Duration::from_millis(120));
+    pb.set_message("downloading");
+    let started = Instant::now();
+    let pb_for_cb = pb.clone();
+    let outcome = download_and_apply(info, move |evt| match evt {
+        Progress::Stage(label) => {
+            pb_for_cb.set_message(label);
+        }
+        Progress::Download { downloaded, total } => {
+            // GitHub sometimes reports a different content-length than the
+            // asset record, so cap the bar at its declared length.
+            pb_for_cb.set_position(downloaded.min(total.max(1)));
+        }
+    });
+    match outcome {
+        Ok(applied) => {
+            pb.finish_with_message("installed");
+            let elapsed = started.elapsed();
+            println!(
+                "updated to {} in {:.1}s.",
+                applied.tag,
+                elapsed.as_secs_f32()
+            );
+            println!("replaced: {}", applied.replaced_self.display());
+            if let Some(s) = applied.replaced_sibling {
+                println!("replaced: {}", s.display());
+            }
+            println!("restart `mogen` (and `mogen-studio`) to pick up the new version.");
+            Ok(())
+        }
+        Err(e) => {
+            pb.abandon_with_message("failed");
+            Err(anyhow!("update failed: {e:#}"))
+        }
+    }
+}

--- a/crates/mogen/src/main.rs
+++ b/crates/mogen/src/main.rs
@@ -17,6 +17,7 @@ use commands::inspect::{check, dump_scene, inspect, parse_cmd};
 use commands::modify::{modify, ModifyArgs};
 use commands::repair::{repair, RepairArgs};
 use commands::textures::textures_cmd;
+use commands::update::{update, UpdateArgs};
 
 /// CLI-facing mirror of [`ThinkingLevel`]. Kept separate so we don't leak
 /// `clap::ValueEnum` into the `mogen-llm` library crate.
@@ -376,6 +377,23 @@ enum Cmd {
         #[arg(long, default_value_t = mogen_llm::textures::DEFAULT_TEXTURE_SIZE)]
         texture_size: u32,
     },
+    /// Download the latest release from GitHub and replace the running
+    /// `mogen` (and sibling `mogen-studio`) binary in place. By default this
+    /// only checks for an update and prints what it would do — pass `--yes`
+    /// to actually install. Updates are matched against the host's target
+    /// triple from the assets uploaded by the project's release workflow.
+    Update {
+        /// Install the update without prompting.
+        #[arg(long)]
+        yes: bool,
+        /// Print the latest release tag and exit without downloading anything.
+        #[arg(long)]
+        check: bool,
+        /// Reinstall the latest release even if the running binary already
+        /// matches it. Useful for repairing a corrupted install.
+        #[arg(long)]
+        force: bool,
+    },
     /// Run a suite of prompts through `generate` and report success rate and
     /// mean token cost. Does not write GLBs.
     Bench {
@@ -578,6 +596,11 @@ fn main() -> ExitCode {
             no_metallic_roughness,
             no_occlusion,
             texture_size,
+        }),
+        Cmd::Update { yes, check, force } => update(UpdateArgs {
+            yes,
+            check_only: check,
+            force,
         }),
         Cmd::Bench {
             prompts,


### PR DESCRIPTION
New `mogen-update` crate fetches the latest release from
github.com/krazyjakee/MoGen, picks the archive matching the host triple
emitted by the release workflow, extracts both bundled binaries, and
swaps them in place via self_replace.

- CLI: `mogen update [--check|--yes|--force]` with a streaming
  indicatif progress bar.
- Studio: Help -> Check for Updates... modal with a worker-thread state
  machine mirroring the existing build pipeline. Channel-based progress
  feeds a download bar; the install worker is allowed to outlive the
  modal so a mid-update close doesn't leave the binary half-written.