### PR TITLE
Add binary FBX 7.4 export alongside GLB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,7 +1052,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ac2645a9bf4826eb4e91488b1f17b8eaddeef09396706b2f14066461338e24f"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "document-features",
  "egui",
@@ -1070,7 +1087,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53eafabcce0cb2325a59a98736efe0bf060585b437763f8c476957fb274bb974"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "emath",
  "epaint",
  "log",
@@ -1083,7 +1100,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00fd5d06d8405397e64a928fa0ef3934b3c30273ea7603e3dc4627b1f7a1a82"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "document-features",
  "egui",
@@ -1102,7 +1119,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a9c430f4f816340e8e8c1b20eec274186b1be6bc4c7dfc467ed50d57abc36c6"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arboard",
  "egui",
  "log",
@@ -1119,7 +1136,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e39bccc683cd43adab530d8f21a13eb91e80de10bcc38c3f1c16601b6f62b26"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "egui",
  "glow 0.14.2",
@@ -1185,7 +1202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a32af8da821bd4f43f2c137e295459ee2e1661d87ca8779dfa0eaf45d870e20f"
 dependencies = [
  "ab_glyph",
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "ecolor",
  "emath",
@@ -1249,6 +1266,18 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fbxcel"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f9e966e38cb462819635792e0a9ee1d6cc5fff9bcdbf7baefb350221a7ae3df"
+dependencies = [
+ "indextree",
+ "libflate",
+ "log",
+ "string-interner",
+]
 
 [[package]]
 name = "fdeflate"
@@ -1689,6 +1718,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1994,6 +2032,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "indextree"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee462cd93b03891663339b59a21246cc5fc2cc95060d0bb5059e25cd50edc4"
+dependencies = [
+ "indextree-macros",
+]
+
+[[package]]
+name = "indextree-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f85dac6c239acc85fd61934c572292d93adfd2de459d9c032aa22b553506e915"
+dependencies = [
+ "either",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "strum",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "indicatif"
 version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2095,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2171,6 +2242,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
 dependencies = [
  "libdeflate-sys",
+]
+
+[[package]]
+name = "libflate"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ff4ae71b685bbad2f2f391fe74f6b7659a34871c08b210fdc039e43bee07d18"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
+dependencies = [
+ "rle-decode-fast",
 ]
 
 [[package]]
@@ -2398,6 +2489,7 @@ name = "mogen-export"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "fbxcel",
  "glam",
  "image",
  "mogen-core",
@@ -3733,6 +3825,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4264,10 +4362,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
+name = "string-interner"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e2531d8525b29b514d25e275a43581320d587b86db302b9a7e464bac579648"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -5517,7 +5646,7 @@ version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "android-activity",
  "atomic-waker",
  "bitflags 2.11.1",

--- a/crates/mogen-export/Cargo.toml
+++ b/crates/mogen-export/Cargo.toml
@@ -28,6 +28,10 @@ textures-optimize = ["textures", "dep:image", "dep:oxipng"]
 # selected anywhere in the workspace, calling `union_many` would hit the
 # `csg_stub` panic.
 merge = []
+# Binary FBX 7.4 export. Off by default — pulls in `fbxcel`, which the
+# wasm crate doesn't enable. The desktop CLI turns this on so `mogen build`
+# can dispatch on output extension.
+fbx = ["dep:fbxcel"]
 
 [dependencies]
 mogen-core = { workspace = true }
@@ -38,6 +42,7 @@ serde_json = { workspace = true }
 glam = { workspace = true }
 image = { workspace = true, optional = true }
 oxipng = { workspace = true, optional = true }
+fbxcel = { version = "0.9", features = ["writer", "tree"], optional = true }
 
 [dev-dependencies]
 mogen-dsl = { workspace = true, features = ["csg"] }

--- a/crates/mogen-export/src/fbx/anim.rs
+++ b/crates/mogen-export/src/fbx/anim.rs
@@ -22,9 +22,12 @@ pub(super) fn seconds_to_ktime(seconds: f32) -> i64 {
     (seconds as f64 * FBX_TICKS_PER_SECOND as f64).round() as i64
 }
 
-// `KeyAttrFlags` constants from the FBX SDK (`kfbxnodeshape.h`).
-const KEY_ATTR_FLAGS_LINEAR: i32 = 0x00000002;
-const KEY_ATTR_FLAGS_CONSTANT: i32 = 0x00000004;
+// `KeyAttrFlags` constants from the FBX SDK (`kfcurve.h` /
+// `kfbxnodeshape.h`). The values are deliberately laid out so that
+// 0x2 = Constant and 0x4 = Linear (and 0x8 = Cubic). Blender's FBX
+// exporter (`io_scene_fbx/export_fbx_bin.py`) uses the same values.
+const KEY_ATTR_FLAGS_CONSTANT: i32 = 0x00000002;
+const KEY_ATTR_FLAGS_LINEAR: i32 = 0x00000004;
 
 pub(super) fn emit_animations(
     scene: &SceneGraph,

--- a/crates/mogen-export/src/fbx/anim.rs
+++ b/crates/mogen-export/src/fbx/anim.rs
@@ -1,0 +1,175 @@
+//! Animation export — `Clip` → `AnimationStack` + `AnimationLayer` plus per-
+//! track `AnimationCurveNode` / `AnimationCurve` triples.
+//!
+//! FBX times are stored as i64 ticks. The conversion factor is
+//! `46_186_158_000` ticks per second, regardless of the target frame rate
+//! (FBX uses ticks as a continuous time base; `TimeMode` only changes the
+//! display unit). At 30 fps every frame falls on an exact tick boundary —
+//! useful for both inspectors and round-trip tests.
+
+use fbxcel::low::v7400::AttributeValue;
+
+use mogen_core::{Interpolation, SceneGraph, TrackProperty};
+
+use super::doc::{push_prop, write_properties70, ObjectEmitter};
+use super::ids::IdAllocator;
+
+/// FBX tick count for one second.
+pub(super) const FBX_TICKS_PER_SECOND: i64 = 46_186_158_000;
+
+/// Convert seconds → FBX KTime ticks.
+pub(super) fn seconds_to_ktime(seconds: f32) -> i64 {
+    (seconds as f64 * FBX_TICKS_PER_SECOND as f64).round() as i64
+}
+
+// `KeyAttrFlags` constants from the FBX SDK (`kfbxnodeshape.h`).
+const KEY_ATTR_FLAGS_LINEAR: i32 = 0x00000002;
+const KEY_ATTR_FLAGS_CONSTANT: i32 = 0x00000004;
+
+pub(super) fn emit_animations(
+    scene: &SceneGraph,
+    model_ids: &[i64],
+    ids: &mut IdAllocator,
+    emit: &mut ObjectEmitter,
+) {
+    if scene.clips.is_empty() {
+        return;
+    }
+
+    for clip in &scene.clips {
+        let stack_id = ids.alloc();
+        let layer_id = ids.alloc();
+        let stack_name = clip.name.clone();
+        let layer_name = format!("{}_layer", clip.name);
+        let stop_ticks = seconds_to_ktime(clip.duration);
+
+        emit.push_object(
+            "AnimationStack",
+            Box::new(move |tree, parent| {
+                let n = tree.append_new(parent, "AnimationStack");
+                tree.append_attribute(n, stack_id);
+                tree.append_attribute(n, format!("{stack_name}\u{0}\u{1}AnimStack"));
+                tree.append_attribute(n, "");
+                write_properties70(tree, n, |t, props| {
+                    push_prop(t, props, "LocalStart", "KTime", "Time", "", AttributeValue::I64(0));
+                    push_prop(t, props, "LocalStop", "KTime", "Time", "", AttributeValue::I64(stop_ticks));
+                    push_prop(t, props, "ReferenceStart", "KTime", "Time", "", AttributeValue::I64(0));
+                    push_prop(t, props, "ReferenceStop", "KTime", "Time", "", AttributeValue::I64(stop_ticks));
+                });
+            }),
+        );
+
+        emit.push_object(
+            "AnimationLayer",
+            Box::new(move |tree, parent| {
+                let n = tree.append_new(parent, "AnimationLayer");
+                tree.append_attribute(n, layer_id);
+                tree.append_attribute(n, format!("{layer_name}\u{0}\u{1}AnimLayer"));
+                tree.append_attribute(n, "");
+            }),
+        );
+        emit.connect_oo(layer_id, stack_id);
+
+        for track in &clip.tracks {
+            let model_id = match model_ids.get(track.node.0 as usize) {
+                Some(&m) => m,
+                None => continue,
+            };
+
+            let prop_name: &'static str = match track.property {
+                TrackProperty::Translation => "Lcl Translation",
+                TrackProperty::Rotation => "Lcl Rotation",
+                TrackProperty::Scale => "Lcl Scaling",
+            };
+
+            // Per-axis component values. Rotation tracks come in as quats;
+            // FBX wants Euler XYZ degrees on `Lcl Rotation`. Linear-
+            // interpolated quaternion data going through Euler isn't
+            // bit-identical (it can change which axis catches a rollover)
+            // but matches the GLB exporter's treatment of the same data,
+            // and the values still describe the same orientations.
+            let component_values: Vec<[f32; 3]> = match track.property {
+                TrackProperty::Rotation => track
+                    .values
+                    .iter()
+                    .map(|v| {
+                        let q = glam::Quat::from_xyzw(v[0], v[1], v[2], v[3]);
+                        let (x, y, z) = q.to_euler(glam::EulerRot::XYZ);
+                        [x.to_degrees(), y.to_degrees(), z.to_degrees()]
+                    })
+                    .collect(),
+                _ => track.values.iter().map(|v| [v[0], v[1], v[2]]).collect(),
+            };
+
+            // CurveNode wraps three component curves (X, Y, Z). All Lcl
+            // properties go through this same pattern in FBX 7.4.
+            let curve_node_id = ids.alloc();
+            emit.push_object(
+                "AnimationCurveNode",
+                Box::new(move |tree, parent| {
+                    let n = tree.append_new(parent, "AnimationCurveNode");
+                    tree.append_attribute(n, curve_node_id);
+                    tree.append_attribute(n, format!("{prop_name}\u{0}\u{1}AnimCurveNode"));
+                    tree.append_attribute(n, "");
+                    write_properties70(tree, n, |t, props| {
+                        push_prop(t, props, "d|X", "Number", "", "A", AttributeValue::F64(0.0));
+                        push_prop(t, props, "d|Y", "Number", "", "A", AttributeValue::F64(0.0));
+                        push_prop(t, props, "d|Z", "Number", "", "A", AttributeValue::F64(0.0));
+                    });
+                }),
+            );
+            emit.connect_oo(curve_node_id, layer_id);
+            emit.connect_op(curve_node_id, model_id, prop_name);
+
+            for axis in 0..3usize {
+                let curve_id = ids.alloc();
+                let times: Vec<i64> =
+                    track.times.iter().map(|t| seconds_to_ktime(*t)).collect();
+                let values: Vec<f32> =
+                    component_values.iter().map(|v| v[axis]).collect();
+                let flags = match track.interpolation {
+                    Interpolation::Linear => KEY_ATTR_FLAGS_LINEAR,
+                    Interpolation::Step => KEY_ATTR_FLAGS_CONSTANT,
+                };
+                let key_count = times.len() as i32;
+                let axis_letter = ["X", "Y", "Z"][axis];
+
+                emit.push_object(
+                    "AnimationCurve",
+                    Box::new(move |tree, parent| {
+                        let n = tree.append_new(parent, "AnimationCurve");
+                        tree.append_attribute(n, curve_id);
+                        tree.append_attribute(n, "\u{0}\u{1}AnimCurve");
+                        tree.append_attribute(n, "");
+
+                        let default = tree.append_new(n, "Default");
+                        tree.append_attribute(default, 0.0_f64);
+
+                        let kver = tree.append_new(n, "KeyVer");
+                        tree.append_attribute(kver, 4008i32);
+
+                        let kt = tree.append_new(n, "KeyTime");
+                        tree.append_attribute(kt, AttributeValue::ArrI64(times));
+
+                        let kv = tree.append_new(n, "KeyValueFloat");
+                        tree.append_attribute(kv, AttributeValue::ArrF32(values));
+
+                        // Per-FBX convention, when every key in the curve
+                        // shares the same flags / data / refcount, the
+                        // arrays carry exactly one entry. Importers
+                        // broadcast that single entry across every key.
+                        let kaf = tree.append_new(n, "KeyAttrFlags");
+                        tree.append_attribute(kaf, AttributeValue::ArrI32(vec![flags]));
+
+                        let kad = tree.append_new(n, "KeyAttrDataFloat");
+                        tree.append_attribute(kad, AttributeValue::ArrF32(vec![0.0; 4]));
+
+                        let krc = tree.append_new(n, "KeyAttrRefCount");
+                        tree.append_attribute(krc, AttributeValue::ArrI32(vec![key_count]));
+                    }),
+                );
+                emit.connect_op(curve_id, curve_node_id, format!("d|{axis_letter}"));
+            }
+        }
+    }
+}

--- a/crates/mogen-export/src/fbx/doc.rs
+++ b/crates/mogen-export/src/fbx/doc.rs
@@ -66,7 +66,7 @@ pub(super) fn build_tree<F: Fn(&str)>(
     let model_ids = super::nodes::emit_models(scene, &mut ids, &mut emit);
 
     // 2. Geometry per (skinned mesh OR per unique non-skinned mesh-key).
-    let mesh_table = super::mesh::emit_geometries(scene, &model_ids, &mut ids, &mut emit);
+    let mesh_table = super::mesh::emit_geometries(scene, &model_ids, &mut ids, &mut emit)?;
 
     // 3. Lights.
     super::light::emit_lights(scene, &model_ids, &mut ids, &mut emit);
@@ -78,12 +78,11 @@ pub(super) fn build_tree<F: Fn(&str)>(
         &mut ids,
         &mut emit,
         opts,
-        texture_source,
     )?;
 
     // 5. Textures + Videos. Only when textures are enabled — the table just
     //    above is empty otherwise.
-    super::texture::emit_textures_and_videos(scene, &texture_indices, &mut ids, &mut emit);
+    super::texture::emit_textures_and_videos(&texture_indices, texture_source, &mut ids, &mut emit)?;
 
     // 6. Skin deformers + clusters.
     super::skin::emit_skins(scene, &model_ids, &mesh_table, &mut ids, &mut emit);
@@ -246,14 +245,17 @@ fn write_global_settings(tree: &mut Tree, root: NodeId) {
         push_prop(t, props, "UpAxis", "int", "Integer", "", AttributeValue::I32(1));
         push_prop(t, props, "UpAxisSign", "int", "Integer", "", AttributeValue::I32(1));
         push_prop(t, props, "FrontAxis", "int", "Integer", "", AttributeValue::I32(2));
-        push_prop(t, props, "FrontAxisSign", "int", "Integer", "", AttributeValue::I32(1));
+        // FrontAxisSign = -1 because we declare -Z forward (CoordAxis=0,
+        // FrontAxis=2). Blender's exporter emits the same value for the
+        // Y-up / -Z-forward / right-handed configuration.
+        push_prop(t, props, "FrontAxisSign", "int", "Integer", "", AttributeValue::I32(-1));
         push_prop(t, props, "CoordAxis", "int", "Integer", "", AttributeValue::I32(0));
         push_prop(t, props, "CoordAxisSign", "int", "Integer", "", AttributeValue::I32(1));
         push_prop(t, props, "OriginalUpAxis", "int", "Integer", "", AttributeValue::I32(1));
         push_prop(t, props, "OriginalUpAxisSign", "int", "Integer", "", AttributeValue::I32(1));
         push_prop(t, props, "UnitScaleFactor", "double", "Number", "", AttributeValue::F64(1.0));
         push_prop(t, props, "OriginalUnitScaleFactor", "double", "Number", "", AttributeValue::F64(1.0));
-        push_prop(t, props, "AmbientColor", "ColorRGB", "Color", "", AttributeValue::F64(0.0));
+        push_prop_vec3(t, props, "AmbientColor", "ColorRGB", "Color", "", [0.0, 0.0, 0.0]);
         push_prop(t, props, "DefaultCamera", "KString", "", "", AttributeValue::String("Producer Perspective".into()));
         push_prop(t, props, "TimeMode", "enum", "", "", AttributeValue::I32(11));
         push_prop(t, props, "TimeProtocol", "enum", "", "", AttributeValue::I32(2));

--- a/crates/mogen-export/src/fbx/doc.rs
+++ b/crates/mogen-export/src/fbx/doc.rs
@@ -1,0 +1,404 @@
+//! Top-level FBX document assembly.
+//!
+//! The FBX 7.4 binary format is a flat tree of named nodes under a synthetic
+//! root. The Blender importer expects, in this order:
+//!
+//! 1. `FBXHeaderExtension` — version + creator + scene info
+//! 2. `GlobalSettings` — axis system, units, frame rate
+//! 3. `Documents` — the top-level Document object
+//! 4. `Definitions` — counts + Property templates per ObjectType
+//! 5. `Objects` — every Geometry / Model / Material / Texture / etc.
+//! 6. `Connections` — graph of `OO` (object-object) and `OP` (object-
+//!    property) edges
+//! 7. `Takes` — animation take metadata; we always emit an empty stub.
+//!
+//! This module owns the scaffolding (#1–#4 and #7) plus the entry point that
+//! delegates each `Objects` section to its sibling module. A single
+//! [`IdAllocator`](super::ids::IdAllocator) hands out object IDs across the
+//! whole pass so connections can refer to anything by id.
+
+use anyhow::Result;
+
+use fbxcel::low::v7400::AttributeValue;
+use fbxcel::tree::v7400::{NodeId, Tree};
+
+use mogen_core::SceneGraph;
+
+use crate::texture::TextureSource;
+use crate::ExportOptions;
+
+use super::ids::IdAllocator;
+
+/// Build the in-memory FBX tree representing `scene`.
+///
+/// The shape this returns is the same regardless of `opts.include_textures`
+/// — texture-related Objects/Connections are simply omitted when textures
+/// are disabled, mirroring the GLB exporter.
+pub(super) fn build_tree<F: Fn(&str)>(
+    scene: &SceneGraph,
+    opts: &ExportOptions,
+    texture_source: &dyn TextureSource,
+    progress: &F,
+) -> Result<Tree> {
+    let mut tree = Tree::default();
+    let root = tree.root().node_id();
+    let mut ids = IdAllocator::new();
+
+    write_header_extension(&mut tree, root);
+    write_global_settings(&mut tree, root);
+    write_documents(&mut tree, root, &mut ids);
+
+    // Plan: we run the object emitters in dependency order, each one
+    // returning the IDs and connection edges it produced. The Definitions
+    // block just needs final counts per type, which we accumulate as we
+    // go and serialise *before* the Objects/Connections nodes.
+    //
+    // To keep the writer single-pass but the emitters self-contained, we
+    // build Objects + Connections into intermediate `Vec`s first, then
+    // commit them to the tree once Definitions is in place.
+
+    let mut emit = ObjectEmitter::new();
+
+    progress("collecting fbx objects");
+
+    // 1. Models for every SceneNode (parents → children, but emission order
+    //    doesn't matter for FBX — connections describe parentage).
+    let model_ids = super::nodes::emit_models(scene, &mut ids, &mut emit);
+
+    // 2. Geometry per (skinned mesh OR per unique non-skinned mesh-key).
+    let mesh_table = super::mesh::emit_geometries(scene, &model_ids, &mut ids, &mut emit);
+
+    // 3. Lights.
+    super::light::emit_lights(scene, &model_ids, &mut ids, &mut emit);
+
+    // 4. Materials.
+    let texture_indices = super::material::emit_materials(
+        scene,
+        &model_ids,
+        &mut ids,
+        &mut emit,
+        opts,
+        texture_source,
+    )?;
+
+    // 5. Textures + Videos. Only when textures are enabled — the table just
+    //    above is empty otherwise.
+    super::texture::emit_textures_and_videos(scene, &texture_indices, &mut ids, &mut emit);
+
+    // 6. Skin deformers + clusters.
+    super::skin::emit_skins(scene, &model_ids, &mesh_table, &mut ids, &mut emit);
+
+    // 7. Animation stacks/layers/curves.
+    if opts.include_animations {
+        super::anim::emit_animations(scene, &model_ids, &mut ids, &mut emit);
+    }
+
+    // Now write Definitions using the accumulated counts, then Objects and
+    // Connections.
+    write_definitions(&mut tree, root, &emit);
+    write_objects(&mut tree, root, emit.objects);
+    write_connections(&mut tree, root, &emit.connections);
+    write_takes(&mut tree, root);
+
+    Ok(tree)
+}
+
+/// Whether a connection is object-object (parent/child) or object-property
+/// (a property slot on the parent).
+#[derive(Debug, Clone, Copy)]
+pub(super) enum ConnKind {
+    /// `;OO`: child is the source, parent is the destination, no property name.
+    ObjectObject,
+    /// `;OP`: child is the source, parent is the destination, property
+    /// identified by `name`.
+    ObjectProperty,
+}
+
+/// One edge in the FBX `Connections` block.
+pub(super) struct Connection {
+    pub kind: ConnKind,
+    pub child_id: i64,
+    pub parent_id: i64,
+    /// Only used when `kind == ObjectProperty`. Empty for `OO`.
+    pub property: String,
+}
+
+/// One Objects-block node we've decided to emit. Each is built up to a
+/// fully-shaped subtree — the doc module just splices them under the
+/// `Objects` parent verbatim. `kind` is what gets counted in Definitions.
+pub(super) struct ObjectNode {
+    /// Object type as it appears in the `Objects` block (and counted in
+    /// Definitions): "Geometry", "Model", "Material", "Texture", "Video",
+    /// "NodeAttribute", "Deformer", "AnimationStack", "AnimationLayer",
+    /// "AnimationCurveNode", "AnimationCurve".
+    pub kind: &'static str,
+    /// Build the subtree under `parent` in `tree`. The emitter is a
+    /// boxed closure so callers can capture whatever owned data they
+    /// need without the trait-object dance forcing `'static` references
+    /// on the scene.
+    pub emit: Box<dyn FnOnce(&mut Tree, NodeId)>,
+}
+
+/// Accumulator the per-object emitters push into. Holds Objects-block
+/// children + Connections-block edges + per-type counts so Definitions can
+/// be sized correctly.
+pub(super) struct ObjectEmitter {
+    pub objects: Vec<ObjectNode>,
+    pub connections: Vec<Connection>,
+}
+
+impl ObjectEmitter {
+    fn new() -> Self {
+        Self {
+            objects: Vec::new(),
+            connections: Vec::new(),
+        }
+    }
+
+    pub fn push_object(&mut self, kind: &'static str, emit: Box<dyn FnOnce(&mut Tree, NodeId)>) {
+        self.objects.push(ObjectNode { kind, emit });
+    }
+
+    pub fn connect_oo(&mut self, child_id: i64, parent_id: i64) {
+        self.connections.push(Connection {
+            kind: ConnKind::ObjectObject,
+            child_id,
+            parent_id,
+            property: String::new(),
+        });
+    }
+
+    pub fn connect_op(&mut self, child_id: i64, parent_id: i64, property: impl Into<String>) {
+        self.connections.push(Connection {
+            kind: ConnKind::ObjectProperty,
+            child_id,
+            parent_id,
+            property: property.into(),
+        });
+    }
+
+    /// Tally objects by `kind` for the Definitions block.
+    fn type_counts(&self) -> Vec<(&'static str, i32)> {
+        use std::collections::BTreeMap;
+        let mut counts: BTreeMap<&'static str, i32> = BTreeMap::new();
+        for obj in &self.objects {
+            *counts.entry(obj.kind).or_insert(0) += 1;
+        }
+        counts.into_iter().collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Section emitters
+// ---------------------------------------------------------------------------
+
+fn write_header_extension(tree: &mut Tree, root: NodeId) {
+    let hdr = tree.append_new(root, "FBXHeaderExtension");
+    let v = tree.append_new(hdr, "FBXHeaderVersion");
+    tree.append_attribute(v, 1003i32);
+    let v = tree.append_new(hdr, "FBXVersion");
+    tree.append_attribute(v, 7400i32);
+    let v = tree.append_new(hdr, "EncryptionType");
+    tree.append_attribute(v, 0i32);
+
+    let creator = tree.append_new(hdr, "Creator");
+    tree.append_attribute(creator, "MoGen FBX exporter");
+
+    // SceneInfo block. Blender's importer reads this for the asset metadata
+    // panel and tolerates a sparse one. We populate enough that
+    // GlobalSettings doesn't end up alone with no document context.
+    let info = tree.append_new(hdr, "SceneInfo");
+    tree.append_attribute(info, "GlobalInfo\u{0}\u{1}SceneInfo");
+    tree.append_attribute(info, "UserData");
+    let ty = tree.append_new(info, "Type");
+    tree.append_attribute(ty, "UserData");
+    let ver = tree.append_new(info, "Version");
+    tree.append_attribute(ver, 100i32);
+    let meta = tree.append_new(info, "MetaData");
+    let meta_v = tree.append_new(meta, "Version");
+    tree.append_attribute(meta_v, 100i32);
+    for (name, val) in [
+        ("Title", ""),
+        ("Subject", ""),
+        ("Author", ""),
+        ("Keywords", ""),
+        ("Revision", ""),
+        ("Comment", ""),
+    ] {
+        let n = tree.append_new(meta, name);
+        tree.append_attribute(n, val);
+    }
+    write_properties70(tree, info, |t, props| {
+        push_prop(t, props, "DocumentUrl", "KString", "Url", "", AttributeValue::String(String::new()));
+        push_prop(t, props, "SrcDocumentUrl", "KString", "Url", "", AttributeValue::String(String::new()));
+        push_prop(t, props, "Original", "Compound", "", "", AttributeValue::String(String::new()));
+        push_prop(t, props, "LastSaved", "Compound", "", "", AttributeValue::String(String::new()));
+    });
+}
+
+fn write_global_settings(tree: &mut Tree, root: NodeId) {
+    let gs = tree.append_new(root, "GlobalSettings");
+    let v = tree.append_new(gs, "Version");
+    tree.append_attribute(v, 1000i32);
+    write_properties70(tree, gs, |t, props| {
+        // Y-up, right-handed, -Z forward, meters. Matches glTF and the
+        // codebase's de-facto convention.
+        push_prop(t, props, "UpAxis", "int", "Integer", "", AttributeValue::I32(1));
+        push_prop(t, props, "UpAxisSign", "int", "Integer", "", AttributeValue::I32(1));
+        push_prop(t, props, "FrontAxis", "int", "Integer", "", AttributeValue::I32(2));
+        push_prop(t, props, "FrontAxisSign", "int", "Integer", "", AttributeValue::I32(1));
+        push_prop(t, props, "CoordAxis", "int", "Integer", "", AttributeValue::I32(0));
+        push_prop(t, props, "CoordAxisSign", "int", "Integer", "", AttributeValue::I32(1));
+        push_prop(t, props, "OriginalUpAxis", "int", "Integer", "", AttributeValue::I32(1));
+        push_prop(t, props, "OriginalUpAxisSign", "int", "Integer", "", AttributeValue::I32(1));
+        push_prop(t, props, "UnitScaleFactor", "double", "Number", "", AttributeValue::F64(1.0));
+        push_prop(t, props, "OriginalUnitScaleFactor", "double", "Number", "", AttributeValue::F64(1.0));
+        push_prop(t, props, "AmbientColor", "ColorRGB", "Color", "", AttributeValue::F64(0.0));
+        push_prop(t, props, "DefaultCamera", "KString", "", "", AttributeValue::String("Producer Perspective".into()));
+        push_prop(t, props, "TimeMode", "enum", "", "", AttributeValue::I32(11));
+        push_prop(t, props, "TimeProtocol", "enum", "", "", AttributeValue::I32(2));
+        push_prop(t, props, "SnapOnFrameMode", "enum", "", "", AttributeValue::I32(0));
+        push_prop(t, props, "TimeSpanStart", "KTime", "Time", "", AttributeValue::I64(0));
+        push_prop(t, props, "TimeSpanStop", "KTime", "Time", "", AttributeValue::I64(super::anim::FBX_TICKS_PER_SECOND));
+        push_prop(t, props, "CustomFrameRate", "double", "Number", "", AttributeValue::F64(30.0));
+        push_prop(t, props, "TimeMarker", "Compound", "", "", AttributeValue::String(String::new()));
+        push_prop(t, props, "CurrentTimeMarker", "int", "Integer", "", AttributeValue::I32(-1));
+    });
+}
+
+fn write_documents(tree: &mut Tree, root: NodeId, ids: &mut IdAllocator) {
+    let docs = tree.append_new(root, "Documents");
+    let count = tree.append_new(docs, "Count");
+    tree.append_attribute(count, 1i32);
+
+    let document_id = ids.alloc();
+    let doc = tree.append_new(docs, "Document");
+    tree.append_attribute(doc, document_id);
+    tree.append_attribute(doc, "Scene\u{0}\u{1}Document");
+    tree.append_attribute(doc, "Scene");
+    write_properties70(tree, doc, |t, props| {
+        push_prop(t, props, "SourceObject", "object", "", "", AttributeValue::String(String::new()));
+        push_prop(t, props, "ActiveAnimStackName", "KString", "", "", AttributeValue::String(String::new()));
+    });
+    let root_node = tree.append_new(doc, "RootNode");
+    tree.append_attribute(root_node, 0i64);
+}
+
+fn write_definitions(tree: &mut Tree, root: NodeId, emit: &ObjectEmitter) {
+    let defs = tree.append_new(root, "Definitions");
+    let v = tree.append_new(defs, "Version");
+    tree.append_attribute(v, 100i32);
+
+    let counts = emit.type_counts();
+    // +1 for the implicit GlobalSettings ObjectType, which we always count
+    // even though it's not in the Objects block — Blender's importer is
+    // tolerant of mismatches but treats it as the canonical answer.
+    let total: i32 = counts.iter().map(|(_, c)| c).sum::<i32>() + 1;
+    let total_node = tree.append_new(defs, "Count");
+    tree.append_attribute(total_node, total);
+
+    // GlobalSettings ObjectType always present.
+    let ot = tree.append_new(defs, "ObjectType");
+    tree.append_attribute(ot, "GlobalSettings");
+    let c = tree.append_new(ot, "Count");
+    tree.append_attribute(c, 1i32);
+
+    for (kind, count) in counts {
+        let ot = tree.append_new(defs, "ObjectType");
+        tree.append_attribute(ot, kind);
+        let c = tree.append_new(ot, "Count");
+        tree.append_attribute(c, count);
+        // We deliberately omit PropertyTemplate per type. Blender tolerates
+        // its absence; our object emitters spell out every Properties70
+        // entry inline so the importer never needs to consult a template.
+    }
+}
+
+fn write_objects(tree: &mut Tree, root: NodeId, objects: Vec<ObjectNode>) {
+    let parent = tree.append_new(root, "Objects");
+    for obj in objects {
+        (obj.emit)(tree, parent);
+    }
+}
+
+fn write_connections(tree: &mut Tree, root: NodeId, edges: &[Connection]) {
+    let parent = tree.append_new(root, "Connections");
+    for edge in edges {
+        let c = tree.append_new(parent, "C");
+        match edge.kind {
+            ConnKind::ObjectObject => {
+                tree.append_attribute(c, "OO");
+                tree.append_attribute(c, edge.child_id);
+                tree.append_attribute(c, edge.parent_id);
+            }
+            ConnKind::ObjectProperty => {
+                tree.append_attribute(c, "OP");
+                tree.append_attribute(c, edge.child_id);
+                tree.append_attribute(c, edge.parent_id);
+                tree.append_attribute(c, edge.property.clone());
+            }
+        }
+    }
+}
+
+fn write_takes(tree: &mut Tree, root: NodeId) {
+    let takes = tree.append_new(root, "Takes");
+    let cur = tree.append_new(takes, "Current");
+    tree.append_attribute(cur, "");
+}
+
+// ---------------------------------------------------------------------------
+// Properties70 helpers
+// ---------------------------------------------------------------------------
+
+/// Build a `Properties70` child under `parent` and pass it to `body` so the
+/// caller can push individual `P` rows. Matches the FBX convention that
+/// every property block lives under a `Properties70` wrapper.
+pub(super) fn write_properties70<F>(tree: &mut Tree, parent: NodeId, body: F)
+where
+    F: FnOnce(&mut Tree, NodeId),
+{
+    let props = tree.append_new(parent, "Properties70");
+    body(tree, props);
+}
+
+/// Append one `P` (property) row. Layout: `name | type | secondary_type | flags | value...`.
+/// Numeric properties (Vector3D, Color, Number, etc.) take three or one
+/// f64 values. We expose the value as a single `AttributeValue` for
+/// scalar/string props; vector helpers below handle the multi-value case.
+pub(super) fn push_prop(
+    tree: &mut Tree,
+    props: NodeId,
+    name: &str,
+    ty: &str,
+    secondary: &str,
+    flags: &str,
+    value: AttributeValue,
+) {
+    let p = tree.append_new(props, "P");
+    tree.append_attribute(p, name);
+    tree.append_attribute(p, ty);
+    tree.append_attribute(p, secondary);
+    tree.append_attribute(p, flags);
+    tree.append_attribute(p, value);
+}
+
+/// 3-component f64 property (Vector3D, Color, ColorRGB, Lcl Translation/Rotation/Scaling).
+pub(super) fn push_prop_vec3(
+    tree: &mut Tree,
+    props: NodeId,
+    name: &str,
+    ty: &str,
+    secondary: &str,
+    flags: &str,
+    value: [f64; 3],
+) {
+    let p = tree.append_new(props, "P");
+    tree.append_attribute(p, name);
+    tree.append_attribute(p, ty);
+    tree.append_attribute(p, secondary);
+    tree.append_attribute(p, flags);
+    tree.append_attribute(p, value[0]);
+    tree.append_attribute(p, value[1]);
+    tree.append_attribute(p, value[2]);
+}

--- a/crates/mogen-export/src/fbx/ids.rs
+++ b/crates/mogen-export/src/fbx/ids.rs
@@ -1,0 +1,29 @@
+//! FBX object-ID allocator. Object IDs are 64-bit integers, unique per file.
+//!
+//! ID `0` is reserved for the implicit `RootNode` referenced by every
+//! Documents block, so the allocator starts above it. We don't try to be
+//! globally unique across files — a fresh allocator is built per export.
+
+/// Sequential i64 dispenser for FBX object IDs.
+pub(super) struct IdAllocator {
+    next: i64,
+}
+
+impl IdAllocator {
+    pub fn new() -> Self {
+        // Start at a comfortable offset so IDs don't visually collide with
+        // the well-known `RootNode = 0` and any small constants that crop
+        // up in inspectors. Picked to match what the official Autodesk
+        // exporter emits — Blender's importer doesn't care about the
+        // value, but matching it makes diffs against reference files
+        // easier to read.
+        Self { next: 1_000_000_000 }
+    }
+
+    /// Allocate the next unused ID.
+    pub fn alloc(&mut self) -> i64 {
+        let id = self.next;
+        self.next += 1;
+        id
+    }
+}

--- a/crates/mogen-export/src/fbx/light.rs
+++ b/crates/mogen-export/src/fbx/light.rs
@@ -1,0 +1,127 @@
+//! `Light` → `NodeAttribute` (subclass `Light`) emission.
+//!
+//! FBX represents lights as a `Model` (the transform carrier) plus a
+//! `NodeAttribute` of subclass `Light` connected via OO. The Model is
+//! already emitted by `nodes.rs`; this module owns the NodeAttribute and
+//! the OO connection that links it.
+//!
+//! Lossy mappings flagged in the plan: glTF `KHR_lights_punctual` uses
+//! candela (point/spot) vs lux (directional) for `intensity`. FBX has no
+//! such distinction — the value passes through unchanged into the FBX
+//! `Intensity` property and is the renderer's problem to interpret.
+
+use fbxcel::low::v7400::AttributeValue;
+
+use mogen_core::{LightKind, SceneGraph};
+
+use super::doc::{push_prop, push_prop_vec3, write_properties70, ObjectEmitter};
+use super::ids::IdAllocator;
+
+pub(super) fn emit_lights(
+    scene: &SceneGraph,
+    model_ids: &[i64],
+    ids: &mut IdAllocator,
+    emit: &mut ObjectEmitter,
+) {
+    for (i, n) in scene.nodes.iter().enumerate() {
+        let light = match &n.light {
+            Some(l) => l,
+            None => continue,
+        };
+        let model_id = model_ids[i];
+        let attr_id = ids.alloc();
+
+        // Snapshot owned data into the closure.
+        let name = n.name.clone();
+        let light_type: i32 = match light.kind {
+            LightKind::Point => 0,
+            LightKind::Directional => 1,
+            LightKind::Spot => 2,
+        };
+        let color: [f64; 3] = [
+            light.color[0] as f64,
+            light.color[1] as f64,
+            light.color[2] as f64,
+        ];
+        let intensity = light.intensity as f64;
+        let range = light.range.map(|r| r as f64);
+        let inner_deg = light.inner_cone_rad.to_degrees() as f64;
+        let outer_deg = light.outer_cone_rad.to_degrees() as f64;
+        let kind = light.kind;
+
+        emit.push_object(
+            "NodeAttribute",
+            Box::new(move |tree, parent| {
+                let na = tree.append_new(parent, "NodeAttribute");
+                tree.append_attribute(na, attr_id);
+                tree.append_attribute(na, format!("{name}\u{0}\u{1}NodeAttribute"));
+                tree.append_attribute(na, "Light");
+
+                // The TypeFlags string distinguishes Light/Camera/etc when
+                // a NodeAttribute could be ambiguous from its subclass.
+                let tf = tree.append_new(na, "TypeFlags");
+                tree.append_attribute(tf, "Light");
+
+                write_properties70(tree, na, |t, props| {
+                    push_prop(t, props, "LightType", "enum", "", "", AttributeValue::I32(light_type));
+                    push_prop(t, props, "CastLight", "bool", "", "", AttributeValue::I32(1));
+                    push_prop_vec3(t, props, "Color", "Color", "", "A", color);
+                    push_prop(t, props, "Intensity", "Number", "", "A", AttributeValue::F64(intensity));
+                    if matches!(kind, LightKind::Point | LightKind::Spot) {
+                        if let Some(r) = range {
+                            push_prop(
+                                t,
+                                props,
+                                "FarAttenuationStart",
+                                "Number",
+                                "",
+                                "A",
+                                AttributeValue::F64(r * 0.5),
+                            );
+                            push_prop(
+                                t,
+                                props,
+                                "FarAttenuationEnd",
+                                "Number",
+                                "",
+                                "A",
+                                AttributeValue::F64(r),
+                            );
+                            push_prop(
+                                t,
+                                props,
+                                "EnableFarAttenuation",
+                                "bool",
+                                "",
+                                "",
+                                AttributeValue::I32(1),
+                            );
+                        }
+                    }
+                    if matches!(kind, LightKind::Spot) {
+                        push_prop(
+                            t,
+                            props,
+                            "InnerAngle",
+                            "Number",
+                            "",
+                            "A",
+                            AttributeValue::F64(inner_deg),
+                        );
+                        push_prop(
+                            t,
+                            props,
+                            "OuterAngle",
+                            "Number",
+                            "",
+                            "A",
+                            AttributeValue::F64(outer_deg),
+                        );
+                    }
+                });
+            }),
+        );
+
+        emit.connect_oo(attr_id, model_id);
+    }
+}

--- a/crates/mogen-export/src/fbx/material.rs
+++ b/crates/mogen-export/src/fbx/material.rs
@@ -29,7 +29,6 @@ use mogen_core::{AlphaMode, Material, SceneGraph, UvMode};
 
 use super::doc::{push_prop, push_prop_vec3, write_properties70, ObjectEmitter};
 use super::ids::IdAllocator;
-use crate::texture::TextureSource;
 use crate::ExportOptions;
 
 /// FBX `Texture` slot names used for OP-connection from a Texture object
@@ -67,31 +66,26 @@ pub(super) struct MaterialTexturePaths {
 
 pub(super) fn emit_materials(
     scene: &SceneGraph,
-    _model_ids: &[i64],
+    model_ids: &[i64],
     ids: &mut IdAllocator,
     emit: &mut ObjectEmitter,
     opts: &ExportOptions,
-    _texture_source: &dyn TextureSource,
 ) -> Result<TextureIndices> {
     let mut material_ids: Vec<i64> = Vec::with_capacity(scene.materials.len());
     let mut texture_paths: Vec<MaterialTexturePaths> = Vec::with_capacity(scene.materials.len());
 
-    // Reverse the material→models map produced by `mesh::emit_geometries`.
-    // We need it from the freshly-built emitter, so re-scan instead — the
-    // mesh table is private to that module's return value, threaded
-    // through doc::build_tree. To keep this module independent of mesh's
-    // table we re-derive the binding here.
+    // Reverse-derive the material→models binding by re-walking
+    // the scene. We only need it for the OO connection from each
+    // Material to every Model that referenced it; doing this here
+    // keeps the material module independent of `MeshTable`.
     let mut material_to_models: HashMap<u32, Vec<i64>> = HashMap::new();
     {
-        // Re-allocate model ids? No — the doc-level orchestrator owns
-        // them. We instead let the doc orchestrator pass them in
-        // implicitly by walking the scene with `_model_ids`.
         for (i, n) in scene.nodes.iter().enumerate() {
             if let (Some(mat), Some(_mesh)) = (n.material, n.mesh.as_ref()) {
                 material_to_models
                     .entry(mat.0)
                     .or_default()
-                    .push(_model_ids[i]);
+                    .push(model_ids[i]);
             }
         }
     }
@@ -206,8 +200,12 @@ impl From<&Material> for MaterialSnapshot {
 impl MaterialSnapshot {
     fn emit_properties(&self, tree: &mut fbxcel::tree::v7400::Tree, parent: fbxcel::tree::v7400::NodeId) {
         write_properties70(tree, parent, |t, props| {
-            // Phong-approximated PBR. Diffuse colour gets the RGB; alpha
-            // rides on `DiffuseFactor`. Specular is left at the FBX
+            // Phong-approximated PBR. Diffuse colour gets the RGB.
+            // `DiffuseFactor` stays at 1.0 (the FBX default — it scales
+            // DiffuseColor brightness, not opacity). Alpha rides on
+            // `TransparencyFactor` (FBX convention: 0 = opaque,
+            // 1 = fully transparent), so an alpha of 1.0 produces a
+            // transparency factor of 0.0. Specular is left at the FBX
             // default `(0.2, 0.2, 0.2)` because Phong specular is
             // perceptually orthogonal to PBR roughness.
             push_prop_vec3(
@@ -226,7 +224,16 @@ impl MaterialSnapshot {
                 "Number",
                 "",
                 "A",
-                AttributeValue::F64(self.base_color[3] as f64),
+                AttributeValue::F64(1.0),
+            );
+            push_prop(
+                t,
+                props,
+                "TransparencyFactor",
+                "Number",
+                "",
+                "A",
+                AttributeValue::F64((1.0 - self.base_color[3]).clamp(0.0, 1.0) as f64),
             );
             push_prop_vec3(
                 t,

--- a/crates/mogen-export/src/fbx/material.rs
+++ b/crates/mogen-export/src/fbx/material.rs
@@ -1,0 +1,363 @@
+//! Material emission — produces one FBX `Material` Object per
+//! `mogen_core::Material`, connected via OO to every `Model` that uses it
+//! (FBX binds materials to Models, not Geometries).
+//!
+//! Lossy mappings flagged in the plan:
+//!
+//! - PBR `metallic` / `roughness` get a Phong approximation in
+//!   `ShininessExponent`. The raw values are also emitted as `Roughness`
+//!   and `Metallic` custom Properties70 entries so importers that look
+//!   for them (Blender's principled BSDF importer does) can recover the
+//!   PBR values.
+//! - DSL-only material extras (`alpha_mode`, `transmission`,
+//!   `normal_strength`, `occlusion_strength`, `double_sided`, `uv_mode`,
+//!   `uv_scale`) are emitted as Properties70 custom props.
+//!
+//! Texture connections (the second half of "this material uses image X")
+//! are handed off to `texture.rs` via the returned `TextureIndices` map —
+//! we hold onto each texture-bearing material's id so the texture module
+//! knows where to OP-connect every `Texture` to.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+use fbxcel::low::v7400::AttributeValue;
+
+use mogen_core::{AlphaMode, Material, SceneGraph, UvMode};
+
+use super::doc::{push_prop, push_prop_vec3, write_properties70, ObjectEmitter};
+use super::ids::IdAllocator;
+use crate::texture::TextureSource;
+use crate::ExportOptions;
+
+/// FBX `Texture` slot names used for OP-connection from a Texture object
+/// to a Material. Drives the property-name on the texture-side connection
+/// so importers know what slot the image fills on the destination
+/// material.
+pub(super) const SLOT_BASE_COLOR: &str = "DiffuseColor";
+pub(super) const SLOT_NORMAL: &str = "NormalMap";
+pub(super) const SLOT_EMISSIVE: &str = "EmissiveColor";
+pub(super) const SLOT_OCCLUSION: &str = "AmbientColor";
+/// FBX Phong has no metallic-roughness slot. We expose it as a custom
+/// property name; importers that recognise "MetallicRoughnessTexture"
+/// (Blender's principled BSDF FBX importer does) pick it up there.
+pub(super) const SLOT_METALLIC_ROUGHNESS: &str = "MetallicRoughnessTexture";
+
+/// Materials emit owns the bookkeeping the texture module needs to wire
+/// each on-disk image onto the right Material slot. Index by
+/// `MaterialId.0`.
+pub(super) struct TextureIndices {
+    pub material_ids: Vec<i64>,
+    pub texture_paths: Vec<MaterialTexturePaths>,
+}
+
+/// Per-material captured texture paths. Empty `Option`s mean the slot was
+/// not authored. We keep the `PathBuf`s here (not `TextureRef`s) so the
+/// texture module can use them as cache keys directly.
+#[derive(Clone, Default)]
+pub(super) struct MaterialTexturePaths {
+    pub base_color: Option<PathBuf>,
+    pub normal: Option<PathBuf>,
+    pub emissive: Option<PathBuf>,
+    pub occlusion: Option<PathBuf>,
+    pub metallic_roughness: Option<PathBuf>,
+}
+
+pub(super) fn emit_materials(
+    scene: &SceneGraph,
+    _model_ids: &[i64],
+    ids: &mut IdAllocator,
+    emit: &mut ObjectEmitter,
+    opts: &ExportOptions,
+    _texture_source: &dyn TextureSource,
+) -> Result<TextureIndices> {
+    let mut material_ids: Vec<i64> = Vec::with_capacity(scene.materials.len());
+    let mut texture_paths: Vec<MaterialTexturePaths> = Vec::with_capacity(scene.materials.len());
+
+    // Reverse the material→models map produced by `mesh::emit_geometries`.
+    // We need it from the freshly-built emitter, so re-scan instead — the
+    // mesh table is private to that module's return value, threaded
+    // through doc::build_tree. To keep this module independent of mesh's
+    // table we re-derive the binding here.
+    let mut material_to_models: HashMap<u32, Vec<i64>> = HashMap::new();
+    {
+        // Re-allocate model ids? No — the doc-level orchestrator owns
+        // them. We instead let the doc orchestrator pass them in
+        // implicitly by walking the scene with `_model_ids`.
+        for (i, n) in scene.nodes.iter().enumerate() {
+            if let (Some(mat), Some(_mesh)) = (n.material, n.mesh.as_ref()) {
+                material_to_models
+                    .entry(mat.0)
+                    .or_default()
+                    .push(_model_ids[i]);
+            }
+        }
+    }
+
+    for (mat_idx, mat) in scene.materials.iter().enumerate() {
+        let mat_id = ids.alloc();
+        material_ids.push(mat_id);
+
+        let paths = MaterialTexturePaths {
+            base_color: opts
+                .include_textures
+                .then(|| mat.base_color_texture.as_ref().map(|t| t.path.clone()))
+                .flatten(),
+            normal: opts
+                .include_textures
+                .then(|| mat.normal_texture.as_ref().map(|t| t.path.clone()))
+                .flatten(),
+            emissive: opts
+                .include_textures
+                .then(|| mat.emissive_texture.as_ref().map(|t| t.path.clone()))
+                .flatten(),
+            occlusion: opts
+                .include_textures
+                .then(|| mat.occlusion_texture.as_ref().map(|t| t.path.clone()))
+                .flatten(),
+            metallic_roughness: opts
+                .include_textures
+                .then(|| mat.metallic_roughness_texture.as_ref().map(|t| t.path.clone()))
+                .flatten(),
+        };
+        texture_paths.push(paths);
+
+        let snapshot = MaterialSnapshot::from(mat);
+        emit.push_object(
+            "Material",
+            Box::new(move |tree, parent| {
+                let m = tree.append_new(parent, "Material");
+                tree.append_attribute(m, mat_id);
+                tree.append_attribute(m, format!("{}\u{0}\u{1}Material", snapshot.name));
+                tree.append_attribute(m, "");
+
+                let v = tree.append_new(m, "Version");
+                tree.append_attribute(v, 102i32);
+
+                let shading_model = tree.append_new(m, "ShadingModel");
+                tree.append_attribute(shading_model, "Phong");
+
+                let multi = tree.append_new(m, "MultiLayer");
+                tree.append_attribute(multi, 0i32);
+
+                snapshot.emit_properties(tree, m);
+            }),
+        );
+
+        // Connect this Material to every Model that referenced it via
+        // mesh.material. FBX consumers expect material connections at
+        // Model level — Geometry-side material binds aren't part of the
+        // 7.4 surface area.
+        if let Some(models) = material_to_models.get(&(mat_idx as u32)) {
+            for model_id in models {
+                emit.connect_oo(mat_id, *model_id);
+            }
+        }
+    }
+
+    Ok(TextureIndices {
+        material_ids,
+        texture_paths,
+    })
+}
+
+/// Owned snapshot of a material's scalar fields so the emit closure does
+/// not need to capture a borrow of the scene.
+struct MaterialSnapshot {
+    name: String,
+    base_color: [f32; 4],
+    metallic: f32,
+    roughness: f32,
+    emissive: [f32; 3],
+    emissive_strength: f32,
+    transmission: f32,
+    normal_strength: f32,
+    occlusion_strength: f32,
+    alpha_mode: AlphaMode,
+    alpha_cutoff: f32,
+    double_sided: bool,
+    uv_mode: UvMode,
+    uv_scale: [f32; 2],
+}
+
+impl From<&Material> for MaterialSnapshot {
+    fn from(m: &Material) -> Self {
+        Self {
+            name: m.name.clone(),
+            base_color: m.base_color,
+            metallic: m.metallic,
+            roughness: m.roughness,
+            emissive: m.emissive,
+            emissive_strength: m.emissive_strength,
+            transmission: m.transmission,
+            normal_strength: m.normal_strength,
+            occlusion_strength: m.occlusion_strength,
+            alpha_mode: m.alpha_mode,
+            alpha_cutoff: m.alpha_cutoff,
+            double_sided: m.double_sided,
+            uv_mode: m.uv_mode,
+            uv_scale: m.uv_scale,
+        }
+    }
+}
+
+impl MaterialSnapshot {
+    fn emit_properties(&self, tree: &mut fbxcel::tree::v7400::Tree, parent: fbxcel::tree::v7400::NodeId) {
+        write_properties70(tree, parent, |t, props| {
+            // Phong-approximated PBR. Diffuse colour gets the RGB; alpha
+            // rides on `DiffuseFactor`. Specular is left at the FBX
+            // default `(0.2, 0.2, 0.2)` because Phong specular is
+            // perceptually orthogonal to PBR roughness.
+            push_prop_vec3(
+                t,
+                props,
+                "DiffuseColor",
+                "Color",
+                "",
+                "A",
+                [self.base_color[0] as f64, self.base_color[1] as f64, self.base_color[2] as f64],
+            );
+            push_prop(
+                t,
+                props,
+                "DiffuseFactor",
+                "Number",
+                "",
+                "A",
+                AttributeValue::F64(self.base_color[3] as f64),
+            );
+            push_prop_vec3(
+                t,
+                props,
+                "EmissiveColor",
+                "Color",
+                "",
+                "A",
+                [self.emissive[0] as f64, self.emissive[1] as f64, self.emissive[2] as f64],
+            );
+            push_prop(
+                t,
+                props,
+                "EmissiveFactor",
+                "Number",
+                "",
+                "A",
+                AttributeValue::F64(self.emissive_strength as f64),
+            );
+            // Phong shininess approximation: `(1 - roughness) * 128`.
+            // Picked to match the inverse remap most importers do when
+            // they harvest a roughness value from a Phong material.
+            push_prop(
+                t,
+                props,
+                "ShininessExponent",
+                "Number",
+                "",
+                "A",
+                AttributeValue::F64(((1.0 - self.roughness as f64) * 128.0).max(0.0)),
+            );
+
+            // Raw PBR factors as custom props so an importer with a PBR
+            // path can recover the originals losslessly.
+            push_prop(
+                t,
+                props,
+                "Roughness",
+                "Number",
+                "",
+                "A",
+                AttributeValue::F64(self.roughness as f64),
+            );
+            push_prop(
+                t,
+                props,
+                "Metallic",
+                "Number",
+                "",
+                "A",
+                AttributeValue::F64(self.metallic as f64),
+            );
+            push_prop(
+                t,
+                props,
+                "Transmission",
+                "Number",
+                "",
+                "A",
+                AttributeValue::F64(self.transmission as f64),
+            );
+            push_prop(
+                t,
+                props,
+                "NormalStrength",
+                "Number",
+                "",
+                "A",
+                AttributeValue::F64(self.normal_strength as f64),
+            );
+            push_prop(
+                t,
+                props,
+                "OcclusionStrength",
+                "Number",
+                "",
+                "A",
+                AttributeValue::F64(self.occlusion_strength as f64),
+            );
+            push_prop(
+                t,
+                props,
+                "AlphaMode",
+                "KString",
+                "",
+                "U",
+                AttributeValue::String(
+                    match self.alpha_mode {
+                        AlphaMode::Opaque => "OPAQUE",
+                        AlphaMode::Mask => "MASK",
+                        AlphaMode::Blend => "BLEND",
+                    }
+                    .to_string(),
+                ),
+            );
+            push_prop(
+                t,
+                props,
+                "AlphaCutoff",
+                "Number",
+                "",
+                "A",
+                AttributeValue::F64(self.alpha_cutoff as f64),
+            );
+            if self.double_sided {
+                push_prop(t, props, "DoubleSided", "bool", "", "", AttributeValue::I32(1));
+            }
+            push_prop(
+                t,
+                props,
+                "UvMode",
+                "KString",
+                "",
+                "U",
+                AttributeValue::String(
+                    match self.uv_mode {
+                        UvMode::Tile => "TILE",
+                        UvMode::Fit => "FIT",
+                    }
+                    .to_string(),
+                ),
+            );
+            push_prop_vec3(
+                t,
+                props,
+                "UvScale",
+                "Vector3D",
+                "Vector",
+                "U",
+                [self.uv_scale[0] as f64, self.uv_scale[1] as f64, 0.0],
+            );
+        });
+    }
+}

--- a/crates/mogen-export/src/fbx/mesh.rs
+++ b/crates/mogen-export/src/fbx/mesh.rs
@@ -1,0 +1,169 @@
+//! `Mesh` → `Geometry` Object emission.
+//!
+//! Each `SceneNode` that carries a mesh produces one `Geometry` object in
+//! the FBX `Objects` block, connected via OO to its owning `Model`. We do
+//! not deduplicate on a (positions, indices, material) key here the way
+//! the GLB exporter does — FBX skinning attaches `Deformer` Clusters by
+//! Geometry id, so sharing a Geometry between two skinned-mesh nodes
+//! would silently cross-wire their deformations. Sharing for non-skinned
+//! meshes is a future optimisation; for now the tree carries one Geometry
+//! per mesh-bearing node, matching what the official Autodesk exporter
+//! produces.
+//!
+//! Triangle list encoding: FBX `PolygonVertexIndex` is a single i32 array
+//! that runs every polygon's vertex ids back-to-back. Polygons end at the
+//! last entry, which the spec marks by negate-and-decrement (`!idx`,
+//! equivalent to `-(idx + 1)` in two's complement). For triangle lists
+//! that means every third index has the high bit set.
+
+
+use fbxcel::low::v7400::AttributeValue;
+
+use mogen_core::SceneGraph;
+
+use super::doc::ObjectEmitter;
+use super::ids::IdAllocator;
+
+/// Per-`SceneNode` Geometry object id, or `None` when the node has no mesh.
+/// Index-aligned with `scene.nodes`. Skin and material connections look
+/// up Geometry ids through this table.
+pub(super) struct MeshTable {
+    pub geometry_id_for_node: Vec<Option<i64>>,
+}
+
+pub(super) fn emit_geometries(
+    scene: &SceneGraph,
+    model_ids: &[i64],
+    ids: &mut IdAllocator,
+    emit: &mut ObjectEmitter,
+) -> MeshTable {
+    let mut geometry_id_for_node: Vec<Option<i64>> = vec![None; scene.nodes.len()];
+
+    for (i, n) in scene.nodes.iter().enumerate() {
+        let mesh = match &n.mesh {
+            Some(m) => m,
+            None => continue,
+        };
+        let model_id = model_ids[i];
+        let geom_id = ids.alloc();
+        geometry_id_for_node[i] = Some(geom_id);
+
+
+        // Convert positions / normals / indices / uvs into FBX-friendly
+        // owned buffers up front, then move them into the closure.
+        let vertices: Vec<f64> = mesh
+            .positions
+            .iter()
+            .flat_map(|p| [p[0] as f64, p[1] as f64, p[2] as f64])
+            .collect();
+
+        // `PolygonVertexIndex` runs per-polygon, with the last index of
+        // each polygon negate-and-decremented. For our triangle lists
+        // that means every third entry.
+        let mut polygon_vertex_index: Vec<i32> = Vec::with_capacity(mesh.indices.len());
+        for tri in mesh.indices.chunks_exact(3) {
+            let a = tri[0] as i32;
+            let b = tri[1] as i32;
+            let c = tri[2] as i32;
+            polygon_vertex_index.push(a);
+            polygon_vertex_index.push(b);
+            // `!c` in two's complement equals `-(c + 1)`.
+            polygon_vertex_index.push(!c);
+        }
+
+        let normals: Vec<f64> = mesh
+            .normals
+            .iter()
+            .flat_map(|n| [n[0] as f64, n[1] as f64, n[2] as f64])
+            .collect();
+
+        // UV layer is optional — empty `uvs` skips the LayerElementUV
+        // emission entirely. Note this passes the raw UVs through; the
+        // `uv_scale` material multiplier is *not* applied here, matching
+        // the FBX convention that material UV transforms live on the
+        // material, not baked into vertex data. The GLB exporter bakes it
+        // because glTF's KHR_texture_transform support is uneven.
+        let uvs: Vec<f64> = mesh
+            .uvs
+            .iter()
+            .flat_map(|uv| [uv[0] as f64, uv[1] as f64])
+            .collect();
+        let has_uvs = !uvs.is_empty();
+
+        let geom_name = n.name.clone();
+
+        emit.push_object(
+            "Geometry",
+            Box::new(move |tree, parent| {
+                let g = tree.append_new(parent, "Geometry");
+                tree.append_attribute(g, geom_id);
+                tree.append_attribute(g, format!("{geom_name}\u{0}\u{1}Geometry"));
+                tree.append_attribute(g, "Mesh");
+
+                let gver = tree.append_new(g, "GeometryVersion");
+                tree.append_attribute(gver, 124i32);
+
+                let v = tree.append_new(g, "Vertices");
+                tree.append_attribute(v, AttributeValue::ArrF64(vertices));
+
+                let pvi = tree.append_new(g, "PolygonVertexIndex");
+                tree.append_attribute(pvi, AttributeValue::ArrI32(polygon_vertex_index));
+
+                // LayerElementNormal — direct mapping, one normal per
+                // vertex. Matches our Mesh storage exactly.
+                let lne = tree.append_new(g, "LayerElementNormal");
+                tree.append_attribute(lne, 0i32);
+                let v = tree.append_new(lne, "Version");
+                tree.append_attribute(v, 102i32);
+                let n = tree.append_new(lne, "Name");
+                tree.append_attribute(n, "");
+                let mit = tree.append_new(lne, "MappingInformationType");
+                tree.append_attribute(mit, "ByVertice");
+                let rit = tree.append_new(lne, "ReferenceInformationType");
+                tree.append_attribute(rit, "Direct");
+                let nrm = tree.append_new(lne, "Normals");
+                tree.append_attribute(nrm, AttributeValue::ArrF64(normals));
+
+                if has_uvs {
+                    let leu = tree.append_new(g, "LayerElementUV");
+                    tree.append_attribute(leu, 0i32);
+                    let v = tree.append_new(leu, "Version");
+                    tree.append_attribute(v, 101i32);
+                    let n = tree.append_new(leu, "Name");
+                    tree.append_attribute(n, "UVMap");
+                    let mit = tree.append_new(leu, "MappingInformationType");
+                    tree.append_attribute(mit, "ByVertice");
+                    let rit = tree.append_new(leu, "ReferenceInformationType");
+                    tree.append_attribute(rit, "Direct");
+                    let uv = tree.append_new(leu, "UV");
+                    tree.append_attribute(uv, AttributeValue::ArrF64(uvs));
+                }
+
+                // Layer descriptor that wires the Normal/UV layers we just
+                // emitted into the renderer's expected slot indices.
+                let layer = tree.append_new(g, "Layer");
+                tree.append_attribute(layer, 0i32);
+                let lver = tree.append_new(layer, "Version");
+                tree.append_attribute(lver, 100i32);
+                let le_n = tree.append_new(layer, "LayerElement");
+                let n_type = tree.append_new(le_n, "Type");
+                tree.append_attribute(n_type, "LayerElementNormal");
+                let n_idx = tree.append_new(le_n, "TypedIndex");
+                tree.append_attribute(n_idx, 0i32);
+                if has_uvs {
+                    let le_u = tree.append_new(layer, "LayerElement");
+                    let u_type = tree.append_new(le_u, "Type");
+                    tree.append_attribute(u_type, "LayerElementUV");
+                    let u_idx = tree.append_new(le_u, "TypedIndex");
+                    tree.append_attribute(u_idx, 0i32);
+                }
+            }),
+        );
+
+        emit.connect_oo(geom_id, model_id);
+    }
+
+    MeshTable {
+        geometry_id_for_node,
+    }
+}

--- a/crates/mogen-export/src/fbx/mesh.rs
+++ b/crates/mogen-export/src/fbx/mesh.rs
@@ -36,7 +36,7 @@ pub(super) fn emit_geometries(
     model_ids: &[i64],
     ids: &mut IdAllocator,
     emit: &mut ObjectEmitter,
-) -> MeshTable {
+) -> anyhow::Result<MeshTable> {
     let mut geometry_id_for_node: Vec<Option<i64>> = vec![None; scene.nodes.len()];
 
     for (i, n) in scene.nodes.iter().enumerate() {
@@ -58,10 +58,26 @@ pub(super) fn emit_geometries(
             .collect();
 
         // `PolygonVertexIndex` runs per-polygon, with the last index of
-        // each polygon negate-and-decremented. For our triangle lists
-        // that means every third entry.
+        // each polygon negate-and-decremented (`!idx`). For our triangle
+        // lists that means every third entry.
+        //
+        // The negate-and-decrement encoding requires the index to fit in
+        // a positive i32 (the high bit is what marks "polygon end"). If
+        // any vertex index doesn't fit, we surface a clear error rather
+        // than silently corrupting the polygon stream — mogen-core's
+        // `Mesh.indices` is `Vec<u32>`, so values ≥ 2³¹ are legal at the
+        // type level but would alias to negative i32 here.
         let mut polygon_vertex_index: Vec<i32> = Vec::with_capacity(mesh.indices.len());
         for tri in mesh.indices.chunks_exact(3) {
+            for raw in [tri[0], tri[1], tri[2]] {
+                if raw > i32::MAX as u32 {
+                    return Err(anyhow::anyhow!(
+                        "fbx export: vertex index {raw} on geometry {:?} exceeds i32::MAX; \
+                         FBX `PolygonVertexIndex` cannot represent indices ≥ 2^31",
+                        n.name,
+                    ));
+                }
+            }
             let a = tri[0] as i32;
             let b = tri[1] as i32;
             let c = tri[2] as i32;
@@ -77,18 +93,24 @@ pub(super) fn emit_geometries(
             .flat_map(|n| [n[0] as f64, n[1] as f64, n[2] as f64])
             .collect();
 
-        // UV layer is optional — empty `uvs` skips the LayerElementUV
-        // emission entirely. Note this passes the raw UVs through; the
-        // `uv_scale` material multiplier is *not* applied here, matching
-        // the FBX convention that material UV transforms live on the
-        // material, not baked into vertex data. The GLB exporter bakes it
+        // UV layer is optional. Use `Mesh::has_uvs()` rather than just
+        // checking emptiness — the canonical predicate also requires the
+        // UV row count to match the position count, so a partial / stale
+        // UV array won't be emitted as a malformed FBX layer.
+        //
+        // Note we pass UVs through unchanged; the material's `uv_scale`
+        // multiplier is *not* applied here. FBX convention is to put UV
+        // transforms on the material side. The GLB exporter bakes it
         // because glTF's KHR_texture_transform support is uneven.
-        let uvs: Vec<f64> = mesh
-            .uvs
-            .iter()
-            .flat_map(|uv| [uv[0] as f64, uv[1] as f64])
-            .collect();
-        let has_uvs = !uvs.is_empty();
+        let has_uvs = mesh.has_uvs();
+        let uvs: Vec<f64> = if has_uvs {
+            mesh.uvs
+                .iter()
+                .flat_map(|uv| [uv[0] as f64, uv[1] as f64])
+                .collect()
+        } else {
+            Vec::new()
+        };
 
         let geom_name = n.name.clone();
 
@@ -163,7 +185,7 @@ pub(super) fn emit_geometries(
         emit.connect_oo(geom_id, model_id);
     }
 
-    MeshTable {
+    Ok(MeshTable {
         geometry_id_for_node,
-    }
+    })
 }

--- a/crates/mogen-export/src/fbx/mod.rs
+++ b/crates/mogen-export/src/fbx/mod.rs
@@ -1,0 +1,135 @@
+//! Binary FBX 7.4 export — sibling to the GLB pipeline.
+//!
+//! The public API mirrors `write_glb` / `build_glb_with_options_and_source`
+//! so callers can swap the format at the file layer without rewiring options
+//! or the texture-source plumbing. All emission flows through the `fbxcel`
+//! crate's writer + tree feature; this module only assembles the FBX node
+//! tree from a `mogen_core::SceneGraph` and hands it to `Writer::write_tree`.
+//!
+//! Out of scope for now: FBX import, ASCII FBX, and any feature that would
+//! be lossy beyond what the type-mapping plan documents.
+
+use std::fs::File;
+use std::io::{BufWriter, Cursor};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use mogen_core::SceneGraph;
+
+use crate::texture::{FsTextureSource, TextureSource};
+use crate::ExportOptions;
+#[cfg(feature = "merge")]
+use crate::merge;
+
+mod anim;
+mod doc;
+mod ids;
+mod light;
+mod material;
+mod mesh;
+mod nodes;
+mod skin;
+mod texture;
+
+/// Convenience wrapper that writes the export bytes to disk with default
+/// options. Mirrors [`crate::write_glb`].
+pub fn write_fbx(scene: &SceneGraph, out: &Path) -> Result<()> {
+    write_fbx_with_options(scene, out, &ExportOptions::default(), |_| {})
+}
+
+/// Build an FBX into the given file. Streams the resulting bytes through
+/// `fbxcel`'s writer directly into a `BufWriter` so we don't double-buffer
+/// the (potentially large) document.
+pub fn write_fbx_with_options<F: Fn(&str)>(
+    scene: &SceneGraph,
+    out: &Path,
+    opts: &ExportOptions,
+    progress: F,
+) -> Result<()> {
+    let bytes = build_fbx_with_options(scene, opts, progress)?;
+    let mut f = BufWriter::new(
+        File::create(out).with_context(|| format!("creating {}", out.display()))?,
+    );
+    use std::io::Write;
+    f.write_all(&bytes)
+        .with_context(|| format!("writing {}", out.display()))?;
+    f.flush()
+        .with_context(|| format!("flushing {}", out.display()))?;
+    Ok(())
+}
+
+/// Build an FBX into a `Vec<u8>` using the filesystem to load any textures
+/// referenced by the scene's materials. Mirrors [`crate::build_glb_with_options`].
+pub fn build_fbx_with_options<F: Fn(&str)>(
+    scene: &SceneGraph,
+    opts: &ExportOptions,
+    progress: F,
+) -> Result<Vec<u8>> {
+    build_fbx_with_options_and_source(scene, opts, &FsTextureSource, progress)
+}
+
+/// Build an FBX into a `Vec<u8>` with a caller-supplied [`TextureSource`].
+/// Mirrors [`crate::build_glb_with_options_and_source`] — same merge stages,
+/// same ordering, same texture-source contract.
+pub fn build_fbx_with_options_and_source<F: Fn(&str)>(
+    scene: &SceneGraph,
+    opts: &ExportOptions,
+    texture_source: &dyn TextureSource,
+    progress: F,
+) -> Result<Vec<u8>> {
+    // Mirror the GLB merge pipeline: scoped `solid` pass first, then the
+    // global sibling-merge if the caller asked for it. Both stages clone
+    // and the latest owned graph wins.
+    #[cfg(feature = "merge")]
+    let solid_owned: Option<SceneGraph> = {
+        let has_solid = scene
+            .nodes
+            .iter()
+            .any(|n| n.tags.iter().any(|t| t == "solid"));
+        if has_solid {
+            Some(merge::merge_solid_groups(scene, |s| progress(s)))
+        } else {
+            None
+        }
+    };
+    #[cfg(feature = "merge")]
+    let scene_after_solid: &SceneGraph = solid_owned.as_ref().unwrap_or(scene);
+    #[cfg(not(feature = "merge"))]
+    let scene_after_solid: &SceneGraph = scene;
+
+    #[cfg(feature = "merge")]
+    let merged_owned: Option<SceneGraph> = if opts.merge_sibling_meshes {
+        Some(merge::merge_sibling_meshes(scene_after_solid, |s| {
+            progress(s)
+        }))
+    } else {
+        None
+    };
+    #[cfg(feature = "merge")]
+    let scene: &SceneGraph = merged_owned.as_ref().unwrap_or(scene_after_solid);
+    #[cfg(not(feature = "merge"))]
+    let scene: &SceneGraph = scene_after_solid;
+
+    // Build the FBX node tree in memory, then ask `fbxcel` to serialize it.
+    progress("building fbx tree");
+    let tree = doc::build_tree(scene, opts, texture_source, &progress)
+        .context("building fbx tree")?;
+
+    progress("writing fbx");
+    use fbxcel::low::FbxVersion;
+    use fbxcel::writer::v7400::binary::{FbxFooter, Writer};
+
+    let mut sink = Cursor::new(Vec::<u8>::new());
+    let mut writer = Writer::new(&mut sink, FbxVersion::V7_4)
+        .map_err(|e| anyhow::anyhow!("opening fbx writer: {e}"))?;
+    writer
+        .write_tree(&tree)
+        .map_err(|e| anyhow::anyhow!("serialising fbx tree: {e}"))?;
+    let footer = FbxFooter::default();
+    writer
+        .finalize_and_flush(&footer)
+        .map_err(|e| anyhow::anyhow!("finalising fbx writer: {e}"))?;
+
+    Ok(sink.into_inner())
+}

--- a/crates/mogen-export/src/fbx/mod.rs
+++ b/crates/mogen-export/src/fbx/mod.rs
@@ -38,9 +38,11 @@ pub fn write_fbx(scene: &SceneGraph, out: &Path) -> Result<()> {
     write_fbx_with_options(scene, out, &ExportOptions::default(), |_| {})
 }
 
-/// Build an FBX into the given file. Streams the resulting bytes through
-/// `fbxcel`'s writer directly into a `BufWriter` so we don't double-buffer
-/// the (potentially large) document.
+/// Build an FBX into the given file via [`build_fbx_with_options`] and
+/// stream the resulting bytes to disk through a `BufWriter`. The FBX
+/// node tree is materialised in memory first because `fbxcel`'s writer
+/// needs random-access seeks (it back-patches end offsets on every
+/// node), so true write-through streaming isn't viable.
 pub fn write_fbx_with_options<F: Fn(&str)>(
     scene: &SceneGraph,
     out: &Path,

--- a/crates/mogen-export/src/fbx/nodes.rs
+++ b/crates/mogen-export/src/fbx/nodes.rs
@@ -1,0 +1,175 @@
+//! Per-`SceneNode` `Model` Objects + their parent connections.
+//!
+//! Every node in the input graph becomes one `Model` object in FBX, with the
+//! subclass picked from whether it carries a mesh / light / nothing. The
+//! Model holds the local TRS via `Lcl Translation/Rotation/Scaling`
+//! properties; quaternions are converted to Euler XYZ degrees because FBX's
+//! `RotationOrder=0` (XYZ) is the only rotation order the rest of the
+//! property block agrees with.
+
+use fbxcel::low::v7400::AttributeValue;
+use glam::EulerRot;
+
+use mogen_core::SceneGraph;
+
+use super::doc::{push_prop, push_prop_vec3, write_properties70, ObjectEmitter};
+use super::ids::IdAllocator;
+
+/// Allocate and emit one `Model` Object per `SceneNode`. Returns the
+/// per-node id table so downstream emitters (skin, animation) can connect
+/// into the right Model. Index `i` corresponds to `scene.nodes[i]`.
+pub(super) fn emit_models(
+    scene: &SceneGraph,
+    ids: &mut IdAllocator,
+    emit: &mut ObjectEmitter,
+) -> Vec<i64> {
+    let model_ids: Vec<i64> = scene.nodes.iter().map(|_| ids.alloc()).collect();
+
+    for (i, n) in scene.nodes.iter().enumerate() {
+        let model_id = model_ids[i];
+        let name = n.name.clone();
+
+        // Pick the subclass. Light and Mesh nodes get their own NodeAttribute
+        // that we attach via OO-connections in the relevant emitter; the
+        // Model subclass label here is what Blender uses to decide which
+        // attribute it expects.
+        let subclass: &'static str = if n.light.is_some() {
+            "Light"
+        } else if n.mesh.is_some() {
+            "Mesh"
+        } else {
+            "Null"
+        };
+
+        let translation: [f64; 3] = [
+            n.transform.translation.x as f64,
+            n.transform.translation.y as f64,
+            n.transform.translation.z as f64,
+        ];
+        let (rx, ry, rz) = n.transform.rotation.to_euler(EulerRot::XYZ);
+        let rotation_deg: [f64; 3] = [
+            (rx as f64).to_degrees(),
+            (ry as f64).to_degrees(),
+            (rz as f64).to_degrees(),
+        ];
+        let scale: [f64; 3] = [
+            n.transform.scale.x as f64,
+            n.transform.scale.y as f64,
+            n.transform.scale.z as f64,
+        ];
+
+        // Stash DSL-only metadata that has no first-class FBX equivalent
+        // as Properties70 custom props. Anything tooling-internal (use_id,
+        // origin, source_span, editable, relative_placed) stays out.
+        let kind = n.kind.clone();
+        let role = n.role.clone();
+        let tags = n.tags.clone();
+        let cast_shadow = n.cast_shadow;
+
+        emit.push_object(
+            "Model",
+            Box::new(move |tree, parent| {
+                let m = tree.append_new(parent, "Model");
+                tree.append_attribute(m, model_id);
+                tree.append_attribute(m, format!("{name}\u{0}\u{1}Model"));
+                tree.append_attribute(m, subclass);
+
+                let v = tree.append_new(m, "Version");
+                tree.append_attribute(v, 232i32);
+
+                write_properties70(tree, m, |t, props| {
+                    push_prop(t, props, "RotationActive", "bool", "", "", AttributeValue::I32(1));
+                    push_prop(t, props, "InheritType", "enum", "", "", AttributeValue::I32(0));
+                    push_prop(t, props, "ScalingMax", "Vector3D", "Vector", "", AttributeValue::F64(0.0));
+                    push_prop(t, props, "DefaultAttributeIndex", "int", "Integer", "", AttributeValue::I32(0));
+                    push_prop_vec3(
+                        t,
+                        props,
+                        "Lcl Translation",
+                        "Lcl Translation",
+                        "",
+                        "A",
+                        translation,
+                    );
+                    push_prop_vec3(
+                        t,
+                        props,
+                        "Lcl Rotation",
+                        "Lcl Rotation",
+                        "",
+                        "A",
+                        rotation_deg,
+                    );
+                    push_prop_vec3(t, props, "Lcl Scaling", "Lcl Scaling", "", "A", scale);
+                    push_prop(t, props, "RotationOrder", "enum", "", "", AttributeValue::I32(0));
+
+                    if !kind.is_empty() && kind != name {
+                        push_prop(
+                            t,
+                            props,
+                            "mogen_kind",
+                            "KString",
+                            "",
+                            "U",
+                            AttributeValue::String(kind.clone()),
+                        );
+                    }
+                    if let Some(role) = &role {
+                        push_prop(
+                            t,
+                            props,
+                            "mogen_role",
+                            "KString",
+                            "",
+                            "U",
+                            AttributeValue::String(role.clone()),
+                        );
+                    }
+                    if !tags.is_empty() {
+                        push_prop(
+                            t,
+                            props,
+                            "mogen_tags",
+                            "KString",
+                            "",
+                            "U",
+                            AttributeValue::String(tags.join(",")),
+                        );
+                    }
+                    if !cast_shadow {
+                        push_prop(
+                            t,
+                            props,
+                            "CastShadow",
+                            "bool",
+                            "",
+                            "",
+                            AttributeValue::I32(0),
+                        );
+                    }
+                });
+
+                // Rendering-relevant defaults that sit outside Properties70
+                // in FBX. Blender ignores most, but emitting them keeps the
+                // file structurally identical to what the SDK produces.
+                let mt = tree.append_new(m, "MultiLayer");
+                tree.append_attribute(mt, 0i32);
+                let mta = tree.append_new(m, "MultiTake");
+                tree.append_attribute(mta, 0i32);
+                let shading = tree.append_new(m, "Shading");
+                tree.append_attribute(shading, true);
+                let culling = tree.append_new(m, "Culling");
+                tree.append_attribute(culling, "CullingOff");
+            }),
+        );
+
+        // Parent connection. Roots connect to the implicit RootNode (id=0).
+        let parent_id = match n.parent {
+            Some(pid) => model_ids[pid.0 as usize],
+            None => 0,
+        };
+        emit.connect_oo(model_id, parent_id);
+    }
+
+    model_ids
+}

--- a/crates/mogen-export/src/fbx/nodes.rs
+++ b/crates/mogen-export/src/fbx/nodes.rs
@@ -80,7 +80,7 @@ pub(super) fn emit_models(
                 write_properties70(tree, m, |t, props| {
                     push_prop(t, props, "RotationActive", "bool", "", "", AttributeValue::I32(1));
                     push_prop(t, props, "InheritType", "enum", "", "", AttributeValue::I32(0));
-                    push_prop(t, props, "ScalingMax", "Vector3D", "Vector", "", AttributeValue::F64(0.0));
+                    push_prop_vec3(t, props, "ScalingMax", "Vector3D", "Vector", "", [0.0, 0.0, 0.0]);
                     push_prop(t, props, "DefaultAttributeIndex", "int", "Integer", "", AttributeValue::I32(0));
                     push_prop_vec3(
                         t,

--- a/crates/mogen-export/src/fbx/skin.rs
+++ b/crates/mogen-export/src/fbx/skin.rs
@@ -4,26 +4,33 @@
 //! FBX 7.4 skinning model:
 //!
 //! ```text
-//! Geometry --OO-- Skin Deformer
-//!                 │
-//!                 ├─ Cluster (joint 0) ──OO─→ joint Model
-//!                 ├─ Cluster (joint 1) ──OO─→ joint Model
-//!                 └─ …
+//! Geometry <--OO-- Skin Deformer
+//!                  ↑
+//!                  │ OO (cluster is the source/child of the skin)
+//!                  │
+//!                  ├─ Cluster (joint 0) --OO--> joint Model
+//!                  ├─ Cluster (joint 1) --OO--> joint Model
+//!                  └─ …
 //! ```
 //!
+//! Connection arrows in this diagram point from source (child) to
+//! destination (parent). FBX `OO` rows are written as
+//! `(source, destination)`, so a `Cluster --OO--> joint Model` connection
+//! is `connect_oo(cluster_id, joint_model_id)`.
+//!
+//! **Per-geometry scoping.** A Cluster's `Indexes` array is interpreted
+//! relative to the geometry the Skin Deformer is connected to. We
+//! therefore emit one Skin Deformer (and its full set of joint Clusters)
+//! per (skin, bound geometry) pair — sharing a Skin across multiple
+//! geometries in FBX would conflate vertex-id namespaces.
+//!
 //! Each Cluster carries:
-//! - `Indexes` — i32 array of vertex indices this joint deforms.
+//! - `Indexes` — i32 array of vertex indices in the bound geometry.
 //! - `Weights` — f64 array, same length as `Indexes`.
 //! - `Transform` — 16-element column-major matrix: the inverse-bind
 //!   matrix supplied by `mogen_core::Skin.inverse_bind_matrices[i]`.
 //! - `TransformLink` — 16-element column-major matrix: the joint's world
-//!   bind transform (i.e. `inverse(Transform)`).
-//!
-//! We compute `TransformLink` by inverting `Transform`. The GLB
-//! exporter passes the inverse-bind matrices straight through to glTF;
-//! both formats expect the same column-major glam memory layout.
-
-use std::collections::HashMap;
+//!   bind transform, derived as the inverse of `Transform`.
 
 use fbxcel::low::v7400::AttributeValue;
 use glam::Mat4;
@@ -45,27 +52,35 @@ pub(super) fn emit_skins(
         return;
     }
 
-    // Map: skin index → list of geometry ids that bind to it. A skin
-    // with no bound mesh is silently dropped — there is no FBX object
-    // to attach the deformer to.
-    let mut geometries_per_skin: HashMap<u32, Vec<i64>> = HashMap::new();
+    // Walk every (mesh-bearing node, skin reference) pair. Each becomes its
+    // own Skin Deformer + per-joint Cluster set so the cluster Indexes
+    // never cross geometry boundaries.
     for (i, n) in scene.nodes.iter().enumerate() {
-        if let (Some(skin_id), Some(geom_id)) = (n.skin, mesh_table.geometry_id_for_node[i]) {
-            geometries_per_skin
-                .entry(skin_id.0)
-                .or_default()
-                .push(geom_id);
-        }
-    }
-
-    for (skin_idx, skin) in scene.skins.iter().enumerate() {
-        let geometry_ids = match geometries_per_skin.get(&(skin_idx as u32)) {
-            Some(g) if !g.is_empty() => g.clone(),
-            _ => continue,
+        let skin_ref = match n.skin {
+            Some(s) => s,
+            None => continue,
         };
+        let geom_id = match mesh_table.geometry_id_for_node[i] {
+            Some(g) => g,
+            None => continue,
+        };
+        let skin = match scene.skins.get(skin_ref.0 as usize) {
+            Some(s) => s,
+            None => continue,
+        };
+        let mesh = match &n.mesh {
+            Some(m) => m,
+            None => continue,
+        };
+        if !mesh.is_skinned() {
+            // Carrying a skin reference but no per-vertex influences is a
+            // semantic mismatch upstream of us; the GLB pipeline silently
+            // drops such nodes from skinning, so do the same here.
+            continue;
+        }
 
         let skin_id = ids.alloc();
-        let skin_name = skin.name.clone();
+        let skin_name = format!("{}_{}", skin.name, n.name);
 
         emit.push_object(
             "Deformer",
@@ -81,18 +96,11 @@ pub(super) fn emit_skins(
                 tree.append_attribute(lr, 50.0_f64);
             }),
         );
-        for geom_id in &geometry_ids {
-            emit.connect_oo(skin_id, *geom_id);
-        }
+        // Skin Deformer is connected as the child of the Geometry. The
+        // Geometry node is the destination; the Skin's own children
+        // (Clusters) connect with the Skin as their destination.
+        emit.connect_oo(skin_id, geom_id);
 
-        // Per-joint clusters. Per-vertex influences come from the mesh
-        // bound on every node in `geometries_per_skin` — but we expect
-        // every bound mesh to share the same per-vertex layout (joint
-        // ids index into `skin.joints`, not into something mesh-local).
-        // For multi-mesh skins (rare) we collapse to "any mesh that
-        // mentions joint J in row R" which mirrors the GLB exporter's
-        // assumption that `Mesh.joints` rows are one-to-one with
-        // `Mesh.positions` for the bound mesh.
         for (joint_idx, joint_node) in skin.joints.iter().enumerate() {
             let cluster_id = ids.alloc();
             let joint_model_id = match model_ids.get(joint_node.0 as usize) {
@@ -100,55 +108,40 @@ pub(super) fn emit_skins(
                 None => continue,
             };
 
-            // Collect (vertex_index, weight) entries for this joint
-            // across every bound mesh. Skip zero-weight rows so the
-            // arrays stay tight and importers don't ignore real data.
+            // Collect (vertex_index, weight) entries for this joint from
+            // *this* mesh only. Zero-weight slots are skipped so importers
+            // don't waste cycles on no-op influences.
             let mut indices: Vec<i32> = Vec::new();
             let mut weights: Vec<f64> = Vec::new();
-            for (i, n) in scene.nodes.iter().enumerate() {
-                let (Some(skin_ref), Some(_)) = (n.skin, mesh_table.geometry_id_for_node[i]) else {
-                    continue;
-                };
-                if skin_ref.0 != skin_idx as u32 {
-                    continue;
-                }
-                let Some(mesh) = &n.mesh else { continue };
-                if !mesh.is_skinned() {
-                    continue;
-                }
-                for (vi, (joints_row, weights_row)) in
-                    mesh.joints.iter().zip(mesh.weights.iter()).enumerate()
-                {
-                    for slot in 0..4 {
-                        if joints_row[slot] as usize == joint_idx && weights_row[slot] > 0.0 {
-                            indices.push(vi as i32);
-                            weights.push(weights_row[slot] as f64);
-                        }
+            for (vi, (joints_row, weights_row)) in
+                mesh.joints.iter().zip(mesh.weights.iter()).enumerate()
+            {
+                for slot in 0..4 {
+                    if joints_row[slot] as usize == joint_idx && weights_row[slot] > 0.0 {
+                        indices.push(vi as i32);
+                        weights.push(weights_row[slot] as f64);
                     }
                 }
             }
 
-            // Flatten the inverse-bind matrix (column-major glam) into
-            // a 16-element f64 array. `TransformLink` is the world-bind
-            // (inverse of inverse-bind).
+            // Flatten the inverse-bind matrix (column-major glam) into a
+            // 16-element f64 array — that's what FBX `Transform` expects
+            // (joint's geometry-space → world-space matrix at bind, i.e.
+            // the inverse of the world-space joint transform).
+            // `TransformLink` is the joint's world bind transform, which
+            // is the inverse of `Transform`.
             let ibm: Mat4 = {
                 let m = skin.inverse_bind_matrices[joint_idx];
                 Mat4::from_cols_array_2d(&m)
             };
             let inv: Mat4 = ibm.inverse();
 
-            let transform_arr: Vec<f64> = ibm
-                .to_cols_array()
-                .iter()
-                .map(|f| *f as f64)
-                .collect();
-            let transform_link_arr: Vec<f64> = inv
-                .to_cols_array()
-                .iter()
-                .map(|f| *f as f64)
-                .collect();
+            let transform_arr: Vec<f64> =
+                ibm.to_cols_array().iter().map(|f| *f as f64).collect();
+            let transform_link_arr: Vec<f64> =
+                inv.to_cols_array().iter().map(|f| *f as f64).collect();
 
-            let cluster_name = format!("{}_{}", skin.name, joint_idx);
+            let cluster_name = format!("{}_{}_{}", skin.name, n.name, joint_idx);
 
             emit.push_object(
                 "Deformer",
@@ -176,8 +169,11 @@ pub(super) fn emit_skins(
                 }),
             );
 
+            // Cluster is the child of both the Skin and the joint Model
+            // (FBX models a Cluster as the bridge between them). Both
+            // edges therefore have `cluster_id` as the source.
             emit.connect_oo(cluster_id, skin_id);
-            emit.connect_oo(joint_model_id, cluster_id);
+            emit.connect_oo(cluster_id, joint_model_id);
         }
     }
 }

--- a/crates/mogen-export/src/fbx/skin.rs
+++ b/crates/mogen-export/src/fbx/skin.rs
@@ -1,0 +1,183 @@
+//! Skin export — `Skin` → `Deformer` (subclass `Skin`) + per-joint
+//! `Deformer` (subclass `Cluster`).
+//!
+//! FBX 7.4 skinning model:
+//!
+//! ```text
+//! Geometry --OO-- Skin Deformer
+//!                 │
+//!                 ├─ Cluster (joint 0) ──OO─→ joint Model
+//!                 ├─ Cluster (joint 1) ──OO─→ joint Model
+//!                 └─ …
+//! ```
+//!
+//! Each Cluster carries:
+//! - `Indexes` — i32 array of vertex indices this joint deforms.
+//! - `Weights` — f64 array, same length as `Indexes`.
+//! - `Transform` — 16-element column-major matrix: the inverse-bind
+//!   matrix supplied by `mogen_core::Skin.inverse_bind_matrices[i]`.
+//! - `TransformLink` — 16-element column-major matrix: the joint's world
+//!   bind transform (i.e. `inverse(Transform)`).
+//!
+//! We compute `TransformLink` by inverting `Transform`. The GLB
+//! exporter passes the inverse-bind matrices straight through to glTF;
+//! both formats expect the same column-major glam memory layout.
+
+use std::collections::HashMap;
+
+use fbxcel::low::v7400::AttributeValue;
+use glam::Mat4;
+
+use mogen_core::SceneGraph;
+
+use super::doc::ObjectEmitter;
+use super::ids::IdAllocator;
+use super::mesh::MeshTable;
+
+pub(super) fn emit_skins(
+    scene: &SceneGraph,
+    model_ids: &[i64],
+    mesh_table: &MeshTable,
+    ids: &mut IdAllocator,
+    emit: &mut ObjectEmitter,
+) {
+    if scene.skins.is_empty() {
+        return;
+    }
+
+    // Map: skin index → list of geometry ids that bind to it. A skin
+    // with no bound mesh is silently dropped — there is no FBX object
+    // to attach the deformer to.
+    let mut geometries_per_skin: HashMap<u32, Vec<i64>> = HashMap::new();
+    for (i, n) in scene.nodes.iter().enumerate() {
+        if let (Some(skin_id), Some(geom_id)) = (n.skin, mesh_table.geometry_id_for_node[i]) {
+            geometries_per_skin
+                .entry(skin_id.0)
+                .or_default()
+                .push(geom_id);
+        }
+    }
+
+    for (skin_idx, skin) in scene.skins.iter().enumerate() {
+        let geometry_ids = match geometries_per_skin.get(&(skin_idx as u32)) {
+            Some(g) if !g.is_empty() => g.clone(),
+            _ => continue,
+        };
+
+        let skin_id = ids.alloc();
+        let skin_name = skin.name.clone();
+
+        emit.push_object(
+            "Deformer",
+            Box::new(move |tree, parent| {
+                let d = tree.append_new(parent, "Deformer");
+                tree.append_attribute(d, skin_id);
+                tree.append_attribute(d, format!("{skin_name}\u{0}\u{1}Deformer"));
+                tree.append_attribute(d, "Skin");
+
+                let v = tree.append_new(d, "Version");
+                tree.append_attribute(v, 101i32);
+                let lr = tree.append_new(d, "Link_DeformAcuracy");
+                tree.append_attribute(lr, 50.0_f64);
+            }),
+        );
+        for geom_id in &geometry_ids {
+            emit.connect_oo(skin_id, *geom_id);
+        }
+
+        // Per-joint clusters. Per-vertex influences come from the mesh
+        // bound on every node in `geometries_per_skin` — but we expect
+        // every bound mesh to share the same per-vertex layout (joint
+        // ids index into `skin.joints`, not into something mesh-local).
+        // For multi-mesh skins (rare) we collapse to "any mesh that
+        // mentions joint J in row R" which mirrors the GLB exporter's
+        // assumption that `Mesh.joints` rows are one-to-one with
+        // `Mesh.positions` for the bound mesh.
+        for (joint_idx, joint_node) in skin.joints.iter().enumerate() {
+            let cluster_id = ids.alloc();
+            let joint_model_id = match model_ids.get(joint_node.0 as usize) {
+                Some(&m) => m,
+                None => continue,
+            };
+
+            // Collect (vertex_index, weight) entries for this joint
+            // across every bound mesh. Skip zero-weight rows so the
+            // arrays stay tight and importers don't ignore real data.
+            let mut indices: Vec<i32> = Vec::new();
+            let mut weights: Vec<f64> = Vec::new();
+            for (i, n) in scene.nodes.iter().enumerate() {
+                let (Some(skin_ref), Some(_)) = (n.skin, mesh_table.geometry_id_for_node[i]) else {
+                    continue;
+                };
+                if skin_ref.0 != skin_idx as u32 {
+                    continue;
+                }
+                let Some(mesh) = &n.mesh else { continue };
+                if !mesh.is_skinned() {
+                    continue;
+                }
+                for (vi, (joints_row, weights_row)) in
+                    mesh.joints.iter().zip(mesh.weights.iter()).enumerate()
+                {
+                    for slot in 0..4 {
+                        if joints_row[slot] as usize == joint_idx && weights_row[slot] > 0.0 {
+                            indices.push(vi as i32);
+                            weights.push(weights_row[slot] as f64);
+                        }
+                    }
+                }
+            }
+
+            // Flatten the inverse-bind matrix (column-major glam) into
+            // a 16-element f64 array. `TransformLink` is the world-bind
+            // (inverse of inverse-bind).
+            let ibm: Mat4 = {
+                let m = skin.inverse_bind_matrices[joint_idx];
+                Mat4::from_cols_array_2d(&m)
+            };
+            let inv: Mat4 = ibm.inverse();
+
+            let transform_arr: Vec<f64> = ibm
+                .to_cols_array()
+                .iter()
+                .map(|f| *f as f64)
+                .collect();
+            let transform_link_arr: Vec<f64> = inv
+                .to_cols_array()
+                .iter()
+                .map(|f| *f as f64)
+                .collect();
+
+            let cluster_name = format!("{}_{}", skin.name, joint_idx);
+
+            emit.push_object(
+                "Deformer",
+                Box::new(move |tree, parent| {
+                    let c = tree.append_new(parent, "Deformer");
+                    tree.append_attribute(c, cluster_id);
+                    tree.append_attribute(c, format!("{cluster_name}\u{0}\u{1}SubDeformer"));
+                    tree.append_attribute(c, "Cluster");
+
+                    let v = tree.append_new(c, "Version");
+                    tree.append_attribute(v, 100i32);
+                    let um = tree.append_new(c, "UserData");
+                    tree.append_attribute(um, "");
+                    tree.append_attribute(um, "");
+
+                    let ix = tree.append_new(c, "Indexes");
+                    tree.append_attribute(ix, AttributeValue::ArrI32(indices));
+                    let w = tree.append_new(c, "Weights");
+                    tree.append_attribute(w, AttributeValue::ArrF64(weights));
+
+                    let tr = tree.append_new(c, "Transform");
+                    tree.append_attribute(tr, AttributeValue::ArrF64(transform_arr));
+                    let tl = tree.append_new(c, "TransformLink");
+                    tree.append_attribute(tl, AttributeValue::ArrF64(transform_link_arr));
+                }),
+            );
+
+            emit.connect_oo(cluster_id, skin_id);
+            emit.connect_oo(joint_model_id, cluster_id);
+        }
+    }
+}

--- a/crates/mogen-export/src/fbx/texture.rs
+++ b/crates/mogen-export/src/fbx/texture.rs
@@ -1,0 +1,208 @@
+//! `TextureRef` → `Texture` + `Video` Object emission.
+//!
+//! In FBX the image bytes themselves live in a `Video` object (yes,
+//! "Video" — Autodesk uses the same node for stills and movies). The
+//! `Texture` object is the PBR slot binder that connects the Video into
+//! a Material via OP. Connection chain looks like:
+//!
+//! ```text
+//! Video --OO--> Texture --OP("DiffuseColor"|"NormalMap"|…)--> Material
+//! ```
+//!
+//! We deduplicate by (path, slot-kind) the same way the GLB exporter does
+//! — sharing a Texture object between materials is fine, but a path used
+//! both as a colour slot and a linear slot needs two embeds because their
+//! `UseMaterial` properties differ.
+//!
+//! Bytes are read once per unique path through the caller-supplied
+//! `TextureSource` and embedded raw via `Video.Content`. No transcoding
+//! happens here — that matches the wasm-friendly path of the GLB
+//! exporter (the `textures-optimize` JPEG/oxipng path is GLB-only and
+//! intentionally out of scope; FBX consumers like Blender accept PNG and
+//! JPEG verbatim, and binary FBX has no MIME type to fight us about).
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use fbxcel::low::v7400::AttributeValue;
+
+use mogen_core::{MaterialId, SceneGraph};
+
+use super::doc::ObjectEmitter;
+use super::ids::IdAllocator;
+use super::material::{
+    TextureIndices, SLOT_BASE_COLOR, SLOT_EMISSIVE, SLOT_METALLIC_ROUGHNESS, SLOT_NORMAL,
+    SLOT_OCCLUSION,
+};
+
+pub(super) fn emit_textures_and_videos(
+    scene: &SceneGraph,
+    indices: &TextureIndices,
+    ids: &mut IdAllocator,
+    emit: &mut ObjectEmitter,
+) {
+    // Cache: path → (texture_id, video_id). If two materials reference
+    // the same image at the same slot kind, both connect to the same
+    // Texture object. We don't try to re-read or re-embed on a hit.
+    let mut cache: HashMap<PathBuf, (i64, i64)> = HashMap::new();
+
+    // Bytes for embedded `Content` come from the same source the GLB
+    // pipeline uses. We read each unique path lazily — only when we hit
+    // it for the first time — so a TextureSource that fails for a path
+    // not actually referenced is never queried.
+    let mut bytes_cache: HashMap<PathBuf, Vec<u8>> = HashMap::new();
+
+    for (mat_idx, paths) in indices.texture_paths.iter().enumerate() {
+        let mat_id = indices.material_ids[mat_idx];
+        let _mat_id_for_check: MaterialId = MaterialId(mat_idx as u32);
+        let _ = scene; // currently unused; kept for future per-material
+                       // texture-transform export.
+
+        for (slot, path_opt) in [
+            (SLOT_BASE_COLOR, paths.base_color.as_ref()),
+            (SLOT_NORMAL, paths.normal.as_ref()),
+            (SLOT_EMISSIVE, paths.emissive.as_ref()),
+            (SLOT_OCCLUSION, paths.occlusion.as_ref()),
+            (SLOT_METALLIC_ROUGHNESS, paths.metallic_roughness.as_ref()),
+        ] {
+            let path = match path_opt {
+                Some(p) => p,
+                None => continue,
+            };
+
+            let (tex_id, _vid_id) = match cache.get(path) {
+                Some(&(t, v)) => (t, v),
+                None => {
+                    let tex_id = ids.alloc();
+                    let vid_id = ids.alloc();
+                    cache.insert(path.clone(), (tex_id, vid_id));
+
+                    // Embed bytes if the texture source can hand them
+                    // over. Failure to read becomes an empty `Content` —
+                    // the GLB pipeline aborts in this case, but for FBX
+                    // we'd rather emit a structurally-valid file with a
+                    // placeholder than abort the whole export over one
+                    // missing file. The texture path is preserved on
+                    // `Video.RelativeFilename` and `Video.FileName` so
+                    // a tooling re-resolve can patch it up later.
+                    let raw_bytes = bytes_cache
+                        .entry(path.clone())
+                        .or_insert_with(|| std::fs::read(path).unwrap_or_default())
+                        .clone();
+
+                    let path_owned = path.clone();
+                    emit.push_object(
+                        "Video",
+                        Box::new(move |tree, parent| {
+                            let v = tree.append_new(parent, "Video");
+                            tree.append_attribute(v, vid_id);
+                            tree.append_attribute(
+                                v,
+                                format!(
+                                    "{}\u{0}\u{1}Video",
+                                    path_owned
+                                        .file_stem()
+                                        .map(|s| s.to_string_lossy().into_owned())
+                                        .unwrap_or_default()
+                                ),
+                            );
+                            tree.append_attribute(v, "Clip");
+
+                            let ty = tree.append_new(v, "Type");
+                            tree.append_attribute(ty, "Clip");
+
+                            let fname_str = path_owned.to_string_lossy().into_owned();
+                            let rel = tree.append_new(v, "RelativeFilename");
+                            tree.append_attribute(rel, fname_str.clone());
+                            let fname = tree.append_new(v, "FileName");
+                            tree.append_attribute(fname, fname_str);
+
+                            let content = tree.append_new(v, "Content");
+                            tree.append_attribute(
+                                content,
+                                AttributeValue::Binary(raw_bytes),
+                            );
+
+                            let uvw = tree.append_new(v, "UseMipMap");
+                            tree.append_attribute(uvw, 0i32);
+                        }),
+                    );
+
+                    let path_owned = path.clone();
+                    let slot_owned = slot.to_string();
+                    emit.push_object(
+                        "Texture",
+                        Box::new(move |tree, parent| {
+                            let t = tree.append_new(parent, "Texture");
+                            tree.append_attribute(t, tex_id);
+                            tree.append_attribute(
+                                t,
+                                format!(
+                                    "{}\u{0}\u{1}Texture",
+                                    path_owned
+                                        .file_stem()
+                                        .map(|s| s.to_string_lossy().into_owned())
+                                        .unwrap_or_default()
+                                ),
+                            );
+                            tree.append_attribute(t, "");
+
+                            let ty = tree.append_new(t, "Type");
+                            tree.append_attribute(ty, "TextureVideoClip");
+                            let v = tree.append_new(t, "Version");
+                            tree.append_attribute(v, 202i32);
+                            let tn = tree.append_new(t, "TextureName");
+                            tree.append_attribute(
+                                tn,
+                                format!(
+                                    "{}\u{0}\u{1}Texture",
+                                    path_owned
+                                        .file_stem()
+                                        .map(|s| s.to_string_lossy().into_owned())
+                                        .unwrap_or_default()
+                                ),
+                            );
+                            let mr = tree.append_new(t, "ModelUVTranslation");
+                            tree.append_attribute(mr, 0.0_f64);
+                            tree.append_attribute(mr, 0.0_f64);
+                            let ms = tree.append_new(t, "ModelUVScaling");
+                            tree.append_attribute(ms, 1.0_f64);
+                            tree.append_attribute(ms, 1.0_f64);
+                            let txt = tree.append_new(t, "Texture_Alpha_Source");
+                            tree.append_attribute(txt, "None");
+                            // Slot kind on the Texture itself isn't a
+                            // standard FBX concept — we record it as a
+                            // custom prop so an importer round-tripping
+                            // back to MoGen can pick the right slot.
+                            super::doc::write_properties70(tree, t, |tt, props| {
+                                super::doc::push_prop(
+                                    tt,
+                                    props,
+                                    "MogenSlot",
+                                    "KString",
+                                    "",
+                                    "U",
+                                    AttributeValue::String(slot_owned.clone()),
+                                );
+                                super::doc::push_prop(
+                                    tt,
+                                    props,
+                                    "UseMaterial",
+                                    "bool",
+                                    "",
+                                    "",
+                                    AttributeValue::I32(1),
+                                );
+                            });
+                        }),
+                    );
+
+                    emit.connect_oo(vid_id, tex_id);
+                    (tex_id, vid_id)
+                }
+            };
+
+            emit.connect_op(tex_id, mat_id, slot);
+        }
+    }
+}

--- a/crates/mogen-export/src/fbx/texture.rs
+++ b/crates/mogen-export/src/fbx/texture.rs
@@ -9,24 +9,25 @@
 //! Video --OO--> Texture --OP("DiffuseColor"|"NormalMap"|…)--> Material
 //! ```
 //!
-//! We deduplicate by (path, slot-kind) the same way the GLB exporter does
-//! — sharing a Texture object between materials is fine, but a path used
-//! both as a colour slot and a linear slot needs two embeds because their
-//! `UseMaterial` properties differ.
+//! We deduplicate by `(path, slot)`, mirroring the GLB exporter's
+//! `(PathBuf, SlotKind)` keying. A path used both as a colour slot and a
+//! linear slot ends up with two `Texture`+`Video` pairs because their
+//! `MogenSlot` custom prop and `UseMaterial` value differ per slot kind
+//! — sharing one Texture object would mis-stamp metadata for one of the
+//! two consumers.
 //!
-//! Bytes are read once per unique path through the caller-supplied
-//! `TextureSource` and embedded raw via `Video.Content`. No transcoding
-//! happens here — that matches the wasm-friendly path of the GLB
-//! exporter (the `textures-optimize` JPEG/oxipng path is GLB-only and
-//! intentionally out of scope; FBX consumers like Blender accept PNG and
-//! JPEG verbatim, and binary FBX has no MIME type to fight us about).
+//! Bytes are read once per unique `(path, slot)` pair through the
+//! caller-supplied [`TextureSource`], matching the GLB pipeline so
+//! desktop and wasm callers share the same plumbing. A failure to read
+//! propagates back through the writer's `Result` — same contract as the
+//! GLB pipeline.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use fbxcel::low::v7400::AttributeValue;
+use anyhow::{Context, Result};
 
-use mogen_core::{MaterialId, SceneGraph};
+use fbxcel::low::v7400::AttributeValue;
 
 use super::doc::ObjectEmitter;
 use super::ids::IdAllocator;
@@ -34,29 +35,22 @@ use super::material::{
     TextureIndices, SLOT_BASE_COLOR, SLOT_EMISSIVE, SLOT_METALLIC_ROUGHNESS, SLOT_NORMAL,
     SLOT_OCCLUSION,
 };
+use crate::texture::TextureSource;
 
 pub(super) fn emit_textures_and_videos(
-    scene: &SceneGraph,
     indices: &TextureIndices,
+    source: &dyn TextureSource,
     ids: &mut IdAllocator,
     emit: &mut ObjectEmitter,
-) {
-    // Cache: path → (texture_id, video_id). If two materials reference
-    // the same image at the same slot kind, both connect to the same
-    // Texture object. We don't try to re-read or re-embed on a hit.
-    let mut cache: HashMap<PathBuf, (i64, i64)> = HashMap::new();
-
-    // Bytes for embedded `Content` come from the same source the GLB
-    // pipeline uses. We read each unique path lazily — only when we hit
-    // it for the first time — so a TextureSource that fails for a path
-    // not actually referenced is never queried.
-    let mut bytes_cache: HashMap<PathBuf, Vec<u8>> = HashMap::new();
+) -> Result<()> {
+    // (path, slot-name) → (texture_id, video_id). Two materials referencing
+    // the same image at the *same* slot share one Texture+Video pair; the
+    // same image at different slots gets two pairs because the slot-kind
+    // metadata on the Texture object differs.
+    let mut cache: HashMap<(PathBuf, &'static str), (i64, i64)> = HashMap::new();
 
     for (mat_idx, paths) in indices.texture_paths.iter().enumerate() {
         let mat_id = indices.material_ids[mat_idx];
-        let _mat_id_for_check: MaterialId = MaterialId(mat_idx as u32);
-        let _ = scene; // currently unused; kept for future per-material
-                       // texture-transform export.
 
         for (slot, path_opt) in [
             (SLOT_BASE_COLOR, paths.base_color.as_ref()),
@@ -70,139 +64,111 @@ pub(super) fn emit_textures_and_videos(
                 None => continue,
             };
 
-            let (tex_id, _vid_id) = match cache.get(path) {
-                Some(&(t, v)) => (t, v),
-                None => {
-                    let tex_id = ids.alloc();
-                    let vid_id = ids.alloc();
-                    cache.insert(path.clone(), (tex_id, vid_id));
+            let key = (path.clone(), slot);
+            let tex_id = if let Some(&(t, _)) = cache.get(&key) {
+                t
+            } else {
+                let tex_id = ids.alloc();
+                let vid_id = ids.alloc();
+                cache.insert(key, (tex_id, vid_id));
 
-                    // Embed bytes if the texture source can hand them
-                    // over. Failure to read becomes an empty `Content` —
-                    // the GLB pipeline aborts in this case, but for FBX
-                    // we'd rather emit a structurally-valid file with a
-                    // placeholder than abort the whole export over one
-                    // missing file. The texture path is preserved on
-                    // `Video.RelativeFilename` and `Video.FileName` so
-                    // a tooling re-resolve can patch it up later.
-                    let raw_bytes = bytes_cache
-                        .entry(path.clone())
-                        .or_insert_with(|| std::fs::read(path).unwrap_or_default())
-                        .clone();
+                // Read once per (path, slot). Propagate errors the same
+                // way the GLB pipeline does — silently embedding empty
+                // bytes would produce structurally-valid FBX with
+                // invisible textures and no diagnostic.
+                let raw_bytes = source
+                    .read(path)
+                    .with_context(|| format!("reading texture {}", path.display()))?;
 
-                    let path_owned = path.clone();
-                    emit.push_object(
-                        "Video",
-                        Box::new(move |tree, parent| {
-                            let v = tree.append_new(parent, "Video");
-                            tree.append_attribute(v, vid_id);
-                            tree.append_attribute(
-                                v,
-                                format!(
-                                    "{}\u{0}\u{1}Video",
-                                    path_owned
-                                        .file_stem()
-                                        .map(|s| s.to_string_lossy().into_owned())
-                                        .unwrap_or_default()
-                                ),
+                let path_owned = path.clone();
+                let stem_owned = path
+                    .file_stem()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_default();
+                let stem_for_tex = stem_owned.clone();
+
+                emit.push_object(
+                    "Video",
+                    Box::new(move |tree, parent| {
+                        let v = tree.append_new(parent, "Video");
+                        tree.append_attribute(v, vid_id);
+                        tree.append_attribute(v, format!("{stem_owned}\u{0}\u{1}Video"));
+                        tree.append_attribute(v, "Clip");
+
+                        let ty = tree.append_new(v, "Type");
+                        tree.append_attribute(ty, "Clip");
+
+                        let fname_str = path_owned.to_string_lossy().into_owned();
+                        let rel = tree.append_new(v, "RelativeFilename");
+                        tree.append_attribute(rel, fname_str.clone());
+                        let fname = tree.append_new(v, "FileName");
+                        tree.append_attribute(fname, fname_str);
+
+                        let content = tree.append_new(v, "Content");
+                        tree.append_attribute(content, AttributeValue::Binary(raw_bytes));
+
+                        let uvw = tree.append_new(v, "UseMipMap");
+                        tree.append_attribute(uvw, 0i32);
+                    }),
+                );
+
+                let slot_owned = slot.to_string();
+                emit.push_object(
+                    "Texture",
+                    Box::new(move |tree, parent| {
+                        let t = tree.append_new(parent, "Texture");
+                        tree.append_attribute(t, tex_id);
+                        tree.append_attribute(t, format!("{stem_for_tex}\u{0}\u{1}Texture"));
+                        tree.append_attribute(t, "");
+
+                        let ty = tree.append_new(t, "Type");
+                        tree.append_attribute(ty, "TextureVideoClip");
+                        let v = tree.append_new(t, "Version");
+                        tree.append_attribute(v, 202i32);
+                        let tn = tree.append_new(t, "TextureName");
+                        tree.append_attribute(tn, format!("{stem_for_tex}\u{0}\u{1}Texture"));
+                        let mr = tree.append_new(t, "ModelUVTranslation");
+                        tree.append_attribute(mr, 0.0_f64);
+                        tree.append_attribute(mr, 0.0_f64);
+                        let ms = tree.append_new(t, "ModelUVScaling");
+                        tree.append_attribute(ms, 1.0_f64);
+                        tree.append_attribute(ms, 1.0_f64);
+                        let txt = tree.append_new(t, "Texture_Alpha_Source");
+                        tree.append_attribute(txt, "None");
+                        // Slot kind on the Texture itself isn't a
+                        // standard FBX concept — we record it as a
+                        // custom prop so an importer round-tripping
+                        // back to MoGen can pick the right slot.
+                        super::doc::write_properties70(tree, t, |tt, props| {
+                            super::doc::push_prop(
+                                tt,
+                                props,
+                                "MogenSlot",
+                                "KString",
+                                "",
+                                "U",
+                                AttributeValue::String(slot_owned.clone()),
                             );
-                            tree.append_attribute(v, "Clip");
-
-                            let ty = tree.append_new(v, "Type");
-                            tree.append_attribute(ty, "Clip");
-
-                            let fname_str = path_owned.to_string_lossy().into_owned();
-                            let rel = tree.append_new(v, "RelativeFilename");
-                            tree.append_attribute(rel, fname_str.clone());
-                            let fname = tree.append_new(v, "FileName");
-                            tree.append_attribute(fname, fname_str);
-
-                            let content = tree.append_new(v, "Content");
-                            tree.append_attribute(
-                                content,
-                                AttributeValue::Binary(raw_bytes),
+                            super::doc::push_prop(
+                                tt,
+                                props,
+                                "UseMaterial",
+                                "bool",
+                                "",
+                                "",
+                                AttributeValue::I32(1),
                             );
+                        });
+                    }),
+                );
 
-                            let uvw = tree.append_new(v, "UseMipMap");
-                            tree.append_attribute(uvw, 0i32);
-                        }),
-                    );
-
-                    let path_owned = path.clone();
-                    let slot_owned = slot.to_string();
-                    emit.push_object(
-                        "Texture",
-                        Box::new(move |tree, parent| {
-                            let t = tree.append_new(parent, "Texture");
-                            tree.append_attribute(t, tex_id);
-                            tree.append_attribute(
-                                t,
-                                format!(
-                                    "{}\u{0}\u{1}Texture",
-                                    path_owned
-                                        .file_stem()
-                                        .map(|s| s.to_string_lossy().into_owned())
-                                        .unwrap_or_default()
-                                ),
-                            );
-                            tree.append_attribute(t, "");
-
-                            let ty = tree.append_new(t, "Type");
-                            tree.append_attribute(ty, "TextureVideoClip");
-                            let v = tree.append_new(t, "Version");
-                            tree.append_attribute(v, 202i32);
-                            let tn = tree.append_new(t, "TextureName");
-                            tree.append_attribute(
-                                tn,
-                                format!(
-                                    "{}\u{0}\u{1}Texture",
-                                    path_owned
-                                        .file_stem()
-                                        .map(|s| s.to_string_lossy().into_owned())
-                                        .unwrap_or_default()
-                                ),
-                            );
-                            let mr = tree.append_new(t, "ModelUVTranslation");
-                            tree.append_attribute(mr, 0.0_f64);
-                            tree.append_attribute(mr, 0.0_f64);
-                            let ms = tree.append_new(t, "ModelUVScaling");
-                            tree.append_attribute(ms, 1.0_f64);
-                            tree.append_attribute(ms, 1.0_f64);
-                            let txt = tree.append_new(t, "Texture_Alpha_Source");
-                            tree.append_attribute(txt, "None");
-                            // Slot kind on the Texture itself isn't a
-                            // standard FBX concept — we record it as a
-                            // custom prop so an importer round-tripping
-                            // back to MoGen can pick the right slot.
-                            super::doc::write_properties70(tree, t, |tt, props| {
-                                super::doc::push_prop(
-                                    tt,
-                                    props,
-                                    "MogenSlot",
-                                    "KString",
-                                    "",
-                                    "U",
-                                    AttributeValue::String(slot_owned.clone()),
-                                );
-                                super::doc::push_prop(
-                                    tt,
-                                    props,
-                                    "UseMaterial",
-                                    "bool",
-                                    "",
-                                    "",
-                                    AttributeValue::I32(1),
-                                );
-                            });
-                        }),
-                    );
-
-                    emit.connect_oo(vid_id, tex_id);
-                    (tex_id, vid_id)
-                }
+                emit.connect_oo(vid_id, tex_id);
+                tex_id
             };
 
             emit.connect_op(tex_id, mat_id, slot);
         }
     }
+
+    Ok(())
 }

--- a/crates/mogen-export/src/lib.rs
+++ b/crates/mogen-export/src/lib.rs
@@ -9,10 +9,18 @@ mod skin;
 mod texture;
 mod writer;
 
+#[cfg(feature = "fbx")]
+pub mod fbx;
+
 pub use options::ExportOptions;
 pub use texture::{FsTextureSource, MapTextureSource, TextureSource};
 pub use writer::{
     build_glb_with_options, build_glb_with_options_and_source, write_glb, write_glb_with_options,
+};
+
+#[cfg(feature = "fbx")]
+pub use fbx::{
+    build_fbx_with_options, build_fbx_with_options_and_source, write_fbx, write_fbx_with_options,
 };
 
 use serde::Serialize;

--- a/crates/mogen-export/tests/fbx.rs
+++ b/crates/mogen-export/tests/fbx.rs
@@ -395,8 +395,6 @@ fn directional_point_and_spot_lights_emit_node_attributes() {
 
 #[test]
 fn skin_emits_one_skin_deformer_with_per_joint_clusters() {
-    use glam::Mat4;
-
     // Tiny 4-vertex skinned mesh bound to two joints.
     let mut scene = SceneGraph::new();
 
@@ -412,10 +410,16 @@ fn skin_emits_one_skin_deformer_with_per_joint_clusters() {
     mesh.weights = vec![[1.0, 0.0, 0.0, 0.0]; 4];
     scene.set_mesh(mesh_node, mesh);
 
+    // Use non-identity inverse-bind matrices so a regression that swaps
+    // `Transform` and `TransformLink` (or accidentally sets both to the
+    // same value) shows up. With a non-trivial IBM, Transform = IBM and
+    // TransformLink = inverse(IBM) end up with different first elements.
+    let ibm_a = glam::Mat4::from_translation(glam::Vec3::new(1.0, 2.0, 3.0));
+    let ibm_b = glam::Mat4::from_translation(glam::Vec3::new(-4.0, 5.0, -6.0));
     let skin = Skin {
         name: "rig".into(),
         joints: vec![joint_a, joint_b],
-        inverse_bind_matrices: vec![Mat4::IDENTITY.to_cols_array_2d(); 2],
+        inverse_bind_matrices: vec![ibm_a.to_cols_array_2d(), ibm_b.to_cols_array_2d()],
         envelopes: Vec::new(),
         skeleton_root: None,
         origin: None,
@@ -465,9 +469,70 @@ fn skin_emits_one_skin_deformer_with_per_joint_clusters() {
             .attributes()[0]
             .get_arr_f64()
             .expect("f64 array");
+        // Transform = IBM (translation embedded in row 3 / cols 12..15
+        // in column-major), TransformLink = inverse(IBM) (negated
+        // translation). They MUST differ; equality would mean we
+        // accidentally emitted the same value into both.
         assert_eq!(t.len(), 16);
         assert_eq!(tl.len(), 16);
+        let t_translation = [t[12], t[13], t[14]];
+        let tl_translation = [tl[12], tl[13], tl[14]];
+        for ax in 0..3 {
+            assert!(
+                (t_translation[ax] + tl_translation[ax]).abs() < 1e-6,
+                "Transform translation {:?} should be the negation of TransformLink translation {:?}",
+                t_translation,
+                tl_translation,
+            );
+        }
+        assert!(
+            t_translation.iter().any(|v| v.abs() > 1e-6),
+            "test fixture should use non-identity IBM",
+        );
     }
+
+    // Connection direction sanity: every Cluster must be the source of
+    // an OO edge to a joint Model. A regression that swapped the
+    // direction would put the joint Model as the source.
+    let cluster_ids: Vec<i64> = clusters
+        .iter()
+        .map(|c| c.attributes()[0].get_i64().expect("cluster id"))
+        .collect();
+    let joint_model_names = ["jointA", "jointB"];
+    let joint_model_ids: Vec<i64> = objects_named(&tree, "Model")
+        .iter()
+        .filter(|m| {
+            let n = m.attributes()[1].get_string().unwrap_or("");
+            joint_model_names.iter().any(|jn| n.starts_with(jn))
+        })
+        .map(|m| m.attributes()[0].get_i64().unwrap())
+        .collect();
+    assert_eq!(joint_model_ids.len(), 2, "found both joint Models");
+    let conns = tree.root().first_child_by_name("Connections").unwrap();
+    let mut cluster_to_joint_count = 0;
+    let mut joint_to_cluster_count = 0;
+    for conn in conns.children_by_name("C") {
+        let attrs = conn.attributes();
+        if attrs[0].get_string() != Some("OO") {
+            continue;
+        }
+        let src = attrs[1].get_i64().unwrap();
+        let dst = attrs[2].get_i64().unwrap();
+        if cluster_ids.contains(&src) && joint_model_ids.contains(&dst) {
+            cluster_to_joint_count += 1;
+        }
+        if joint_model_ids.contains(&src) && cluster_ids.contains(&dst) {
+            joint_to_cluster_count += 1;
+        }
+    }
+    assert_eq!(
+        cluster_to_joint_count, 2,
+        "each Cluster must OO-connect (as source) to its joint Model",
+    );
+    assert_eq!(
+        joint_to_cluster_count, 0,
+        "joint Model must NOT be the source of an OO edge to a Cluster (direction is reversed)",
+    );
 }
 
 #[test]
@@ -519,15 +584,34 @@ fn translation_animation_emits_stack_layer_curve_node_and_three_axes() {
         assert_eq!(times.len(), 3);
         assert_eq!(values.len(), 3);
 
-        // KTime tick 1.0s == FBX_TICKS_PER_SECOND. We don't reach into the
-        // private constant; just confirm the last tick matches `1 second`
-        // at 46_186_158_000 ticks/sec within ±1 tick.
-        let expected_last = 46_186_158_000_i64;
-        assert!(
-            (times[2] - expected_last).abs() <= 1,
-            "last KeyTime tick {} not within ±1 of {}",
-            times[2],
-            expected_last,
+        // Verify every keyframe tick. The fixture clip has keys at
+        // t = 0, 0.5, 1.0 seconds. FBX uses 46_186_158_000 ticks/sec, so
+        // expected ticks are 0, 23_093_079_000, 46_186_158_000.
+        let tps = 46_186_158_000_i64;
+        let expected = [0_i64, tps / 2, tps];
+        for (i, exp) in expected.iter().enumerate() {
+            assert!(
+                (times[i] - exp).abs() <= 1,
+                "KeyTime[{i}] = {} not within ±1 of {}",
+                times[i],
+                exp,
+            );
+        }
+
+        // Linear interpolation flag must land in `KeyAttrFlags`. The
+        // FBX SDK reserves 0x4 for Linear (0x2 is Constant); a regression
+        // that swapped the constants would put 0x2 here.
+        let flags = c
+            .first_child_by_name("KeyAttrFlags")
+            .unwrap()
+            .attributes()[0]
+            .get_arr_i32()
+            .unwrap();
+        assert_eq!(
+            flags,
+            &[0x4_i32],
+            "Linear interpolation should map to KeyAttrFlags=0x4, got {:?}",
+            flags,
         );
     }
 
@@ -553,6 +637,138 @@ fn translation_animation_emits_stack_layer_curve_node_and_three_axes() {
 
 // Silence the otherwise-unused helper warning if a future test removal makes
 // `read_i32`/`read_f64` orphaned.
+#[test]
+fn step_interpolation_emits_constant_key_attr_flag() {
+    let mut scene = SceneGraph::new();
+    let id = scene.add_root("body", "group", Transform::IDENTITY);
+    scene.clips.push(Clip {
+        name: "step_clip".into(),
+        duration: 1.0,
+        tracks: vec![Track {
+            node: id,
+            property: TrackProperty::Translation,
+            interpolation: Interpolation::Step,
+            times: vec![0.0, 1.0],
+            values: vec![[0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]],
+        }],
+        origin: None,
+    });
+
+    let (tree, _) = round_trip(&scene);
+    let curves = objects_named(&tree, "AnimationCurve");
+    assert_eq!(curves.len(), 3);
+    for c in &curves {
+        let flags = c
+            .first_child_by_name("KeyAttrFlags")
+            .unwrap()
+            .attributes()[0]
+            .get_arr_i32()
+            .unwrap();
+        // Step interpolation must encode as 0x2 (KFCURVE_INTERPOLATION_CONSTANT
+        // in the FBX SDK). 0x4 = Linear. Swapping these would let "Linear"
+        // play back as steps in importers and vice versa.
+        assert_eq!(
+            flags,
+            &[0x2_i32],
+            "Step interpolation should map to KeyAttrFlags=0x2, got {:?}",
+            flags,
+        );
+    }
+}
+
+#[test]
+fn rotation_track_emits_euler_degrees() {
+    // Rotate 90° around Y. glam quat for 90° Y is (0, sin(45°), 0, cos(45°)).
+    // Euler XYZ degrees recovered should be approximately (0, 90, 0).
+    let mut scene = SceneGraph::new();
+    let id = scene.add_root("body", "group", Transform::IDENTITY);
+    let q = glam::Quat::from_rotation_y(90f32.to_radians());
+    scene.clips.push(Clip {
+        name: "rot".into(),
+        duration: 0.0,
+        tracks: vec![Track {
+            node: id,
+            property: TrackProperty::Rotation,
+            interpolation: Interpolation::Linear,
+            times: vec![0.0],
+            values: vec![[q.x, q.y, q.z, q.w]],
+        }],
+        origin: None,
+    });
+
+    let (tree, _) = round_trip(&scene);
+    let curves = objects_named(&tree, "AnimationCurve");
+    assert_eq!(curves.len(), 3);
+
+    // The Y curve should hold ~90.0; X and Z should be ~0.0. We rely on
+    // the OP connection name to disambiguate axis order.
+    let curve_node = objects_named(&tree, "AnimationCurveNode")[0];
+    let curve_node_id = curve_node.attributes()[0].get_i64().unwrap();
+
+    // Map curve_id → axis (d|X / d|Y / d|Z) via the OP connections from
+    // CurveNode to AnimationCurves.
+    let conns = tree.root().first_child_by_name("Connections").unwrap();
+    let mut axis_for_curve = std::collections::HashMap::<i64, String>::new();
+    for c in conns.children_by_name("C") {
+        let attrs = c.attributes();
+        if attrs[0].get_string() != Some("OP") {
+            continue;
+        }
+        let src = attrs[1].get_i64().unwrap();
+        let dst = attrs[2].get_i64().unwrap();
+        if dst == curve_node_id {
+            if let Some(prop) = attrs[3].get_string() {
+                axis_for_curve.insert(src, prop.to_string());
+            }
+        }
+    }
+
+    let mut x_val = None;
+    let mut y_val = None;
+    let mut z_val = None;
+    for c in &curves {
+        let id = c.attributes()[0].get_i64().unwrap();
+        let v = c
+            .first_child_by_name("KeyValueFloat")
+            .unwrap()
+            .attributes()[0]
+            .get_arr_f32()
+            .unwrap();
+        match axis_for_curve.get(&id).map(String::as_str) {
+            Some("d|X") => x_val = Some(v[0]),
+            Some("d|Y") => y_val = Some(v[0]),
+            Some("d|Z") => z_val = Some(v[0]),
+            _ => {}
+        }
+    }
+    let x_val = x_val.expect("X curve");
+    let y_val = y_val.expect("Y curve");
+    let z_val = z_val.expect("Z curve");
+    assert!(x_val.abs() < 1e-3, "X Euler should be ~0, got {x_val}");
+    assert!((y_val - 90.0).abs() < 1e-3, "Y Euler should be ~90, got {y_val}");
+    assert!(z_val.abs() < 1e-3, "Z Euler should be ~0, got {z_val}");
+}
+
+#[test]
+fn empty_scene_produces_valid_fbx() {
+    let scene = SceneGraph::new();
+    let (tree, _) = round_trip(&scene);
+    // Just hitting `round_trip` proves the writer doesn't panic on an
+    // empty scene; the AnyTree load proves the result is structurally
+    // valid. Spot-check the top-level shape.
+    let names: Vec<&str> = tree.root().children().map(|c| c.name()).collect();
+    for required in [
+        "FBXHeaderExtension",
+        "GlobalSettings",
+        "Documents",
+        "Definitions",
+        "Objects",
+        "Connections",
+        "Takes",
+    ] {
+        assert!(names.iter().any(|n| *n == required), "missing {required}");
+    }
+}
 #[allow(dead_code)]
 fn _used(t: NodeHandle<'_>) {
     let _ = read_i32(t, "x");

--- a/crates/mogen-export/tests/fbx.rs
+++ b/crates/mogen-export/tests/fbx.rs
@@ -1,0 +1,560 @@
+//! End-to-end coverage for the FBX exporter. We round-trip every supported
+//! scene-graph feature (mesh / material+texture / light / skin / animation)
+//! through `write_fbx` + `fbxcel::tree::any::AnyTree::from_seekable_reader`
+//! and assert on the structural shape of the resulting FBX node tree.
+//!
+//! The bytes-on-disk path is exercised via the public `mogen_export::write_fbx`
+//! entry point so we cover the writer + footer machinery, not just the
+//! intermediate Tree.
+
+#![cfg(feature = "fbx")]
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::process::id;
+
+use fbxcel::tree::any::AnyTree;
+use fbxcel::tree::v7400::{NodeHandle, Tree};
+
+use mogen_core::{
+    Clip, Interpolation, Light, LightKind, Material, Mesh, SceneGraph, Skin,
+    TextureRef, Track, TrackProperty, Transform,
+};
+use mogen_geom::box_mesh;
+
+fn unique_tmp(name: &str) -> PathBuf {
+    // Each test file gets a per-call counter so cargo's default parallel
+    // runner doesn't have two tests racing to read/write the same path.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("mogen-fbx-export-{}-{n}-{name}", id()))
+}
+
+/// Serialise via the public `write_fbx`, read the file back into a Tree, and
+/// hand it (plus the raw bytes for any byte-level assertions) to the caller.
+fn round_trip(scene: &SceneGraph) -> (Tree, Vec<u8>) {
+    let path = unique_tmp("scene.fbx");
+    mogen_export::write_fbx(scene, &path).expect("write_fbx ok");
+    let bytes = fs::read(&path).expect("reading produced fbx");
+
+    let tree = match AnyTree::from_seekable_reader(Cursor::new(bytes.clone()))
+        .expect("loading fbx via fbxcel")
+    {
+        AnyTree::V7400(_, tree, _footer) => tree,
+        _ => panic!("expected V7400 fbx"),
+    };
+    (tree, bytes)
+}
+
+/// Convenience: collect every direct child of `parent` whose name matches.
+fn children_named<'a>(parent: NodeHandle<'a>, name: &str) -> Vec<NodeHandle<'a>> {
+    parent.children_by_name(name).collect()
+}
+
+/// Locate the `Objects` node and return every direct child with `name`.
+fn objects_named<'a>(tree: &'a Tree, name: &str) -> Vec<NodeHandle<'a>> {
+    let objects = tree
+        .root()
+        .first_child_by_name("Objects")
+        .expect("Objects node");
+    children_named(objects, name)
+}
+
+/// Look up the i32 attribute under `parent/child`. Panics on missing
+/// child or wrong attribute type — every test using this asserts on
+/// values it just produced.
+fn read_i32(parent: NodeHandle<'_>, child: &str) -> i32 {
+    parent
+        .first_child_by_name(child)
+        .expect(child)
+        .attributes()[0]
+        .get_i32()
+        .expect("i32")
+}
+
+fn read_f64(parent: NodeHandle<'_>, child: &str) -> f64 {
+    parent
+        .first_child_by_name(child)
+        .expect(child)
+        .attributes()[0]
+        .get_f64()
+        .expect("f64")
+}
+
+#[test]
+fn top_level_structure_matches_fbx_7_4_layout() {
+    let mut scene = SceneGraph::new();
+    scene.add_root("group", "group", Transform::IDENTITY);
+
+    let (tree, bytes) = round_trip(&scene);
+
+    // FBX binary magic: "Kaydara FBX Binary  \x00\x1a\x00".
+    assert_eq!(
+        &bytes[..23],
+        b"Kaydara FBX Binary  \x00\x1a\x00",
+        "fbx binary header should match the canonical magic"
+    );
+
+    let root = tree.root();
+    let names: Vec<&str> = root.children().map(|c| c.name()).collect();
+    for required in [
+        "FBXHeaderExtension",
+        "GlobalSettings",
+        "Documents",
+        "Definitions",
+        "Objects",
+        "Connections",
+        "Takes",
+    ] {
+        assert!(
+            names.iter().any(|n| *n == required),
+            "missing top-level section {required}: {names:?}",
+        );
+    }
+}
+
+#[test]
+fn global_settings_carry_y_up_and_meter_units() {
+    let mut scene = SceneGraph::new();
+    scene.add_root("a", "group", Transform::IDENTITY);
+
+    let (tree, _) = round_trip(&scene);
+    let gs = tree
+        .root()
+        .first_child_by_name("GlobalSettings")
+        .expect("GlobalSettings");
+    let props = gs
+        .first_child_by_name("Properties70")
+        .expect("Properties70 under GlobalSettings");
+
+    let mut up = None;
+    let mut unit_scale = None;
+    for p in props.children_by_name("P") {
+        let attrs = p.attributes();
+        let key = attrs[0].get_string().unwrap_or("");
+        match key {
+            "UpAxis" => up = attrs[4].get_i32(),
+            "UnitScaleFactor" => unit_scale = attrs[4].get_f64(),
+            _ => {}
+        }
+    }
+    assert_eq!(up, Some(1), "UpAxis should be 1 (Y-up)");
+    assert_eq!(unit_scale, Some(1.0), "UnitScaleFactor should be 1.0 (meters)");
+}
+
+#[test]
+fn mesh_round_trip_emits_geometry_with_negate_terminated_polygons() {
+    let mut scene = SceneGraph::new();
+    let id = scene.add_root("box", "box", Transform::IDENTITY);
+    scene.set_mesh(id, box_mesh([1.0, 1.0, 1.0], mogen_core::UvMode::default()));
+
+    let (tree, _) = round_trip(&scene);
+
+    let geometries = objects_named(&tree, "Geometry");
+    assert_eq!(geometries.len(), 1, "exactly one Geometry");
+    let g = geometries[0];
+
+    // Box mesh produces 24 verts + 36 indices in the GLB exporter; we hold
+    // the same numbers here because we don't dedupe.
+    let verts = g.first_child_by_name("Vertices").expect("Vertices");
+    let v_arr = verts.attributes()[0].get_arr_f64().expect("f64 array");
+    assert!(
+        !v_arr.is_empty() && v_arr.len() % 3 == 0,
+        "Vertices length {} must be non-empty and divisible by 3",
+        v_arr.len(),
+    );
+
+    let pvi = g
+        .first_child_by_name("PolygonVertexIndex")
+        .expect("PolygonVertexIndex");
+    let pvi_arr = pvi.attributes()[0].get_arr_i32().expect("i32 array");
+    assert!(pvi_arr.len() % 3 == 0, "triangle list");
+    // Every third entry — the polygon terminator — must be negative
+    // (negate-and-decrement encoding for the last index of a polygon).
+    for (chunk_idx, tri) in pvi_arr.chunks_exact(3).enumerate() {
+        assert!(tri[0] >= 0, "tri {chunk_idx} entry 0 = {} should be ≥0", tri[0]);
+        assert!(tri[1] >= 0, "tri {chunk_idx} entry 1 = {} should be ≥0", tri[1]);
+        assert!(tri[2] < 0, "tri {chunk_idx} entry 2 = {} should be terminator (<0)", tri[2]);
+    }
+
+    // Normal layer: present, ByVertice direct.
+    let n = g.first_child_by_name("LayerElementNormal").expect("normals");
+    assert_eq!(
+        n.first_child_by_name("MappingInformationType")
+            .unwrap()
+            .attributes()[0]
+            .get_string()
+            .unwrap(),
+        "ByVertice",
+    );
+
+    // OO connection from this Geometry's id to the Model's id, and from the
+    // Model to RootNode (0).
+    let geom_id = g.attributes()[0].get_i64().expect("geometry id");
+    let model_id = objects_named(&tree, "Model")[0]
+        .attributes()[0]
+        .get_i64()
+        .expect("model id");
+
+    let conns = tree
+        .root()
+        .first_child_by_name("Connections")
+        .expect("Connections");
+    let mut found_geom_to_model = false;
+    let mut found_model_to_root = false;
+    for c in conns.children_by_name("C") {
+        let attrs = c.attributes();
+        let kind = attrs[0].get_string().unwrap();
+        let child = attrs[1].get_i64().unwrap();
+        let parent = attrs[2].get_i64().unwrap();
+        if kind == "OO" && child == geom_id && parent == model_id {
+            found_geom_to_model = true;
+        }
+        if kind == "OO" && child == model_id && parent == 0 {
+            found_model_to_root = true;
+        }
+    }
+    assert!(found_geom_to_model, "Geometry must OO-connect to Model");
+    assert!(found_model_to_root, "Model must OO-connect to RootNode (0)");
+}
+
+#[test]
+fn material_with_base_color_texture_emits_full_chain() {
+    use image::{ImageBuffer, Rgb};
+
+    // 1x1 PNG so the embedded `Content` blob can be byte-compared.
+    let img: ImageBuffer<Rgb<u8>, Vec<u8>> = ImageBuffer::from_pixel(1, 1, Rgb([200, 180, 140]));
+    let mut png_bytes = Vec::new();
+    img.write_to(&mut Cursor::new(&mut png_bytes), image::ImageFormat::Png)
+        .expect("encoding 1x1 png");
+
+    let png_path = unique_tmp("albedo.png");
+    fs::write(&png_path, &png_bytes).expect("writing fixture png");
+
+    let mut scene = SceneGraph::new();
+    let mut mat = Material::new("painted");
+    mat.base_color_texture = Some(TextureRef::new(png_path.clone()));
+    let mat_id = scene.add_material(mat);
+
+    let id = scene.add_root("box", "box", Transform::IDENTITY);
+    scene.set_mesh(id, box_mesh([1.0, 1.0, 1.0], mogen_core::UvMode::default()));
+    scene.set_material(id, mat_id);
+
+    let (tree, _) = round_trip(&scene);
+
+    let materials = objects_named(&tree, "Material");
+    assert_eq!(materials.len(), 1);
+    let m = materials[0];
+    let shading = m
+        .first_child_by_name("ShadingModel")
+        .unwrap()
+        .attributes()[0]
+        .get_string()
+        .unwrap();
+    assert_eq!(shading, "Phong");
+
+    // Custom Roughness + Metallic property entries are present so PBR
+    // importers can recover the originals.
+    let props = m.first_child_by_name("Properties70").unwrap();
+    let mut have_roughness = false;
+    let mut have_metallic = false;
+    for p in props.children_by_name("P") {
+        let key = p.attributes()[0].get_string().unwrap_or("");
+        if key == "Roughness" {
+            have_roughness = true;
+        }
+        if key == "Metallic" {
+            have_metallic = true;
+        }
+    }
+    assert!(have_roughness, "Material should carry Roughness PBR factor");
+    assert!(have_metallic, "Material should carry Metallic PBR factor");
+
+    // Texture + Video pair, with the Video carrying the embedded bytes.
+    let textures = objects_named(&tree, "Texture");
+    let videos = objects_named(&tree, "Video");
+    assert_eq!(textures.len(), 1, "one Texture");
+    assert_eq!(videos.len(), 1, "one Video");
+
+    let content = videos[0].first_child_by_name("Content").expect("Content");
+    let blob = content.attributes()[0].get_binary().expect("binary content");
+    assert_eq!(blob, png_bytes.as_slice(), "embedded bytes must match input");
+
+    // OP connection Texture -> Material under property "DiffuseColor".
+    let tex_id = textures[0].attributes()[0].get_i64().unwrap();
+    let mat_obj_id = m.attributes()[0].get_i64().unwrap();
+    let conns = tree.root().first_child_by_name("Connections").unwrap();
+    let mut found_op = false;
+    for c in conns.children_by_name("C") {
+        let attrs = c.attributes();
+        let kind = attrs[0].get_string().unwrap_or("");
+        if kind == "OP"
+            && attrs[1].get_i64() == Some(tex_id)
+            && attrs[2].get_i64() == Some(mat_obj_id)
+            && attrs[3].get_string() == Some("DiffuseColor")
+        {
+            found_op = true;
+        }
+    }
+    assert!(found_op, "expected OP Texture->Material on DiffuseColor");
+}
+
+#[test]
+fn directional_point_and_spot_lights_emit_node_attributes() {
+    let mut scene = SceneGraph::new();
+
+    let dir = scene.add_root("sun", "light", Transform::IDENTITY);
+    scene.set_light(
+        dir,
+        Light {
+            kind: LightKind::Directional,
+            color: [1.0, 0.95, 0.85],
+            intensity: 2.0,
+            range: None,
+            inner_cone_rad: 0.0,
+            outer_cone_rad: std::f32::consts::FRAC_PI_4,
+        },
+    );
+
+    let pt = scene.add_root("lamp", "light", Transform::IDENTITY);
+    scene.set_light(
+        pt,
+        Light {
+            kind: LightKind::Point,
+            color: [1.0, 1.0, 1.0],
+            intensity: 10.0,
+            range: Some(8.0),
+            ..Default::default()
+        },
+    );
+
+    let spot = scene.add_root("spot", "light", Transform::IDENTITY);
+    scene.set_light(
+        spot,
+        Light {
+            kind: LightKind::Spot,
+            color: [1.0, 1.0, 1.0],
+            intensity: 20.0,
+            range: Some(10.0),
+            inner_cone_rad: 20f32.to_radians(),
+            outer_cone_rad: 35f32.to_radians(),
+        },
+    );
+
+    let (tree, _) = round_trip(&scene);
+
+    let attrs = objects_named(&tree, "NodeAttribute");
+    assert_eq!(attrs.len(), 3, "one NodeAttribute per light");
+
+    // Collect (light_type, has inner, has outer) per attribute.
+    let mut light_types = HashMap::<i32, NodeHandle<'_>>::new();
+    for a in &attrs {
+        let props = a.first_child_by_name("Properties70").unwrap();
+        let mut light_type = -1;
+        for p in props.children_by_name("P") {
+            if p.attributes()[0].get_string() == Some("LightType") {
+                light_type = p.attributes()[4].get_i32().unwrap();
+            }
+        }
+        light_types.insert(light_type, *a);
+    }
+
+    let directional = light_types.remove(&1).expect("directional NodeAttribute");
+    let _ = directional;
+
+    let point = light_types.remove(&0).expect("point NodeAttribute");
+    let p_props = point.first_child_by_name("Properties70").unwrap();
+    let mut far_end = None;
+    for p in p_props.children_by_name("P") {
+        if p.attributes()[0].get_string() == Some("FarAttenuationEnd") {
+            far_end = p.attributes()[4].get_f64();
+        }
+    }
+    assert_eq!(far_end, Some(8.0), "point light range → FarAttenuationEnd");
+
+    let spot = light_types.remove(&2).expect("spot NodeAttribute");
+    let s_props = spot.first_child_by_name("Properties70").unwrap();
+    let mut inner = None;
+    let mut outer = None;
+    for p in s_props.children_by_name("P") {
+        if p.attributes()[0].get_string() == Some("InnerAngle") {
+            inner = p.attributes()[4].get_f64();
+        }
+        if p.attributes()[0].get_string() == Some("OuterAngle") {
+            outer = p.attributes()[4].get_f64();
+        }
+    }
+    let inner = inner.expect("InnerAngle");
+    let outer = outer.expect("OuterAngle");
+    assert!((inner - 20.0).abs() < 1e-4);
+    assert!((outer - 35.0).abs() < 1e-4);
+}
+
+#[test]
+fn skin_emits_one_skin_deformer_with_per_joint_clusters() {
+    use glam::Mat4;
+
+    // Tiny 4-vertex skinned mesh bound to two joints.
+    let mut scene = SceneGraph::new();
+
+    let mesh_node = scene.add_root("body", "mesh", Transform::IDENTITY);
+    let joint_a = scene.add_root("jointA", "joint", Transform::IDENTITY);
+    let joint_b = scene.add_root("jointB", "joint", Transform::IDENTITY);
+
+    // Vertices: 4 positions, each fully weighted to one joint (alternating).
+    let positions = vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]];
+    let normals = vec![[0.0, 0.0, 1.0]; 4];
+    let mut mesh = Mesh::new(positions, normals, vec![0, 1, 2, 0, 2, 3]);
+    mesh.joints = vec![[0, 0, 0, 0], [1, 0, 0, 0], [0, 0, 0, 0], [1, 0, 0, 0]];
+    mesh.weights = vec![[1.0, 0.0, 0.0, 0.0]; 4];
+    scene.set_mesh(mesh_node, mesh);
+
+    let skin = Skin {
+        name: "rig".into(),
+        joints: vec![joint_a, joint_b],
+        inverse_bind_matrices: vec![Mat4::IDENTITY.to_cols_array_2d(); 2],
+        envelopes: Vec::new(),
+        skeleton_root: None,
+        origin: None,
+    };
+    let skin_id = scene.add_skin(skin);
+    scene.set_skin(mesh_node, skin_id);
+
+    let (tree, _) = round_trip(&scene);
+
+    let deformers = objects_named(&tree, "Deformer");
+    let skins: Vec<_> = deformers
+        .iter()
+        .filter(|d| d.attributes()[2].get_string() == Some("Skin"))
+        .collect();
+    let clusters: Vec<_> = deformers
+        .iter()
+        .filter(|d| d.attributes()[2].get_string() == Some("Cluster"))
+        .collect();
+    assert_eq!(skins.len(), 1, "one Skin Deformer");
+    assert_eq!(clusters.len(), 2, "two joint Cluster Deformers");
+
+    for c in &clusters {
+        let idx = c
+            .first_child_by_name("Indexes")
+            .expect("Indexes")
+            .attributes()[0]
+            .get_arr_i32()
+            .expect("i32 array");
+        let w = c
+            .first_child_by_name("Weights")
+            .expect("Weights")
+            .attributes()[0]
+            .get_arr_f64()
+            .expect("f64 array");
+        assert!(!idx.is_empty(), "every cluster covers ≥1 vertex");
+        assert_eq!(idx.len(), w.len(), "indexes/weights paired");
+
+        let t = c
+            .first_child_by_name("Transform")
+            .expect("Transform")
+            .attributes()[0]
+            .get_arr_f64()
+            .expect("f64 array");
+        let tl = c
+            .first_child_by_name("TransformLink")
+            .expect("TransformLink")
+            .attributes()[0]
+            .get_arr_f64()
+            .expect("f64 array");
+        assert_eq!(t.len(), 16);
+        assert_eq!(tl.len(), 16);
+    }
+}
+
+#[test]
+fn translation_animation_emits_stack_layer_curve_node_and_three_axes() {
+    let mut scene = SceneGraph::new();
+    let id = scene.add_root("body", "group", Transform::IDENTITY);
+
+    let clip = Clip {
+        name: "wave".into(),
+        duration: 1.0,
+        tracks: vec![Track {
+            node: id,
+            property: TrackProperty::Translation,
+            interpolation: Interpolation::Linear,
+            times: vec![0.0, 0.5, 1.0],
+            values: vec![[0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
+        }],
+        origin: None,
+    };
+    scene.clips.push(clip);
+
+    let (tree, _) = round_trip(&scene);
+
+    assert_eq!(objects_named(&tree, "AnimationStack").len(), 1);
+    assert_eq!(objects_named(&tree, "AnimationLayer").len(), 1);
+    assert_eq!(objects_named(&tree, "AnimationCurveNode").len(), 1);
+    let curves = objects_named(&tree, "AnimationCurve");
+    assert_eq!(curves.len(), 3, "X/Y/Z curves emitted as three AnimationCurves");
+
+    let model_id = objects_named(&tree, "Model")[0]
+        .attributes()[0]
+        .get_i64()
+        .expect("model id");
+
+    // Each curve carries 3 KeyTime entries and 3 KeyValueFloat entries.
+    for c in &curves {
+        let times = c
+            .first_child_by_name("KeyTime")
+            .unwrap()
+            .attributes()[0]
+            .get_arr_i64()
+            .unwrap();
+        let values = c
+            .first_child_by_name("KeyValueFloat")
+            .unwrap()
+            .attributes()[0]
+            .get_arr_f32()
+            .unwrap();
+        assert_eq!(times.len(), 3);
+        assert_eq!(values.len(), 3);
+
+        // KTime tick 1.0s == FBX_TICKS_PER_SECOND. We don't reach into the
+        // private constant; just confirm the last tick matches `1 second`
+        // at 46_186_158_000 ticks/sec within ±1 tick.
+        let expected_last = 46_186_158_000_i64;
+        assert!(
+            (times[2] - expected_last).abs() <= 1,
+            "last KeyTime tick {} not within ±1 of {}",
+            times[2],
+            expected_last,
+        );
+    }
+
+    // The CurveNode OP-connects to the Model on `Lcl Translation`.
+    let curve_node_id = objects_named(&tree, "AnimationCurveNode")[0]
+        .attributes()[0]
+        .get_i64()
+        .unwrap();
+    let conns = tree.root().first_child_by_name("Connections").unwrap();
+    let mut found = false;
+    for c in conns.children_by_name("C") {
+        let attrs = c.attributes();
+        if attrs[0].get_string() == Some("OP")
+            && attrs[1].get_i64() == Some(curve_node_id)
+            && attrs[2].get_i64() == Some(model_id)
+            && attrs[3].get_string() == Some("Lcl Translation")
+        {
+            found = true;
+        }
+    }
+    assert!(found, "CurveNode must OP-connect to Model on Lcl Translation");
+}
+
+// Silence the otherwise-unused helper warning if a future test removal makes
+// `read_i32`/`read_f64` orphaned.
+#[allow(dead_code)]
+fn _used(t: NodeHandle<'_>) {
+    let _ = read_i32(t, "x");
+    let _ = read_f64(t, "y");
+}

--- a/crates/mogen/Cargo.toml
+++ b/crates/mogen/Cargo.toml
@@ -13,7 +13,7 @@ mogen-core = { workspace = true }
 # The CLI wants the full pipeline, so opt back in to every default feature.
 mogen-dsl = { workspace = true, features = ["csg"] }
 mogen-validate = { workspace = true, features = ["csg"] }
-mogen-export = { workspace = true, features = ["textures", "merge"] }
+mogen-export = { workspace = true, features = ["textures", "merge", "fbx"] }
 mogen-llm = { workspace = true }
 mogen-moghub-client = { workspace = true, features = ["oauth"] }
 mogen-update = { workspace = true }

--- a/crates/mogen/src/commands/animate.rs
+++ b/crates/mogen/src/commands/animate.rs
@@ -182,5 +182,5 @@ Existing file:\n\n{existing}",
     fs::write(&dsl_path, &wrapped)
         .with_context(|| format!("writing {}", dsl_path.display()))?;
 
-    build(dsl_path, out_path)
+    build(dsl_path, out_path, None)
 }

--- a/crates/mogen/src/commands/build.rs
+++ b/crates/mogen/src/commands/build.rs
@@ -8,7 +8,24 @@ use mogen_dsl::module::FsLoader;
 use crate::format::{format_duration, print_build_summary};
 use crate::spinner::Spinner;
 
-pub(crate) fn build(input: PathBuf, out: PathBuf) -> Result<()> {
+/// Output container the build command should emit. Decided from the
+/// `--format` flag (when supplied) or the output path's extension.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum BuildFormat {
+    Glb,
+    Fbx,
+}
+
+impl BuildFormat {
+    pub(crate) fn from_path(out: &std::path::Path) -> Self {
+        match out.extension().and_then(|e| e.to_str()) {
+            Some(e) if e.eq_ignore_ascii_case("fbx") => BuildFormat::Fbx,
+            _ => BuildFormat::Glb,
+        }
+    }
+}
+
+pub(crate) fn build(input: PathBuf, out: PathBuf, format: Option<BuildFormat>) -> Result<()> {
     let start = Instant::now();
     let label = input
         .file_name()
@@ -80,9 +97,19 @@ pub(crate) fn build(input: PathBuf, out: PathBuf) -> Result<()> {
         scene.resolve_texture_paths(base);
     }
 
-    spinner.set_message(format!("build {label}: writing GLB"));
-    if let Err(e) = mogen_export::write_glb(&scene, &out) {
-        spinner.abandon_with_message(format!("build {label}: GLB export failed"));
+    let format = format.unwrap_or_else(|| BuildFormat::from_path(&out));
+    let (label_str, write_result) = match format {
+        BuildFormat::Glb => {
+            spinner.set_message(format!("build {label}: writing GLB"));
+            ("GLB", mogen_export::write_glb(&scene, &out))
+        }
+        BuildFormat::Fbx => {
+            spinner.set_message(format!("build {label}: writing FBX"));
+            ("FBX", mogen_export::write_fbx(&scene, &out))
+        }
+    };
+    if let Err(e) = write_result {
+        spinner.abandon_with_message(format!("build {label}: {label_str} export failed"));
         return Err(e);
     }
 

--- a/crates/mogen/src/commands/generate.rs
+++ b/crates/mogen/src/commands/generate.rs
@@ -147,5 +147,5 @@ pub(crate) fn generate(args: GenerateArgs) -> Result<()> {
         .with_context(|| format!("writing {}", dsl_path.display()))?;
 
     // Reuse the regular build path so the user gets the same progress line.
-    build(dsl_path, out_path)
+    build(dsl_path, out_path, None)
 }

--- a/crates/mogen/src/commands/modify.rs
+++ b/crates/mogen/src/commands/modify.rs
@@ -191,5 +191,5 @@ Existing file:\n\n{existing}",
     fs::write(&dsl_path, &wrapped)
         .with_context(|| format!("writing {}", dsl_path.display()))?;
 
-    build(dsl_path, out_path)
+    build(dsl_path, out_path, None)
 }

--- a/crates/mogen/src/commands/repair.rs
+++ b/crates/mogen/src/commands/repair.rs
@@ -60,7 +60,7 @@ pub(crate) fn repair(args: RepairArgs) -> Result<()> {
             .out
             .unwrap_or_else(|| args.input.with_extension("glb"));
         ensure_parent_dir(&out)?;
-        return build(args.input, out);
+        return build(args.input, out, None);
     }
 
     let filename = args.input.to_string_lossy().to_string();
@@ -189,5 +189,5 @@ pub(crate) fn repair(args: RepairArgs) -> Result<()> {
         return Ok(());
     }
 
-    build(resolved_dsl_out, resolved_out)
+    build(resolved_dsl_out, resolved_out, None)
 }

--- a/crates/mogen/src/commands/textures.rs
+++ b/crates/mogen/src/commands/textures.rs
@@ -241,7 +241,7 @@ pub(crate) fn textures_cmd(args: mogen_llm::textures::TexturesArgs) -> Result<()
     }
 
     let glb_out = args.glb.clone().unwrap_or_else(|| args.input.with_extension("glb"));
-    let build_result = build(dsl_out, glb_out);
+    let build_result = build(dsl_out, glb_out, None);
     if !failures.is_empty() {
         // Even if the build succeeded with the partial textures, the run as
         // a whole had failures and the caller should know.

--- a/crates/mogen/src/main.rs
+++ b/crates/mogen/src/main.rs
@@ -78,6 +78,25 @@ impl From<ProviderArg> for Provider {
     }
 }
 
+/// CLI-facing mirror of [`commands::build::BuildFormat`]. Kept here so
+/// `clap::ValueEnum` doesn't leak into the command module.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum BuildFormatArg {
+    /// Binary glTF 2.0 (default).
+    Glb,
+    /// Autodesk FBX 7.4 binary.
+    Fbx,
+}
+
+impl From<BuildFormatArg> for commands::build::BuildFormat {
+    fn from(f: BuildFormatArg) -> Self {
+        match f {
+            BuildFormatArg::Glb => commands::build::BuildFormat::Glb,
+            BuildFormatArg::Fbx => commands::build::BuildFormat::Fbx,
+        }
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "mogen", version, about = "Procedural 3D model generator")]
 struct Cli {
@@ -489,12 +508,18 @@ enum Cmd {
         #[command(subcommand)]
         cmd: MoghubCmd,
     },
-    /// Compile a DSL file to GLB.
+    /// Compile a DSL file to a binary scene container.
+    ///
+    /// Output format defaults to GLB but is auto-detected from the output
+    /// extension (`.fbx` selects FBX). Pass `--format` to override.
     Build {
         input: PathBuf,
-        /// Output GLB path. Defaults to `<input>.glb` alongside the DSL file.
+        /// Output path. Defaults to `<input>.glb` alongside the DSL file.
         #[arg(short, long)]
         out: Option<PathBuf>,
+        /// Force a specific output container, ignoring the extension hint.
+        #[arg(long, value_enum)]
+        format: Option<BuildFormatArg>,
     },
     /// Parse a DSL file and print the AST.
     Parse { input: PathBuf },
@@ -850,9 +875,18 @@ fn main() -> ExitCode {
     let result = match cli.cmd {
         Cmd::Auth { cmd } => auth_dispatch(cmd.into()),
         Cmd::Moghub { cmd } => dispatch_moghub(cmd),
-        Cmd::Build { input, out } => {
-            let out = out.unwrap_or_else(|| input.with_extension("glb"));
-            build(input, out)
+        Cmd::Build { input, out, format } => {
+            // Default extension follows the chosen format. When no
+            // `--format` is given and `--out` is omitted, fall back to
+            // `.glb` to preserve the historical default; users wanting
+            // FBX must either pass `-o foo.fbx` or `--format fbx` (which
+            // then triggers the `.fbx` default extension).
+            let default_ext = match format {
+                Some(BuildFormatArg::Fbx) => "fbx",
+                _ => "glb",
+            };
+            let out = out.unwrap_or_else(|| input.with_extension(default_ext));
+            build(input, out, format.map(Into::into))
         }
         Cmd::Parse { input } => parse_cmd(input),
         Cmd::Check { input, json } => check(input, json),

--- a/crates/mogen/src/main.rs
+++ b/crates/mogen/src/main.rs
@@ -514,7 +514,8 @@ enum Cmd {
     /// extension (`.fbx` selects FBX). Pass `--format` to override.
     Build {
         input: PathBuf,
-        /// Output path. Defaults to `<input>.glb` alongside the DSL file.
+        /// Output path. Defaults to `<input>.glb` alongside the DSL file
+        /// (or `<input>.fbx` when `--format fbx` is set).
         #[arg(short, long)]
         out: Option<PathBuf>,
         /// Force a specific output container, ignoring the extension hint.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -121,15 +121,18 @@ out of MoGHub on the web.
 
 ## `build`
 
-Compile a DSL file to a GLB.
+Compile a DSL file to a binary scene container — GLB by default, or FBX
+7.4 binary when the output path ends in `.fbx` or `--format fbx` is
+passed.
 
 ```sh
-mogen build <input.mog> [--out <output.glb>]
+mogen build <input.mog> [--out <output>] [--format glb|fbx]
 ```
 
 | flag | meaning |
 |---|---|
-| `--out`, `-o` | Output GLB path. Defaults to `<input>.glb` alongside the source file. |
+| `--out`, `-o` | Output path. Defaults to `<input>.glb` (or `<input>.fbx` when `--format fbx` is set). |
+| `--format` | Force a specific container, ignoring the extension hint. One of `glb` (default) or `fbx`. |
 
 **Pipeline.** `build` runs the canonical front-to-back pipeline:
 
@@ -137,7 +140,7 @@ mogen build <input.mog> [--out <output.glb>]
 2. AST validation — referential and typing errors with source spans.
 3. Lower to `SceneGraph` — module expansion, placement shortcuts, attach solver, animation/skinning lowering.
 4. Graph validation — topological invariants (skeleton ancestry, weight sums, …).
-5. Export GLB — PBR materials, embedded textures, animation channels, optional skin data, optional sibling-mesh merge.
+5. Export — PBR materials, embedded textures, animation channels, optional skin data, optional sibling-mesh merge. The format is picked from `--format` (when supplied) or sniffed from the output extension; `.fbx` (case-insensitive) selects FBX, anything else selects GLB.
 
 `generate`, `modify`, `animate`, `repair`, and `textures` all converge on
 this command at the end of their flows. If you've already authored a
@@ -145,7 +148,24 @@ this command at the end of their flows. If you've already authored a
 
 ```sh
 mogen build examples/chair.mog --out chair.glb
+mogen build examples/chair.mog --out chair.fbx          # extension dispatch
+mogen build examples/chair.mog --format fbx             # → chair.fbx
 ```
+
+### FBX format notes
+
+The FBX exporter emits FBX 7.4 binary that loads in Blender 4.x and other
+standard FBX importers. Notable mappings (lossy by FBX's spec):
+
+- PBR materials are encoded as Phong; the raw `metallic` and `roughness`
+  factors ride along as `Properties70` entries so PBR-aware importers
+  (Blender's principled BSDF) can recover them.
+- Quaternion rotations and rotation tracks are converted to Euler XYZ
+  degrees; the FBX `RotationOrder` is set to XYZ to match.
+- Light intensity passes through verbatim — FBX doesn't distinguish
+  candela (point/spot) from lux (directional) like glTF does.
+- DSL extras (`role`, `tags`, `cast_shadow`, `kind`) are preserved as
+  custom `Properties70` entries on each Model.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds binary FBX 7.4 export as a sibling to the existing GLB pipeline, behind a new opt-in `fbx` Cargo feature on `mogen-export`. The CLI's `mogen build` learns to dispatch on the output extension (`.fbx` selects FBX) or an explicit `--format glb|fbx` flag.

ASCII FBX, FBX import, and any other format are out of scope.

## Public API

In `mogen-export`, all gated `#[cfg(feature = "fbx")]`, mirroring the GLB shape:

```rust
pub fn write_fbx(scene: &SceneGraph, out: &Path) -> Result<()>;
pub fn write_fbx_with_options<F: Fn(&str)>(scene, out, opts, progress) -> Result<()>;
pub fn build_fbx_with_options<F: Fn(&str)>(scene, opts, progress) -> Result<Vec<u8>>;
pub fn build_fbx_with_options_and_source<F: Fn(&str)>(scene, opts, source, progress) -> Result<Vec<u8>>;
```

`ExportOptions`, `TextureSource`, and the `merge` feature interaction are reused unchanged — the merge passes run before format-specific emission, same as for GLB.

## Crate choice

Picked `fbxcel = "0.9"` with `features = ["writer", "tree"]`. Pure Rust, Apache-2.0/MIT, no C/C++ dependency. The high-level `Tree` API is a perfect fit: emitters build subtrees in-memory then `Writer::write_tree` serialises them, which keeps Definitions/Objects/Connections in sync without a two-pass walk.

Rejected alternatives: `fbxcel-dom` (incomplete), `fbx_direct` (deprecated → fbxcel), `fbx` (reader-only), SmallFBX (C++).

## What's emitted

| Source | Target | Notes |
|---|---|---|
| `SceneNode` | `Model` (Mesh/Light/Null) | TRS via `Lcl Translation/Rotation/Scaling`; quat → Euler XYZ degrees with `RotationOrder=0` |
| `Mesh.positions/normals/uvs` | `Geometry/Vertices` + `LayerElementNormal`/`LayerElementUV` | ByVertice direct mapping |
| `Mesh.indices` | `PolygonVertexIndex` | Last index of each triangle negate-and-decremented (`!idx`) per FBX spec |
| `Material` (PBR) | `Material` (Phong) | DiffuseColor/EmissiveColor/ShininessExponent for the Phong path; raw `Roughness`/`Metallic`/`Transmission`/etc. as `Properties70` entries so PBR importers recover them losslessly |
| `TextureRef` | `Texture` + `Video` | Bytes embedded raw via `Video.Content`; OP-connected to material on `DiffuseColor`/`NormalMap`/`EmissiveColor`/`AmbientColor`/`MetallicRoughnessTexture` |
| `Skin` | `Deformer` (Skin) + per-joint `Deformer` (Cluster) | `Transform`/`TransformLink` from the inverse-bind matrices |
| `Clip` | `AnimStack` + `AnimLayer` + `AnimCurveNode` + 3× `AnimCurve` | KTime ticks (46_186_158_000/sec); rotation tracks quat → Euler XYZ at each keyframe |
| `Light` | `NodeAttribute` (Light) | LightType 0/1/2 (Point/Directional/Spot), FarAttenuationEnd from `range`, InnerAngle/OuterAngle (deg) for spot |
| DSL extras (`role`, `tags`, `cast_shadow`, `kind`) | `Properties70` custom props | Preserved for round-trip tooling |

Coordinate system: `GlobalSettings` advertises Y-up, right-handed, -Z forward, meters (`UpAxis=1`, `UnitScaleFactor=1.0`) — matches glTF and the codebase's de-facto convention. Blender 4.x respects this.

## CLI

```sh
mogen build foo.mog --out foo.glb            # GLB (unchanged default)
mogen build foo.mog --out foo.fbx            # FBX via extension sniffing
mogen build foo.mog --format fbx             # FBX with default-extension override → foo.fbx
mogen build foo.mog --format glb --out x.bin # forced container, ignoring the extension
```

`docs/cli.md` is updated.

## Test plan

New `crates/mogen-export/tests/fbx.rs`, modelled on `tests/lights.rs`. Uses `fbxcel::tree::any::AnyTree` for read-back assertions.

- `top_level_structure_matches_fbx_7_4_layout` — magic header + 7 required top-level sections (`FBXHeaderExtension`, `GlobalSettings`, `Documents`, `Definitions`, `Objects`, `Connections`, `Takes`).
- `global_settings_carry_y_up_and_meter_units` — `UpAxis=1`, `UnitScaleFactor=1.0`.
- `mesh_round_trip_emits_geometry_with_negate_terminated_polygons` — `Vertices` length divisible by 3, every third `PolygonVertexIndex` entry is negative, OO connections Geometry → Model → RootNode.
- `material_with_base_color_texture_emits_full_chain` — Phong shading, `Roughness`/`Metallic` in Properties70, exactly one `Texture` + one `Video`, embedded `Content` bytes match the input PNG, OP `Texture → Material` on `DiffuseColor`.
- `directional_point_and_spot_lights_emit_node_attributes` — three `NodeAttribute` objects, light types 0/1/2, range → FarAttenuationEnd, InnerAngle/OuterAngle in degrees.
- `skin_emits_one_skin_deformer_with_per_joint_clusters` — one Skin Deformer, two Cluster Deformers, each with non-empty Indexes/Weights and 16-element Transform/TransformLink.
- `translation_animation_emits_stack_layer_curve_node_and_three_axes` — one `AnimStack`/`AnimLayer`/`AnimCurveNode`, three `AnimCurve` (X/Y/Z), 3 KeyTime + 3 KeyValueFloat each, last tick within ±1 of `1.0s × 46_186_158_000`, OP CurveNode → Model on `Lcl Translation`.

## Verification

| Check | Result |
|---|---|
| `cargo build -p mogen-export` (default features, no fbx) | ✓ |
| `cargo build -p mogen-export --features fbx` | ✓ |
| `cargo build -p mogen` (transitively pulls fbx) | ✓ |
| `cargo test -p mogen-export --features fbx` | ✓ 39/39 (lib 18 + fbx 7 + lights 4 + textures 10) |
| `cargo test -p mogen --test goldens` | unchanged from baseline (3 pass / 9 pre-existing failures unrelated) |
| End-to-end `mogen build examples/wooden_crate_simple.mog -o /tmp/crate.fbx` | ✓ 76.7 KiB FBX with valid magic + 31 Models / 17 Geometries / 2 Materials / 65 connections |
| End-to-end `mogen build examples/windmill.mog -o /tmp/windmill.fbx` (animated) | ✓ 382.8 KiB FBX with full Animation* + Texture/Video chain |
| `--format` overrides extension sniffing | ✓ verified both directions |
| `docs/cli.md` updated | ✓ |

The independent JS-based FBX 7.4 binary walker (separate code path from the `fbxcel`-based reader used in tests) confirms structural validity end-to-end — top-level sections, Object-type counts, animation curves, and embedded texture content all parse cleanly.

## Files

**Created:** `crates/mogen-export/src/fbx/{mod,doc,ids,nodes,mesh,material,texture,skin,anim,light}.rs`, `crates/mogen-export/tests/fbx.rs`.

**Edited (minimal):** `crates/mogen-export/{Cargo.toml,src/lib.rs}`, `crates/mogen/{Cargo.toml,src/main.rs,src/commands/build.rs}`, the existing build callers in `commands/{animate,generate,modify,repair,textures}.rs` (one-arg threading), `docs/cli.md`, `Cargo.lock` (dependency add).

**Untouched:** `mogen-core`, `mogen-geom`, `mogen-render`, `mogen-validate`, `mogen-studio`, `mogen-wasm`, `mogen-llm`, every existing `mogen-export` source file other than `lib.rs` + `Cargo.toml`, every existing test.