### PR TITLE
Add in-app documentation and editor Ctrl+click navigation

### DIFF
--- a/crates/mogen-studio/src/app.rs
+++ b/crates/mogen-studio/src/app.rs
@@ -17,6 +17,7 @@ mod autocomplete;
 mod build;
 mod compile;
 mod crash_consent;
+mod editor_link;
 mod error_class;
 mod file_picker;
 mod files;
@@ -32,6 +33,7 @@ mod text_menu;
 mod thumbnail;
 mod types;
 mod ui_dialogs;
+mod ui_docs;
 mod ui_llm;
 mod ui_menu;
 mod ui_panels;
@@ -42,7 +44,7 @@ mod viewport_menu;
 mod watcher;
 
 use self::types::{
-    viewer_bg_color, AskInFlight, AutocompleteState, BuildOutcome, EnhanceInFlight,
+    viewer_bg_color, AskInFlight, AutocompleteState, BuildOutcome, DocsState, EnhanceInFlight,
     EnhanceTarget, ExternalConflict, FileState, FindState, GenImageInput, SessionUsage,
     SpotlightState, ThumbCache,
 };
@@ -184,6 +186,15 @@ pub struct MogenStudioApp {
     /// (or the user closed the dialog while idle); a `Some(_)` survives modal
     /// closes when an install is in flight so the worker isn't orphaned.
     update_state: Option<self::update::UpdateState>,
+
+    /// Help → Documentation window visibility. Toggled by F1 / the Help
+    /// menu / a Ctrl+click on a keyword in the editor. The window is
+    /// non-modal so users can keep editing while reading docs side-by-side.
+    show_docs: bool,
+    /// Persistent docs viewer state — current page, pending scroll target,
+    /// navigation history, sidebar filter. Survives close/reopen so the
+    /// user lands back where they left off.
+    docs: DocsState,
 
     /// "Build GLB" modal visibility. Also acts as the ui gate on the export
     /// toggles while a build is in flight — the worker writes status through
@@ -432,6 +443,8 @@ impl MogenStudioApp {
             show_about: false,
             show_update: false,
             update_state: None,
+            show_docs: false,
+            docs: DocsState::default(),
             show_export: false,
             export_opts_draft: ExportOptions::default(),
             build_rx: None,
@@ -834,6 +847,7 @@ impl eframe::App for MogenStudioApp {
         self.ui_external_conflict(ctx);
         self.ui_about(ctx);
         self.ui_update_dialog(ctx);
+        self.ui_docs(ctx);
         self.ui_ask(ctx);
         self.ui_spotlight(ctx);
         self.ui_video_options(ctx);

--- a/crates/mogen-studio/src/app/editor_link.rs
+++ b/crates/mogen-studio/src/app/editor_link.rs
@@ -1,0 +1,205 @@
+//! Ctrl+click navigation in the code editor.
+//!
+//! Hooks called from `ui_editor` after the TextEdit has rendered:
+//!
+//! - [`MogenStudioApp::handle_editor_link_click`] — performs hit-testing,
+//!   updates the cursor icon while Ctrl is held, and dispatches the action
+//!   on click. Returns `true` when a click was consumed so the caller can
+//!   skip the normal caret-move side-effects.
+//! - [`MogenStudioApp::open_link_target`] — apply a [`LinkTarget`] (open
+//!   URL, open file, jump caret to local module declaration, scroll docs
+//!   window). Pulled out of the click handler so the inspector can reuse it
+//!   later if we want to surface the same actions through a context menu.
+//!
+//! The token resolver itself lives in `crate::docs` so the navigation logic
+//! is testable without an egui context.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use eframe::egui;
+
+use crate::docs::{self, LinkHit, LinkTarget};
+
+use super::MogenStudioApp;
+
+impl MogenStudioApp {
+    /// One-shot Ctrl+click handler driven from `ui_editor`. Resolves the
+    /// click position to a token, pulls the right [`LinkTarget`] from
+    /// `crate::docs`, and dispatches it. Returns `true` when the event was
+    /// consumed (so `changed = true` doesn't get spuriously set later).
+    ///
+    /// Also paints the cursor as `PointingHand` whenever the user hovers a
+    /// resolvable token with Ctrl held — matches every IDE's affordance for
+    /// "this is a link, click to follow".
+    pub(super) fn handle_editor_link_click(
+        &mut self,
+        ui: &egui::Ui,
+        output: &egui::widgets::text_edit::TextEditOutput,
+    ) -> bool {
+        let resp = &output.response;
+        let Some(hover_pos) = ui.input(|i| i.pointer.hover_pos()) else {
+            return false;
+        };
+        if !resp.rect.contains(hover_pos) {
+            return false;
+        }
+
+        // Modifiers: prefer `command` (works on macOS via Cmd) but also
+        // accept raw Ctrl on every platform — same convention the viewport
+        // already uses for its modifier checks.
+        let ctrl = ui.input(|i| i.modifiers.ctrl || i.modifiers.command);
+        if !ctrl {
+            return false;
+        }
+
+        // Hit-test inside the galley to map the screen position to a byte
+        // offset in the source. egui's CCursor is a char index; convert it
+        // back to bytes so the docs resolver can slice the source directly.
+        let local = hover_pos - output.galley_pos;
+        let cursor = output.galley.cursor_from_pos(local);
+        let char_idx = cursor.ccursor.index;
+        let i = self.active;
+        let source = &self.files[i].source;
+        let byte_off = char_to_byte_offset(source, char_idx);
+
+        let Some(hit) = docs::resolve_link_at(source, byte_off) else {
+            return false;
+        };
+
+        // Ctrl is held over a resolvable token — show the link affordance.
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+
+        // Only dispatch on the actual press; hovering with Ctrl held just
+        // changes the cursor.
+        let pressed = ui.input(|i| i.pointer.primary_pressed());
+        if !pressed {
+            return false;
+        }
+
+        self.open_link_target(ui.ctx(), hit);
+        true
+    }
+
+    /// Apply a resolved [`LinkHit`]. Split out so the click handler stays
+    /// thin and so we can dispatch the same action from a future right-
+    /// click "Go to definition" menu item without duplicating the routing.
+    pub(super) fn open_link_target(&mut self, ctx: &egui::Context, hit: LinkHit) {
+        let i = self.active;
+        match hit.target {
+            LinkTarget::Url(url) => {
+                ctx.open_url(egui::OpenUrl::new_tab(url.clone()));
+                self.files[i].status = format!("opened {url}");
+            }
+            LinkTarget::File(rel) => {
+                let resolved = self.resolve_link_path(&rel);
+                let is_mog = resolved
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .map(|e| e.eq_ignore_ascii_case("mog"))
+                    .unwrap_or(false);
+                if is_mog {
+                    if resolved.is_file() {
+                        self.open_path(&resolved);
+                    } else {
+                        self.files[i].status =
+                            format!("can't open {} — file not found", resolved.display());
+                    }
+                } else if resolved.exists() {
+                    match open_in_os(&resolved) {
+                        Ok(()) => {
+                            self.files[i].status = format!("opened {}", resolved.display());
+                        }
+                        Err(e) => {
+                            self.files[i].status =
+                                format!("open failed: {} ({e})", resolved.display());
+                        }
+                    }
+                } else {
+                    self.files[i].status =
+                        format!("can't open {} — file not found", resolved.display());
+                }
+            }
+            LinkTarget::Module(name) => {
+                // Prefer jumping to the local declaration when one exists;
+                // fall back to the stdlib docs page so a Ctrl+click on
+                // `use "leg"` always lands somewhere useful.
+                let src = &self.files[i].source;
+                if let Some(decl_off) = docs::find_module_decl(src, &name) {
+                    self.files[i].pending_caret = Some(decl_off);
+                    self.files[i].status = format!("jump → module \"{name}\"");
+                } else if docs::STDLIB_MODULE_NAMES.contains(&name.as_str()) {
+                    self.open_docs_at("modules", Some(docs::heading_slug(&name)));
+                    self.files[i].status =
+                        format!("docs → modules.md#{name} (stdlib module)");
+                } else {
+                    self.files[i].status =
+                        format!("no `module \"{name}\"` declaration in this file");
+                }
+            }
+            LinkTarget::Docs(anchor) => {
+                let page = anchor.page;
+                let slug = anchor.slug.clone();
+                self.open_docs_at(page, slug.clone());
+                self.files[i].status = match slug {
+                    Some(s) => format!("docs → {page}.md#{s}"),
+                    None => format!("docs → {page}.md"),
+                };
+            }
+        }
+    }
+
+    /// Resolve a path string from the source against the active file's
+    /// directory. Absolute paths win as-is; relative paths are joined with
+    /// the directory of the .mog file (or the project root when the file
+    /// is untitled).
+    fn resolve_link_path(&self, raw: &str) -> PathBuf {
+        let p = PathBuf::from(raw);
+        if p.is_absolute() {
+            return p;
+        }
+        let base = self.files[self.active]
+            .path
+            .as_deref()
+            .and_then(|p| p.parent())
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| self.project_root.clone());
+        base.join(p)
+    }
+}
+
+/// Convert a character index into a byte offset in `s`. egui's hit-testing
+/// returns char positions but the docs resolver needs to slice into bytes,
+/// so this bridges the two. Saturates at the end of the string when the
+/// caller asks for an index past the last char.
+fn char_to_byte_offset(s: &str, char_idx: usize) -> usize {
+    s.char_indices()
+        .nth(char_idx)
+        .map(|(b, _)| b)
+        .unwrap_or(s.len())
+}
+
+/// Hand a path off to the OS so its default app opens it. Used for non-mog
+/// files referenced from materials (PNG textures, exported .glb assets,
+/// etc.). MoGen doesn't ship with image / model viewers, so delegating is
+/// the only sensible thing to do.
+fn open_in_os(path: &std::path::Path) -> std::io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        Command::new("open").arg(path).status().map(|_| ())
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // `cmd /C start "" path` keeps the title argument quoted so paths
+        // with spaces aren't misinterpreted as the window title.
+        Command::new("cmd")
+            .args(["/C", "start", ""])
+            .arg(path)
+            .status()
+            .map(|_| ())
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        Command::new("xdg-open").arg(path).status().map(|_| ())
+    }
+}

--- a/crates/mogen-studio/src/app/types.rs
+++ b/crates/mogen-studio/src/app/types.rs
@@ -307,6 +307,7 @@ pub(super) enum MenuAction {
     /// VS Code–style line / selection ops dispatched against the active
     /// editor. The same handlers fire from the keyboard in `line_ops.rs`.
     EditorLineOp(super::line_ops::LineOp),
+    OpenDocs,
 }
 
 /// The subset of `MenuAction` variants that are bound to a global keyboard
@@ -327,6 +328,7 @@ pub(super) enum ShortcutAction {
     Quit,
     OpenOptions,
     Frame,
+    OpenDocs,
 }
 
 impl ShortcutAction {
@@ -350,6 +352,9 @@ impl ShortcutAction {
             ShortcutAction::Quit => KeyboardShortcut::new(cmd, Key::Q),
             ShortcutAction::OpenOptions => KeyboardShortcut::new(cmd, Key::Comma),
             ShortcutAction::Frame => KeyboardShortcut::new(cmd, Key::Num0),
+            // F1 mirrors the convention of every JetBrains / VS Code IDE —
+            // unmodified F-row key, opens contextual help.
+            ShortcutAction::OpenDocs => KeyboardShortcut::new(Modifiers::NONE, Key::F1),
         }
     }
 
@@ -368,6 +373,7 @@ impl ShortcutAction {
             ShortcutAction::Quit => MenuAction::Quit,
             ShortcutAction::OpenOptions => MenuAction::OpenOptions,
             ShortcutAction::Frame => MenuAction::Frame,
+            ShortcutAction::OpenDocs => MenuAction::OpenDocs,
         }
     }
 
@@ -393,6 +399,7 @@ impl ShortcutAction {
         ShortcutAction::Quit,
         ShortcutAction::OpenOptions,
         ShortcutAction::Frame,
+        ShortcutAction::OpenDocs,
     ];
 }
 
@@ -618,6 +625,27 @@ pub(super) struct SpotlightState {
     /// Latched on open; cleared after focus is requested on the input. Same
     /// pattern as the find bar / Ask modal.
     pub(super) focus_pending: bool,
+}
+
+/// Documentation window state. The docs viewer is a single-instance modal
+/// that the user opens from Help → Documentation, F1, or a Ctrl+click on a
+/// keyword in the editor. State persists across opens so flipping between
+/// the editor and the docs window doesn't reset the user's place.
+#[derive(Default)]
+pub(super) struct DocsState {
+    /// Currently displayed page id (`"dsl"`, `"modules"`, `"cli"`,
+    /// `"studio"`). Empty until the window is opened for the first time;
+    /// `ui_docs` initialises to the DSL page on first paint.
+    pub(super) page_id: String,
+    /// Slug to scroll to on the next paint. Populated by Ctrl+click and by
+    /// sidebar outline clicks; cleared by the renderer once it has scrolled.
+    pub(super) pending_scroll: Option<String>,
+    /// Previously viewed (page, slug) pairs. Drives the Back button so users
+    /// can step out of a Ctrl+click jump.
+    pub(super) history: Vec<(String, Option<String>)>,
+    /// Substring filter applied to the section outline in the sidebar so
+    /// users can narrow long pages (the DSL page has 30+ headings).
+    pub(super) outline_filter: String,
 }
 
 /// Per-file state. Every open `.mog` owns its own buffer, compile result,

--- a/crates/mogen-studio/src/app/ui_docs.rs
+++ b/crates/mogen-studio/src/app/ui_docs.rs
@@ -1,0 +1,242 @@
+use eframe::egui;
+
+use crate::docs::{self, DOC_PAGES};
+
+use super::types::{DocsState, GITHUB_REPO_URL};
+use super::MogenStudioApp;
+
+impl MogenStudioApp {
+    /// Open the Documentation window on a specific page + section. Used by
+    /// Ctrl+click in the editor to land on the relevant heading. The window
+    /// is non-modal — opening it doesn't steal focus from the editor.
+    pub(super) fn open_docs_at(&mut self, page: &str, slug: Option<String>) {
+        // Push the previous spot onto the back-stack so the Back button can
+        // step out of a Ctrl+click jump. Skip the push when the page hasn't
+        // been initialised yet (first open) or when the destination matches
+        // the current view (avoids no-op history entries).
+        let dest_page = page.to_string();
+        if !self.docs.page_id.is_empty()
+            && (self.docs.page_id != dest_page || self.docs.pending_scroll != slug)
+        {
+            self.docs
+                .history
+                .push((self.docs.page_id.clone(), self.docs.pending_scroll.clone()));
+            // Cap so a long browse session doesn't grow unbounded.
+            const MAX_HIST: usize = 32;
+            let len = self.docs.history.len();
+            if len > MAX_HIST {
+                self.docs.history.drain(0..len - MAX_HIST);
+            }
+        }
+        self.docs.page_id = dest_page;
+        self.docs.pending_scroll = slug;
+        self.show_docs = true;
+    }
+
+    /// Open the Documentation window without changing the current page.
+    /// First-time opens default to the DSL reference (the page users hit
+    /// most often).
+    pub(super) fn open_docs_home(&mut self) {
+        if self.docs.page_id.is_empty() {
+            self.docs.page_id = "dsl".to_string();
+        }
+        self.show_docs = true;
+    }
+
+    pub(super) fn ui_docs(&mut self, ctx: &egui::Context) {
+        if !self.show_docs {
+            return;
+        }
+        // First open: default to the DSL page so the window has something
+        // sensible to render.
+        if self.docs.page_id.is_empty() {
+            self.docs.page_id = "dsl".to_string();
+        }
+
+        let mut open = true;
+        // Draft fields written by the inner closures so we can apply them
+        // after the borrow on `self.docs` ends — the navigation buttons need
+        // mutable access to the same struct.
+        let mut nav_to: Option<(String, Option<String>)> = None;
+        let mut go_back = false;
+        let mut filter_draft = self.docs.outline_filter.clone();
+
+        let page = docs::page_by_id(&self.docs.page_id)
+            .copied()
+            .unwrap_or(DOC_PAGES[0]);
+        let outline = docs::page_outline(&page);
+        let pending_scroll = self.docs.pending_scroll.clone();
+        let history_depth = self.docs.history.len();
+        let current_page_id = self.docs.page_id.clone();
+
+        egui::Window::new("Documentation")
+            .id(egui::Id::new("docs_window"))
+            .open(&mut open)
+            .resizable(true)
+            .collapsible(true)
+            .default_width(820.0)
+            .default_height(620.0)
+            .min_width(520.0)
+            .min_height(360.0)
+            .show(ctx, |ui| {
+                // Top toolbar — page tabs + Back + outline filter.
+                ui.horizontal(|ui| {
+                    let back_enabled = history_depth > 0;
+                    if ui
+                        .add_enabled(back_enabled, egui::Button::new("◀ Back"))
+                        .on_hover_text(if back_enabled {
+                            "Return to the previous page / section"
+                        } else {
+                            "(no history yet)"
+                        })
+                        .clicked()
+                    {
+                        go_back = true;
+                    }
+                    ui.separator();
+                    for p in DOC_PAGES {
+                        let selected = p.id == current_page_id;
+                        if ui
+                            .selectable_label(selected, p.title)
+                            .on_hover_text(p.subtitle)
+                            .clicked()
+                            && !selected
+                        {
+                            nav_to = Some((p.id.to_string(), None));
+                        }
+                    }
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        ui.hyperlink_to("View on GitHub", GITHUB_REPO_URL)
+                            .on_hover_text(
+                                "Open the canonical rendered docs on GitHub. Useful when \
+                                 you want to share a link or follow off-tree references.",
+                            );
+                    });
+                });
+                ui.add_space(4.0);
+                ui.separator();
+
+                // Body: outline sidebar + scrollable content.
+                let avail = ui.available_size();
+                ui.horizontal_top(|ui| {
+                    let sidebar_width = (avail.x * 0.28).clamp(180.0, 280.0);
+                    ui.allocate_ui_with_layout(
+                        egui::vec2(sidebar_width, avail.y),
+                        egui::Layout::top_down(egui::Align::Min),
+                        |ui| {
+                            ui.label(
+                                egui::RichText::new(format!("{} — outline", page.title))
+                                    .small()
+                                    .weak(),
+                            );
+                            ui.add(
+                                egui::TextEdit::singleline(&mut filter_draft)
+                                    .hint_text("filter sections")
+                                    .desired_width(f32::INFINITY),
+                            );
+                            ui.add_space(4.0);
+                            egui::ScrollArea::vertical()
+                                .id_salt("docs_outline_scroll")
+                                .auto_shrink([false, false])
+                                .show(ui, |ui| {
+                                    let needle = filter_draft.trim().to_ascii_lowercase();
+                                    for entry in &outline {
+                                        if !needle.is_empty()
+                                            && !entry
+                                                .title
+                                                .to_ascii_lowercase()
+                                                .contains(&needle)
+                                        {
+                                            continue;
+                                        }
+                                        let indent = match entry.level {
+                                            2 => 0.0,
+                                            3 => 12.0,
+                                            _ => 24.0,
+                                        };
+                                        ui.horizontal(|ui| {
+                                            ui.add_space(indent);
+                                            let selected = pending_scroll
+                                                .as_deref()
+                                                == Some(entry.slug.as_str());
+                                            let label = egui::RichText::new(&entry.title);
+                                            let label = if entry.level == 2 {
+                                                label.strong()
+                                            } else {
+                                                label
+                                            };
+                                            if ui
+                                                .selectable_label(selected, label)
+                                                .clicked()
+                                            {
+                                                nav_to = Some((
+                                                    page.id.to_string(),
+                                                    Some(entry.slug.clone()),
+                                                ));
+                                            }
+                                        });
+                                    }
+                                });
+                        },
+                    );
+
+                    ui.separator();
+
+                    // Right pane: rendered markdown.
+                    ui.allocate_ui_with_layout(
+                        egui::vec2(avail.x - sidebar_width - 12.0, avail.y),
+                        egui::Layout::top_down(egui::Align::Min),
+                        |ui| {
+                            ui.label(
+                                egui::RichText::new(page.subtitle).small().weak(),
+                            );
+                            ui.add_space(4.0);
+                            egui::ScrollArea::vertical()
+                                .id_salt(("docs_body_scroll", page.id))
+                                .auto_shrink([false, false])
+                                .show(ui, |ui| {
+                                    docs::render_markdown(
+                                        ui,
+                                        page.source,
+                                        pending_scroll.as_deref(),
+                                    );
+                                });
+                        },
+                    );
+                });
+            });
+
+        // Apply deferred state mutations now that the immutable borrow on
+        // `self.docs` has ended.
+        self.docs.outline_filter = filter_draft;
+        if go_back {
+            if let Some((page_id, slug)) = self.docs.history.pop() {
+                self.docs.page_id = page_id;
+                self.docs.pending_scroll = slug;
+            }
+        } else if let Some((page_id, slug)) = nav_to {
+            // Push the current spot onto the history before jumping so Back
+            // returns the user to where they clicked from.
+            self.docs
+                .history
+                .push((self.docs.page_id.clone(), self.docs.pending_scroll.clone()));
+            self.docs.page_id = page_id;
+            self.docs.pending_scroll = slug;
+        } else {
+            // Renderer scrolls on the first paint after a pending_scroll is
+            // set. Clear it here so the next paint doesn't keep yanking the
+            // viewport back to the top of the section as the user scrolls.
+            self.docs.pending_scroll = None;
+        }
+
+        if !open {
+            self.show_docs = false;
+        }
+    }
+}
+
+/// Compile-time check: `DocsState` must remain Default-constructible so the
+/// app initialiser can spawn one without parameters. Kept as an associated
+/// const so the compiler emits the error against this file rather than the
+/// app struct's initialiser line.
+const _: fn() -> DocsState = DocsState::default;

--- a/crates/mogen-studio/src/app/ui_menu.rs
+++ b/crates/mogen-studio/src/app/ui_menu.rs
@@ -516,8 +516,20 @@ impl MogenStudioApp {
             }
 
             ui.menu_button("Help", |ui| {
+                if shortcut_menu_item(
+                    ui,
+                    "Documentation",
+                    ShortcutAction::OpenDocs,
+                    "Open the bundled DSL / modules / studio / CLI reference",
+                )
+                .clicked()
+                {
+                    action = MenuAction::OpenDocs;
+                    ui.close_menu();
+                }
+                ui.separator();
                 ui.hyperlink_to("GitHub repository", GITHUB_REPO_URL);
-                ui.hyperlink_to("Documentation", DOCS_URL);
+                ui.hyperlink_to("Documentation on GitHub", DOCS_URL);
                 ui.hyperlink_to("License (MIT)", LICENSE_URL);
                 ui.separator();
                 if ui
@@ -649,6 +661,9 @@ impl MogenStudioApp {
                     self.files[i].last_edit_at = Some(std::time::Instant::now());
                     self.break_undo_chain(i);
                 }
+            }
+            MenuAction::OpenDocs => {
+                self.open_docs_home();
             }
         }
     }

--- a/crates/mogen-studio/src/app/ui_panels/editor.rs
+++ b/crates/mogen-studio/src/app/ui_panels/editor.rs
@@ -198,6 +198,16 @@ impl MogenStudioApp {
                         }
                     }
 
+                    // Ctrl+click navigation: jumps to imported module
+                    // declarations, opens URLs / referenced files, or
+                    // scrolls the in-app docs window to the matching
+                    // section. Dispatched here so we run while the click is
+                    // still in-flight and can paint the link cursor on
+                    // hover.
+                    if !generating {
+                        let _ = self.handle_editor_link_click(ui, &output);
+                    }
+
                     // Paint find-match overlays + drive scroll-to-match. Both
                     // need to happen inside this ScrollArea closure so the
                     // overlay scrolls with the text and `scroll_to_rect`

--- a/crates/mogen-studio/src/docs.rs
+++ b/crates/mogen-studio/src/docs.rs
@@ -1,0 +1,1009 @@
+//! In-app documentation for MoGen Studio.
+//!
+//! Bundles the four reference markdown files (`docs/dsl.md`, `docs/modules.md`,
+//! `docs/cli.md`, `docs/studio.md`) directly into the binary at compile time
+//! and exposes:
+//!
+//! - [`DocPage`] / [`DOC_PAGES`] — the embedded sources, in display order.
+//! - [`DocAnchor`] — `(page, slug)` pair pointing at a single section.
+//! - [`page_outline`] — section index for a page (extracted on demand from
+//!   the markdown's `##` / `###` headings).
+//! - [`lookup_topic`] — maps an editor token (`box`, `material`, `mirror`,
+//!   `use`, a stdlib module name, …) to the docs section that documents it.
+//!   Powers Ctrl+click on a keyword.
+//! - [`render_markdown`] — minimal egui markdown renderer (headings, code
+//!   fences, inline backticks, bullet lists, paragraphs). Deliberately tiny:
+//!   we control the source so we don't need to handle every CommonMark
+//!   construct.
+
+use eframe::egui;
+
+/// One bundled markdown reference file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DocPage {
+    /// Stable slug used in URLs and as the page id in the docs window's
+    /// sidebar. Lower-case, no extension (`"dsl"`, `"modules"`, `"cli"`,
+    /// `"studio"`).
+    pub id: &'static str,
+    /// Friendly title shown in the sidebar tab.
+    pub title: &'static str,
+    /// One-line subtitle shown under the title in the sidebar.
+    pub subtitle: &'static str,
+    /// The raw markdown source.
+    pub source: &'static str,
+}
+
+/// Pointer to a particular heading within a page. Used for cross-links and
+/// for the editor's Ctrl+click resolver.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocAnchor {
+    pub page: &'static str,
+    /// `None` means "scroll to the top of the page". `Some(slug)` is a
+    /// GitHub-style slug derived from a heading line via [`heading_slug`].
+    pub slug: Option<String>,
+}
+
+impl DocAnchor {
+    pub fn section(page: &'static str, slug: impl Into<String>) -> Self {
+        Self {
+            page,
+            slug: Some(slug.into()),
+        }
+    }
+}
+
+/// One entry in a page's outline. Indentation in the sidebar is driven by
+/// `level` (2 = `##`, 3 = `###`).
+#[derive(Debug, Clone)]
+pub struct OutlineEntry {
+    pub level: u8,
+    pub title: String,
+    pub slug: String,
+}
+
+/// Order matches the sidebar listing — DSL first, since most Ctrl+click
+/// resolutions land there.
+pub const DOC_PAGES: &[DocPage] = &[
+    DocPage {
+        id: "dsl",
+        title: "DSL reference",
+        subtitle: "every node kind, attribute, and grammar form",
+        source: include_str!("../../../docs/dsl.md"),
+    },
+    DocPage {
+        id: "modules",
+        title: "Module catalog",
+        subtitle: "stdlib modules invoked via `use`",
+        source: include_str!("../../../docs/modules.md"),
+    },
+    DocPage {
+        id: "studio",
+        title: "MoGen Studio",
+        subtitle: "the desktop GUI you're using right now",
+        source: include_str!("../../../docs/studio.md"),
+    },
+    DocPage {
+        id: "cli",
+        title: "CLI reference",
+        subtitle: "`mogen` command-line subcommands",
+        source: include_str!("../../../docs/cli.md"),
+    },
+];
+
+pub fn page_by_id(id: &str) -> Option<&'static DocPage> {
+    DOC_PAGES.iter().find(|p| p.id == id)
+}
+
+/// Build the section outline for `page`. Walks the source once and skips
+/// headings inside fenced code blocks so a `### example` line in a snippet
+/// doesn't sneak into the table of contents.
+pub fn page_outline(page: &DocPage) -> Vec<OutlineEntry> {
+    let mut out = Vec::new();
+    let mut in_fence = false;
+    for line in page.source.lines() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        let trimmed = line.trim_start();
+        let level = trimmed.bytes().take_while(|b| *b == b'#').count();
+        if level == 0 || level > 6 {
+            continue;
+        }
+        let after = &trimmed[level..];
+        if !after.starts_with(' ') {
+            continue;
+        }
+        // Top-level `#` is the page title — the sidebar tab already shows it.
+        if level == 1 {
+            continue;
+        }
+        let title = after.trim().to_string();
+        let slug = heading_slug(&title);
+        out.push(OutlineEntry {
+            level: level as u8,
+            title,
+            slug,
+        });
+    }
+    out
+}
+
+/// GitHub-style heading slug. Lower-cases, drops backticks and most
+/// punctuation, replaces each space with a hyphen, and preserves underscores
+/// + literal hyphens in the source. Consecutive separators are kept as-is —
+/// `"`union` / `difference`"` becomes `"union--difference"` because the
+/// removed `/` leaves two surrounding spaces, each turning into its own
+/// hyphen. Matches the hand-rolled tables of contents at the top of the
+/// docs files (which were written against the same GitHub algorithm).
+pub fn heading_slug(heading: &str) -> String {
+    let mut out = String::with_capacity(heading.len());
+    for ch in heading.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else if ch == ' ' {
+            out.push('-');
+        } else if ch == '-' || ch == '_' {
+            out.push(ch);
+        }
+        // Everything else (backticks, slashes, colons, commas) is dropped
+        // *without* leaving a separator in its place — the spaces around it
+        // already supply the separators.
+    }
+    out
+}
+
+/// Map a token from the editor to the documentation section that explains
+/// it. Returns `None` when nothing matches — the caller can fall back to
+/// the table of contents or a brief "no docs for X" status message.
+pub fn lookup_topic(token: &str) -> Option<DocAnchor> {
+    let t = token.trim_matches(|c: char| !c.is_ascii_alphanumeric() && c != '_');
+    if t.is_empty() {
+        return None;
+    }
+
+    // Stdlib module names — open the catalog page on the relevant heading.
+    if STDLIB_MODULE_NAMES.contains(&t) {
+        return Some(DocAnchor::section("modules", heading_slug(t)));
+    }
+
+    match t {
+        // Top-level structure
+        "scene" | "group" => Some(DocAnchor::section("dsl", "scene-structure-scene-group")),
+        "solid" => Some(DocAnchor::section("dsl", "solid-groups-solid")),
+        "lod_scale" => Some(DocAnchor::section("dsl", "global-settings")),
+
+        // Modules
+        "module" | "use" => Some(DocAnchor::section("dsl", "modules-module-and-use")),
+
+        // Materials
+        "material" => Some(DocAnchor::section("dsl", "materials")),
+        | "color" | "alpha" | "metallic" | "roughness"
+        | "emissive" | "emissive_strength" | "transmission"
+        | "alpha_mode" | "alpha_cutoff" | "double_sided"
+        | "uv_mode" | "uv_scale"
+        | "base_color_texture" | "metallic_roughness_texture"
+        | "normal_texture" | "occlusion_texture" | "emissive_texture"
+        | "normal_strength" | "occlusion_strength"
+            => Some(DocAnchor::section("dsl", "materials")),
+
+        // Connectors / attach
+        "connector" | "attach" => Some(DocAnchor::section("dsl", "connectors")),
+
+        // Replicators
+        "mirror" => Some(DocAnchor::section("dsl", "mirror")),
+        "array"  => Some(DocAnchor::section("dsl", "array")),
+        "stack"  => Some(DocAnchor::section("dsl", "stack")),
+        "grid"   => Some(DocAnchor::section("dsl", "grid")),
+
+        // CSG
+        "union" | "difference" | "intersect"
+            => Some(DocAnchor::section("dsl", "csg-union--difference--intersect")),
+        "cleanup" => Some(DocAnchor::section("dsl", "cleanupcoplanar")),
+
+        // Animation
+        "joint" | "hinge" | "slider" | "ball" | "rotor"
+            => Some(DocAnchor::section("dsl", "joints")),
+        "clip" | "track"
+            => Some(DocAnchor::section("dsl", "authored-clips")),
+        "spin" | "open_close" | "wave" | "flap" | "idle"
+            => Some(DocAnchor::section("dsl", "procedural-templates")),
+        "skeleton" | "bone" | "skin"
+            => Some(DocAnchor::section("dsl", "animation-joint-clip-templates")),
+
+        // Placement shortcuts
+        "x" | "y" | "z" | "rx" | "ry" | "rz" | "w" | "h" | "d" | "size"
+            => Some(DocAnchor::section("dsl", "per-component-shortcuts")),
+        "from" | "to"
+            => Some(DocAnchor::section("dsl", "from--to--axis-aligned-box-by-corners")),
+        "anchor"
+            => Some(DocAnchor::section("dsl", "anchor--place-by-face-not-centre")),
+        "above" | "below" | "left_of" | "right_of" | "in_front_of" | "behind" | "gap"
+            => Some(DocAnchor::section(
+                "dsl",
+                "relative-placement-above-below-left_of-right_of-in_front_of-behind",
+            )),
+        "pos" | "rot" | "scale" | "mat" | "role" | "tags"
+            => Some(DocAnchor::section("dsl", "common-attributes")),
+
+        // Primitives — every primitive node kind shares the same heading.
+        | "box" | "sphere" | "cylinder" | "cone" | "capsule" | "torus"
+        | "prism" | "pyramid" | "disc" | "icosphere" | "rounded_box"
+        | "plane" | "quad" | "ellipsoid" | "superellipsoid" | "hemisphere"
+        | "frustum" | "tube" | "spline_tube" | "torus_arc" | "half_cylinder"
+        | "curved_plane" | "lathe" | "wedge" | "slab" | "post" | "panel"
+        | "wall" | "roof"
+            => Some(DocAnchor::section("dsl", "primitives")),
+
+        _ => None,
+    }
+}
+
+/// Stdlib module names recognised by the resolver. Keep aligned with
+/// `crates/mogen-dsl/stdlib/*.mog`. Each name corresponds to a `### name`
+/// heading in `docs/modules.md`, but we resolve generously to the catalog
+/// page even when a heading isn't present yet.
+pub const STDLIB_MODULE_NAMES: &[&str] = &[
+    "humanoid_head",
+    "humanoid_torso",
+    "humanoid_arm",
+    "humanoid_leg",
+    "humanoid_hand_5fingers",
+    "quadruped_torso",
+    "quadruped_leg",
+    "tail",
+    "ear",
+    "eye",
+    "leaf",
+    "branch",
+    "leg",
+    "slab",
+    "arm_with_rotor",
+];
+
+// -----------------------------------------------------------------------------
+// Editor Ctrl+click resolver
+// -----------------------------------------------------------------------------
+
+/// What a Ctrl+click on a token should do. Resolved purely from the source
+/// + caret offset; the caller dispatches the action against the live UI
+/// (open browser, open file, jump caret, open docs window).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkTarget {
+    /// External URL (`http://…` / `https://…`). Open in the system browser.
+    Url(String),
+    /// Path string (relative or absolute). Resolved against the active
+    /// file's directory by the dispatcher; `.mog` paths open as a new tab,
+    /// everything else hands off to the OS.
+    File(String),
+    /// `use "name"` referring to a module. The dispatcher checks first if
+    /// there's a matching `module "name"` declaration in the same buffer
+    /// (jump caret) before falling back to a stdlib docs lookup.
+    Module(String),
+    /// Generic keyword / attribute / node-kind that resolves to a docs
+    /// section.
+    Docs(DocAnchor),
+}
+
+/// Result of resolving a click position to something actionable.
+#[derive(Debug, Clone)]
+pub struct LinkHit {
+    /// Byte range of the token that was hit. The caller can use it to draw
+    /// an underline on Ctrl+hover or to scope a context-menu label. Not
+    /// read by the click dispatcher itself, but exposed so the eventual
+    /// "Go to definition" right-click menu can reuse the same resolution.
+    #[allow(dead_code)]
+    pub range: std::ops::Range<usize>,
+    pub target: LinkTarget,
+}
+
+/// Resolve a click at byte offset `at` in `source` to a [`LinkHit`].
+/// Returns `None` when the position lies on whitespace, a number, or
+/// anything else that has no meaningful navigation target.
+pub fn resolve_link_at(source: &str, at: usize) -> Option<LinkHit> {
+    if at > source.len() || !source.is_char_boundary(at) {
+        return None;
+    }
+
+    // Inside a string literal? Strings can carry URLs and file paths, both
+    // of which resolve regardless of context.
+    if let Some(string) = enclosing_string(source, at) {
+        let inner = &source[string.start..string.end];
+        let trimmed = inner.trim();
+        if !trimmed.is_empty() {
+            if is_url(trimmed) {
+                return Some(LinkHit {
+                    range: string,
+                    target: LinkTarget::Url(trimmed.to_string()),
+                });
+            }
+            if looks_like_path(trimmed) {
+                return Some(LinkHit {
+                    range: string,
+                    target: LinkTarget::File(trimmed.to_string()),
+                });
+            }
+            // Not a URL/path — but if the enclosing call is `use "name"`
+            // the string holds a module reference.
+            if preceded_by_use_kind(source, string.start) {
+                return Some(LinkHit {
+                    range: string,
+                    target: LinkTarget::Module(trimmed.to_string()),
+                });
+            }
+        }
+    }
+
+    // Inside a `// …` line comment? URLs in comments still navigate.
+    if let Some(comment) = enclosing_comment(source, at) {
+        if let Some(url_range) = find_url_in(source, comment.clone(), at) {
+            let url = source[url_range.clone()].to_string();
+            return Some(LinkHit {
+                range: url_range,
+                target: LinkTarget::Url(url),
+            });
+        }
+        // Fall through: comments otherwise don't resolve.
+        return None;
+    }
+
+    // Identifier hit — node kinds, attribute names, module declarations, etc.
+    let word = enclosing_ident(source, at)?;
+    let token = &source[word.clone()];
+    if let Some(anchor) = lookup_topic(token) {
+        return Some(LinkHit {
+            range: word,
+            target: LinkTarget::Docs(anchor),
+        });
+    }
+    None
+}
+
+/// Byte range of the string literal containing `at`, exclusive of the
+/// surrounding quotes. `None` when the position isn't inside a string.
+/// Tolerates an unterminated string (user mid-edit) by treating end-of-line
+/// or end-of-file as the closing boundary.
+fn enclosing_string(source: &str, at: usize) -> Option<std::ops::Range<usize>> {
+    let bytes = source.as_bytes();
+    // Walk from the start of the current line to `at`, tracking whether we
+    // are inside a string. If `at` is inside, the start of that string is
+    // the most recent unmatched `"`. Then scan forward to find its close.
+    let line_start = source[..at].rfind('\n').map(|n| n + 1).unwrap_or(0);
+    let mut i = line_start;
+    let mut open: Option<usize> = None;
+    while i < at {
+        let b = bytes[i];
+        if b == b'\\' && i + 1 < at {
+            i += 2;
+            continue;
+        }
+        if b == b'"' {
+            open = if open.is_some() { None } else { Some(i) };
+        }
+        i += 1;
+    }
+    let open = open?;
+    // Find the closing quote (or EOL / EOF).
+    let mut j = at;
+    while j < bytes.len() {
+        let b = bytes[j];
+        if b == b'\\' && j + 1 < bytes.len() {
+            j += 2;
+            continue;
+        }
+        if b == b'"' || b == b'\n' {
+            break;
+        }
+        j += 1;
+    }
+    Some(open + 1..j)
+}
+
+/// Byte range of the `// …` comment containing `at` (the `//` is included),
+/// `None` when `at` is not inside a comment.
+fn enclosing_comment(source: &str, at: usize) -> Option<std::ops::Range<usize>> {
+    let line_start = source[..at].rfind('\n').map(|n| n + 1).unwrap_or(0);
+    let line_end = source[at..]
+        .find('\n')
+        .map(|n| at + n)
+        .unwrap_or(source.len());
+    let line = &source[line_start..line_end];
+    // Walk the line to find a `//` not inside a string. Strings aren't
+    // common in comment-bearing positions so this is fine to be loose.
+    let bytes = line.as_bytes();
+    let mut in_str = false;
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'"' {
+            in_str = !in_str;
+        }
+        if !in_str && bytes[i] == b'/' && bytes[i + 1] == b'/' {
+            let comment_start = line_start + i;
+            if at >= comment_start {
+                return Some(comment_start..line_end);
+            }
+            return None;
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Find the URL that contains `at`, looking only inside `range`. Used to
+/// pinpoint `https://…` substrings inside `// …` comments. Returns a byte
+/// range over the URL itself.
+fn find_url_in(
+    source: &str,
+    range: std::ops::Range<usize>,
+    at: usize,
+) -> Option<std::ops::Range<usize>> {
+    // Split the comment text into whitespace-delimited words and check each
+    // for URL-shape. Cheap because comment lines are short.
+    let segment = &source[range.clone()];
+    let mut idx = 0usize;
+    for word in segment.split_whitespace() {
+        // Recover the byte offset of `word` inside `segment`.
+        let local = match segment[idx..].find(word) {
+            Some(p) => idx + p,
+            None => break,
+        };
+        idx = local + word.len();
+        let abs = range.start + local..range.start + local + word.len();
+        if !abs.contains(&at) && abs.end != at {
+            continue;
+        }
+        // Strip trailing punctuation that often wraps URLs in prose.
+        let cleaned = word.trim_end_matches([',', '.', ')', ']', ';', ':']);
+        if is_url(cleaned) {
+            let trimmed_len = cleaned.len();
+            return Some(abs.start..abs.start + trimmed_len);
+        }
+    }
+    None
+}
+
+/// Identifier (or `$param`) word containing `at`, returned as a byte range.
+fn enclosing_ident(source: &str, at: usize) -> Option<std::ops::Range<usize>> {
+    let bytes = source.as_bytes();
+    if at >= bytes.len() {
+        return None;
+    }
+    let here = bytes[at];
+    // The cursor sits one byte to the right of the just-clicked glyph. If
+    // it's not on an ident byte, look one back.
+    let mut start = at;
+    let mut end = at;
+    if !is_ident_byte(here) {
+        if at == 0 || !is_ident_byte(bytes[at - 1]) {
+            return None;
+        }
+        start = at - 1;
+        end = at;
+    }
+    while start > 0 && is_ident_byte(bytes[start - 1]) {
+        start -= 1;
+    }
+    while end < bytes.len() && is_ident_byte(bytes[end]) {
+        end += 1;
+    }
+    if end == start {
+        return None;
+    }
+    Some(start..end)
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Heuristic: does `s` look like an http/https URL? (No need to be pedantic
+/// — we only call this on free-form text and on string literals, where a
+/// false positive just opens the user's browser to nothing.)
+fn is_url(s: &str) -> bool {
+    s.starts_with("http://") || s.starts_with("https://")
+}
+
+/// Heuristic: does `s` look like a file path? Conservative — we only
+/// trigger when the string contains a path separator or a recognised file
+/// extension, so a literal like `"top"` (a connector tag) doesn't ask the
+/// OS to open a non-existent file.
+fn looks_like_path(s: &str) -> bool {
+    if s.contains('/') || s.contains('\\') {
+        return true;
+    }
+    // Bare filename with a recognised extension.
+    let lower = s.to_ascii_lowercase();
+    [
+        ".mog", ".png", ".jpg", ".jpeg", ".webp", ".bmp", ".tga", ".glb",
+        ".gltf",
+    ]
+    .iter()
+    .any(|ext| lower.ends_with(ext))
+}
+
+/// True when the string whose inner content begins at `inner_start` is the
+/// name argument of a `use "…"` node — i.e. the kind ident immediately to
+/// the left of the opening quote is `use`.
+fn preceded_by_use_kind(source: &str, inner_start: usize) -> bool {
+    if inner_start == 0 {
+        return false;
+    }
+    let bytes = source.as_bytes();
+    // The inner range excludes the opening `"`, so step one back to land on
+    // it before scanning for the kind ident.
+    let mut i = inner_start - 1;
+    if bytes.get(i) != Some(&b'"') {
+        return false;
+    }
+    while i > 0 && bytes[i - 1].is_ascii_whitespace() {
+        i -= 1;
+    }
+    let end = i;
+    while i > 0 && is_ident_byte(bytes[i - 1]) {
+        i -= 1;
+    }
+    if end == i {
+        return false;
+    }
+    &source[i..end] == "use"
+}
+
+/// Find a `module "name"` declaration in `source`. Used by the Ctrl+click
+/// dispatcher to jump from a `use "name"` site to the matching declaration
+/// in the same buffer. Returns the byte offset of the `m` in `module`.
+pub fn find_module_decl(source: &str, name: &str) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let needle = format!("module \"{name}\"");
+    let mut i = 0;
+    while i + needle.len() <= bytes.len() {
+        if source[i..].starts_with(&needle) {
+            // Make sure we're at a token boundary so we don't match
+            // `submodule` if someone names a kind like that someday.
+            let prev_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
+            if prev_ok {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+// -----------------------------------------------------------------------------
+// Markdown renderer
+// -----------------------------------------------------------------------------
+
+/// Render `source` into `ui` as a sequence of egui widgets. Supports:
+///
+/// - `#`/`##`/`###` headings (each registers a scroll anchor named after its
+///   slug so the sidebar can jump to it).
+/// - Fenced code blocks (````) with a monospaced background block.
+/// - Bullet lines starting with `-` or `*`.
+/// - Inline `code` (single backticks).
+/// - Inline links `[text](url)`.
+/// - Paragraph breaks (blank line).
+///
+/// Tables, images, and HTML blocks are left as plain text — the docs files
+/// use a tiny subset of markdown so this is enough.
+pub fn render_markdown(ui: &mut egui::Ui, source: &str, scroll_to_slug: Option<&str>) {
+    let mut lines = source.lines().peekable();
+    let mut paragraph: Vec<String> = Vec::new();
+    let mut in_code = false;
+    let mut code_buf = String::new();
+    let mut requested_scroll = false;
+
+    while let Some(line) = lines.next() {
+        // Fenced code block.
+        if line.trim_start().starts_with("```") {
+            if in_code {
+                render_code_block(ui, &code_buf);
+                code_buf.clear();
+                in_code = false;
+            } else {
+                flush_paragraph(ui, &mut paragraph);
+                in_code = true;
+            }
+            continue;
+        }
+        if in_code {
+            if !code_buf.is_empty() {
+                code_buf.push('\n');
+            }
+            code_buf.push_str(line);
+            continue;
+        }
+
+        let trimmed = line.trim_start();
+
+        // Headings.
+        let hashes = trimmed.bytes().take_while(|b| *b == b'#').count();
+        if hashes >= 1 && hashes <= 6 && trimmed.as_bytes().get(hashes) == Some(&b' ') {
+            flush_paragraph(ui, &mut paragraph);
+            let title = trimmed[hashes + 1..].trim().to_string();
+            let slug = heading_slug(&title);
+            let anchor_id = egui::Id::new(("doc_anchor", slug.clone()));
+            let resp = match hashes {
+                1 => ui.add(egui::Label::new(
+                    egui::RichText::new(title).heading().strong(),
+                )),
+                2 => ui.add(egui::Label::new(
+                    egui::RichText::new(title).size(20.0).strong(),
+                )),
+                3 => ui.add(egui::Label::new(
+                    egui::RichText::new(title).size(16.0).strong(),
+                )),
+                _ => ui.add(egui::Label::new(
+                    egui::RichText::new(title).size(14.0).strong(),
+                )),
+            };
+            ui.scope(|ui| {
+                ui.set_min_size(egui::Vec2::ZERO);
+                ui.allocate_rect(resp.rect, egui::Sense::hover())
+                    .on_hover_text(format!("#{slug}"));
+            });
+            // Register a scroll target keyed by the slug so the sidebar can
+            // jump to it later.
+            ui.ctx().memory_mut(|m| {
+                m.data
+                    .insert_temp::<egui::Pos2>(anchor_id, resp.rect.left_top());
+            });
+            if !requested_scroll {
+                if let Some(target) = scroll_to_slug {
+                    if target == slug {
+                        resp.scroll_to_me(Some(egui::Align::TOP));
+                        requested_scroll = true;
+                    }
+                }
+            }
+            ui.add_space(4.0);
+            continue;
+        }
+
+        // Horizontal rule.
+        if trimmed == "---" {
+            flush_paragraph(ui, &mut paragraph);
+            ui.separator();
+            continue;
+        }
+
+        // Bullet line.
+        if let Some(rest) = trimmed.strip_prefix("- ").or_else(|| trimmed.strip_prefix("* ")) {
+            flush_paragraph(ui, &mut paragraph);
+            ui.horizontal_wrapped(|ui| {
+                ui.label("•");
+                render_inline(ui, rest);
+            });
+            continue;
+        }
+
+        // Numbered list item like `1. text`.
+        if let Some(after) = strip_numbered_marker(trimmed) {
+            flush_paragraph(ui, &mut paragraph);
+            ui.horizontal_wrapped(|ui| {
+                ui.label("•");
+                render_inline(ui, after);
+            });
+            continue;
+        }
+
+        // Blank line ends the current paragraph.
+        if trimmed.is_empty() {
+            flush_paragraph(ui, &mut paragraph);
+            continue;
+        }
+
+        // Regular text — accumulate until the next blank.
+        paragraph.push(line.to_string());
+    }
+    if in_code {
+        // Unterminated fence — render whatever we have so the user still
+        // sees the snippet rather than nothing.
+        render_code_block(ui, &code_buf);
+    }
+    flush_paragraph(ui, &mut paragraph);
+}
+
+fn strip_numbered_marker(s: &str) -> Option<&str> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i == 0 || i + 1 >= bytes.len() {
+        return None;
+    }
+    if bytes[i] != b'.' && bytes[i] != b')' {
+        return None;
+    }
+    if bytes[i + 1] != b' ' {
+        return None;
+    }
+    Some(&s[i + 2..])
+}
+
+fn flush_paragraph(ui: &mut egui::Ui, lines: &mut Vec<String>) {
+    if lines.is_empty() {
+        return;
+    }
+    let joined = lines.join(" ");
+    lines.clear();
+    ui.horizontal_wrapped(|ui| {
+        render_inline(ui, &joined);
+    });
+    ui.add_space(4.0);
+}
+
+fn render_code_block(ui: &mut egui::Ui, code: &str) {
+    egui::Frame::none()
+        .fill(ui.visuals().extreme_bg_color)
+        .inner_margin(egui::Margin::symmetric(8.0, 6.0))
+        .rounding(4.0)
+        .show(ui, |ui| {
+            ui.add(
+                egui::Label::new(
+                    egui::RichText::new(code)
+                        .monospace()
+                        .color(ui.visuals().strong_text_color()),
+                )
+                .selectable(true)
+                .wrap_mode(egui::TextWrapMode::Extend),
+            );
+        });
+    ui.add_space(6.0);
+}
+
+/// Inline tokens: backticks → monospace chip; `[label](url)` → hyperlink;
+/// everything else is plain text.
+fn render_inline(ui: &mut egui::Ui, src: &str) {
+    let mut i = 0;
+    let bytes = src.as_bytes();
+    let mut buf = String::new();
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'`' {
+            // Inline code span.
+            if !buf.is_empty() {
+                ui.label(std::mem::take(&mut buf));
+            }
+            let start = i + 1;
+            let mut end = start;
+            while end < bytes.len() && bytes[end] != b'`' {
+                end += 1;
+            }
+            let span = &src[start..end];
+            ui.add(egui::Label::new(
+                egui::RichText::new(span).monospace().background_color(
+                    ui.visuals().extreme_bg_color,
+                ),
+            ));
+            i = if end < bytes.len() { end + 1 } else { end };
+            continue;
+        }
+        if b == b'[' {
+            // Try to parse `[text](url)` — fall through to plain text on no
+            // match so a stray `[` doesn't drop characters.
+            if let Some((label, url, consumed)) = parse_link(&src[i..]) {
+                if !buf.is_empty() {
+                    ui.label(std::mem::take(&mut buf));
+                }
+                ui.hyperlink_to(label, url);
+                i += consumed;
+                continue;
+            }
+        }
+        // Append this char to the running plain-text buffer. Walk UTF-8
+        // boundaries so multi-byte chars don't panic.
+        let end = next_char_boundary(src, i);
+        buf.push_str(&src[i..end]);
+        i = end;
+    }
+    if !buf.is_empty() {
+        ui.label(buf);
+    }
+}
+
+fn next_char_boundary(src: &str, i: usize) -> usize {
+    let mut j = i + 1;
+    while j < src.len() && !src.is_char_boundary(j) {
+        j += 1;
+    }
+    j
+}
+
+fn parse_link(s: &str) -> Option<(String, String, usize)> {
+    let bytes = s.as_bytes();
+    if bytes.first() != Some(&b'[') {
+        return None;
+    }
+    // Find matching `]`.
+    let mut i = 1;
+    while i < bytes.len() && bytes[i] != b']' {
+        if bytes[i] == b'\n' {
+            return None;
+        }
+        i += 1;
+    }
+    if i >= bytes.len() || i + 1 >= bytes.len() || bytes[i + 1] != b'(' {
+        return None;
+    }
+    let label = s[1..i].to_string();
+    let mut j = i + 2;
+    while j < bytes.len() && bytes[j] != b')' {
+        if bytes[j] == b'\n' {
+            return None;
+        }
+        j += 1;
+    }
+    if j >= bytes.len() {
+        return None;
+    }
+    let url = s[i + 2..j].to_string();
+    Some((label, url, j + 1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_page_loads_and_has_outline() {
+        for page in DOC_PAGES {
+            assert!(!page.source.is_empty(), "page {} embedded empty", page.id);
+            let outline = page_outline(page);
+            assert!(
+                !outline.is_empty(),
+                "page {} produced no outline entries",
+                page.id
+            );
+        }
+    }
+
+    #[test]
+    fn heading_slug_matches_github_anchors() {
+        assert_eq!(heading_slug("Grammar at a glance"), "grammar-at-a-glance");
+        assert_eq!(
+            heading_slug("CSG: `union` / `difference` / `intersect`"),
+            "csg-union--difference--intersect"
+        );
+        assert_eq!(
+            heading_slug("Modules: `module` and `use`"),
+            "modules-module-and-use"
+        );
+        assert_eq!(
+            heading_slug("Scene structure: `scene`, `group`"),
+            "scene-structure-scene-group"
+        );
+    }
+
+    #[test]
+    fn lookup_topic_resolves_keywords() {
+        assert_eq!(
+            lookup_topic("box").unwrap(),
+            DocAnchor::section("dsl", "primitives")
+        );
+        assert_eq!(
+            lookup_topic("material").unwrap(),
+            DocAnchor::section("dsl", "materials")
+        );
+        assert_eq!(
+            lookup_topic("module").unwrap(),
+            DocAnchor::section("dsl", "modules-module-and-use")
+        );
+        assert!(lookup_topic("nonexistent_keyword").is_none());
+    }
+
+    #[test]
+    fn lookup_topic_resolves_stdlib_modules() {
+        let leg = lookup_topic("leg").unwrap();
+        assert_eq!(leg.page, "modules");
+        let humanoid = lookup_topic("humanoid_head").unwrap();
+        assert_eq!(humanoid.page, "modules");
+    }
+
+    #[test]
+    fn lookup_topic_strips_punctuation() {
+        // The Ctrl+click extractor passes the raw word; quotes / parens are
+        // common on string-valued attrs.
+        assert!(lookup_topic("\"box\"").is_some());
+        assert!(lookup_topic("(material)").is_some());
+    }
+
+    #[test]
+    fn page_outline_skips_code_block_headings() {
+        let page = DocPage {
+            id: "x",
+            title: "x",
+            subtitle: "",
+            source: "## real\n```\n## fake\n```\n## also-real\n",
+        };
+        let outline = page_outline(&page);
+        assert_eq!(outline.len(), 2);
+        assert_eq!(outline[0].title, "real");
+        assert_eq!(outline[1].title, "also-real");
+    }
+
+    #[test]
+    fn parse_link_extracts_label_and_url() {
+        let (label, url, consumed) = parse_link("[click](https://x.test) extra").unwrap();
+        assert_eq!(label, "click");
+        assert_eq!(url, "https://x.test");
+        assert_eq!(consumed, "[click](https://x.test)".len());
+    }
+
+    #[test]
+    fn resolves_keyword_at_caret_to_docs() {
+        let src = "scene { box \"b\" (size=[1,1,1]) }";
+        // Place caret inside `box`.
+        let at = src.find("box").unwrap() + 1;
+        let hit = resolve_link_at(src, at).expect("hit");
+        assert_eq!(&src[hit.range], "box");
+        match hit.target {
+            LinkTarget::Docs(a) => {
+                assert_eq!(a.page, "dsl");
+                assert_eq!(a.slug.as_deref(), Some("primitives"));
+            }
+            other => panic!("expected Docs, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolves_use_string_to_module() {
+        let src = "scene { use \"leg\" (height=0.5) }";
+        let at = src.find("leg").unwrap() + 1;
+        let hit = resolve_link_at(src, at).expect("hit");
+        match hit.target {
+            LinkTarget::Module(name) => assert_eq!(name, "leg"),
+            other => panic!("expected Module, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolves_url_in_string_literal() {
+        let src = "// see https://example.test for details\nscene {}";
+        let at = src.find("example").unwrap() + 2;
+        let hit = resolve_link_at(src, at).expect("hit");
+        match hit.target {
+            LinkTarget::Url(url) => assert_eq!(url, "https://example.test"),
+            other => panic!("expected Url, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolves_path_in_string_literal() {
+        let src = "material \"wood\" (base_color_texture=\"./textures/wood.png\")";
+        let at = src.find("wood.png").unwrap() + 2;
+        let hit = resolve_link_at(src, at).expect("hit");
+        match hit.target {
+            LinkTarget::File(p) => assert_eq!(p, "./textures/wood.png"),
+            other => panic!("expected File, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_token_returns_none() {
+        let src = "scene { box \"foobar\" () }";
+        let at = src.find("foobar").unwrap() + 2;
+        // "foobar" is just a node name string with no path/url shape, so no link.
+        assert!(resolve_link_at(src, at).is_none());
+    }
+
+    #[test]
+    fn finds_local_module_declaration() {
+        let src = "module \"leg\" (h=0.5) { box \"b\" () }\nscene { use \"leg\" () }";
+        let off = find_module_decl(src, "leg").expect("found");
+        assert!(src[off..].starts_with("module \"leg\""));
+    }
+
+    #[test]
+    fn looks_like_path_rejects_plain_strings() {
+        assert!(!looks_like_path("top"));
+        assert!(!looks_like_path("seat_back"));
+        assert!(looks_like_path("./textures/wood.png"));
+        assert!(looks_like_path("textures/wood.png"));
+        assert!(looks_like_path("wood.png"));
+        assert!(looks_like_path("/abs/path/file.glb"));
+    }
+}

--- a/crates/mogen-studio/src/main.rs
+++ b/crates/mogen-studio/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod autocomplete;
 mod crash;
+mod docs;
 mod edit;
 mod gizmo;
 mod highlight;


### PR DESCRIPTION
Bundles the four reference markdown files (DSL, modules, studio, CLI) into
the Studio binary and surfaces them through a Help → Documentation window
(F1). The window has a section outline sidebar with a filter, a Back
button, and a tiny markdown renderer (headings, code fences, bullets,
inline links).

Adds Ctrl+click in the code editor that resolves the token under the
cursor and dispatches one of:

- URL in a comment / string → open in system browser
- file path string → open the .mog as a tab, hand other extensions to the
  OS default app
- `use "name"` → jump to the local `module "name"` declaration when one
  exists, otherwise scroll the docs window to the matching stdlib entry
- node kind, attribute, or other recognised keyword → scroll the docs
  window to the relevant section

The token resolver lives in the new `docs` module so it stays unit-tested
without an egui context.

https://claude.ai/code/session_01MM9CcdPTaMnzsGMqCdaGy8