### PR TITLE
Sync viewport selection from editor caret position

### DIFF
--- a/crates/mogen-studio/src/app/types.rs
+++ b/crates/mogen-studio/src/app/types.rs
@@ -804,6 +804,15 @@ pub(super) struct FileState {
     /// selection changes so clicking a leg in 3D jumps the editor caret.
     pub(super) pending_caret: Option<usize>,
 
+    /// Last caret byte offset reflected into the viewport selection. Read
+    /// after the TextEdit paints; when the new offset differs we look up the
+    /// node whose `source_span` contains it and update the viewport
+    /// selection. Pre-armed to the offset whenever we apply `pending_caret`
+    /// so a programmatic jump from a viewport pick can't feed back into
+    /// another sync next frame (the edges of the loop are: viewport pick
+    /// sets pending_caret → editor moves caret → caret diff would re-pick).
+    pub(super) last_synced_caret_byte: Option<usize>,
+
     /// VS Code–style additional selections layered on top of the TextEdit's
     /// own primary cursor. Cmd+D pushes the prior primary range here and
     /// advances the primary to the next occurrence; subsequent typing /
@@ -852,6 +861,7 @@ impl FileState {
             last_edit_at: None,
             needs_compile: false,
             pending_caret: None,
+            last_synced_caret_byte: None,
             extra_carets: Vec::new(),
             undo: UndoStack::default(),
             status: "new scene".into(),
@@ -897,6 +907,7 @@ impl FileState {
             last_edit_at: None,
             needs_compile: false,
             pending_caret: None,
+            last_synced_caret_byte: None,
             extra_carets: Vec::new(),
             undo: UndoStack::default(),
             status,

--- a/crates/mogen-studio/src/app/ui_panels/editor.rs
+++ b/crates/mogen-studio/src/app/ui_panels/editor.rs
@@ -214,6 +214,53 @@ impl MogenStudioApp {
                         }
                     }
 
+                    // Code → viewport selection sync. When the user moves
+                    // the caret inside the editor (click, arrow, Find,
+                    // line ops, …), look up which scene node owns that
+                    // byte offset and make it the primary selection so the
+                    // 3D viewport highlights / gizmos / inspector follow
+                    // along.
+                    //
+                    // Loop avoidance: a viewport pick sets `pending_caret`
+                    // which we consumed above. The TextEdit only sees the
+                    // new offset on the *next* frame, so this frame's
+                    // `output.cursor_range` still reflects the old caret —
+                    // re-syncing from it would clobber the selection the
+                    // pick just established. Pre-arming
+                    // `last_synced_caret_byte` to the offset we just stored
+                    // means the next-frame poll sees no diff and stays
+                    // quiet. The `set_node_at_source_offset` call itself
+                    // never queues a `pending_caret`, so a code-side click
+                    // can't push back into the editor.
+                    if generating {
+                        // Editor is locked while the LLM owns the buffer;
+                        // any cursor wobble during generation is noise.
+                    } else if let Some(applied) = pending_caret {
+                        self.files[i].last_synced_caret_byte = Some(applied);
+                    } else if let Some(range) = output.cursor_range {
+                        let src = &self.files[i].source;
+                        let char_idx = range.primary.ccursor.index;
+                        let byte_off = src
+                            .char_indices()
+                            .nth(char_idx)
+                            .map(|(b, _)| b)
+                            .unwrap_or(src.len());
+                        match self.files[i].last_synced_caret_byte {
+                            Some(prev) if prev == byte_off => {}
+                            Some(_) => {
+                                self.viewer.select_node_at_source_offset(byte_off);
+                                self.files[i].last_synced_caret_byte = Some(byte_off);
+                            }
+                            None => {
+                                // First read for this tab: adopt the
+                                // observed offset without syncing so just
+                                // opening / activating a file doesn't
+                                // synthesise a phantom click.
+                                self.files[i].last_synced_caret_byte = Some(byte_off);
+                            }
+                        }
+                    }
+
                     // Ctrl+click navigation: jumps to imported module
                     // declarations, opens URLs / referenced files, or
                     // scrolls the in-app docs window to the matching

--- a/crates/mogen-studio/src/viewer.rs
+++ b/crates/mogen-studio/src/viewer.rs
@@ -36,9 +36,9 @@ use crate::preview_shader::PreviewShader;
 
 use renderer::Renderer;
 use state::{
-    aspect_for, begin_gizmo_drag, commit_gizmo_drag, gizmo_handles_supported, node_path,
-    replace_selection, replace_selection_cycling, resolve_node_path, toggle_selection,
-    update_gizmo_drag, ViewerState,
+    aspect_for, begin_gizmo_drag, commit_gizmo_drag, find_deepest_node_at_offset,
+    gizmo_handles_supported, node_path, replace_selection, replace_selection_cycling,
+    resolve_node_path, toggle_selection, update_gizmo_drag, ViewerState,
 };
 
 pub struct Viewer {
@@ -191,6 +191,37 @@ impl Viewer {
     /// recompiles when raw `NodeId` indices may have shifted.
     pub fn all_selected_paths(&self) -> Vec<SelectionPath> {
         self.state.lock().unwrap().selected_paths.clone()
+    }
+
+    /// Reverse of the viewport-pick → caret jump: update the primary
+    /// selection to whichever user-authored node's `source_span` contains
+    /// `byte_offset`, so clicking in the code editor highlights the matching
+    /// 3D node. Does **not** queue a `pending_caret` — the caret is already
+    /// where the user moved it, and writing one back would re-trigger this
+    /// path next frame and pingpong forever. Returns `true` when the
+    /// selection actually changed; callers can short-circuit when nothing
+    /// moved. `None` from the offset lookup (caret in a comment, blank line,
+    /// or otherwise outside any span) preserves the existing selection.
+    pub fn select_node_at_source_offset(&self, byte_offset: usize) -> bool {
+        let mut st = self.state.lock().unwrap();
+        let Some(scene) = st.scene.clone() else {
+            return false;
+        };
+        let Some(target) = find_deepest_node_at_offset(&scene, byte_offset) else {
+            return false;
+        };
+        if st.selected.last().copied() == Some(target) {
+            return false;
+        }
+        st.selected.clear();
+        st.selected_paths.clear();
+        st.selected.push(target);
+        if let Some(path) = node_path(&scene, target) {
+            st.selected_paths.push(path);
+        }
+        st.gizmo_drag = None;
+        st.pick_cycle = None;
+        true
     }
 
     /// Set the desired selection by stable paths. Live `NodeId`s are cleared

--- a/crates/mogen-studio/src/viewer/state.rs
+++ b/crates/mogen-studio/src/viewer/state.rs
@@ -1292,3 +1292,41 @@ fn pick_nth_named(scene: &SceneGraph, ids: &[NodeId], name: &str, n: u32) -> Opt
     }
     None
 }
+
+/// Find the deepest user-authored scene node whose `source_span` contains
+/// `byte_offset`. "Deepest" = smallest containing span, so a click inside a
+/// child wins over its enclosing group. Nodes lowered from imported `.mog`
+/// files (`origin = Some(...)`) are skipped: their spans index into another
+/// file, not the active source. Returns `None` when the offset falls in a
+/// comment, whitespace, or otherwise outside every node's authored range —
+/// callers preserve the existing selection in that case rather than treating
+/// it as a deselect.
+pub(super) fn find_deepest_node_at_offset(
+    scene: &SceneGraph,
+    byte_offset: usize,
+) -> Option<NodeId> {
+    let mut best: Option<(NodeId, usize)> = None;
+    for (idx, node) in scene.nodes.iter().enumerate() {
+        if node.origin.is_some() {
+            continue;
+        }
+        let Some(span) = node.source_span else {
+            continue;
+        };
+        // Half-open: a caret resting at `span.end` belongs to whatever
+        // structure starts there (or to none, if nothing follows). Without
+        // this, two adjacent siblings with `prev.end == next.start` would
+        // both claim the boundary offset and the deepest-by-length tiebreak
+        // would pick whichever happened to be enumerated last.
+        if byte_offset < span.start || byte_offset >= span.end {
+            continue;
+        }
+        let len = span.end - span.start;
+        match best {
+            None => best = Some((NodeId(idx as u32), len)),
+            Some((_, prev_len)) if len < prev_len => best = Some((NodeId(idx as u32), len)),
+            _ => {}
+        }
+    }
+    best.map(|(id, _)| id)
+}

--- a/crates/mogen-studio/src/viewer/tests.rs
+++ b/crates/mogen-studio/src/viewer/tests.rs
@@ -1,13 +1,14 @@
     use super::flatten::{flatten, PaletteSource, FLOATS_PER_VERTEX};
     use super::state::{
-        apply_gizmo_drag, commit_gizmo_drag, gizmo_handles_supported, is_import_wrapper, node_path,
-        redirect_pick, replace_selection, replace_selection_cycling, resolve_node_path,
-        snap_rotate_delta, snap_scale_factor, snap_translate_delta, toggle_selection, GizmoDrag,
-        PendingEdit, ViewerState, PICK_CYCLE_RADIUS_PX, SCALE_SNAP_STEP,
+        apply_gizmo_drag, commit_gizmo_drag, find_deepest_node_at_offset, gizmo_handles_supported,
+        is_import_wrapper, node_path, redirect_pick, replace_selection, replace_selection_cycling,
+        resolve_node_path, snap_rotate_delta, snap_scale_factor, snap_translate_delta,
+        toggle_selection, GizmoDrag, PendingEdit, ViewerState, PICK_CYCLE_RADIUS_PX,
+        SCALE_SNAP_STEP,
     };
     use eframe::egui;
     use glam::{Mat4, Quat, Vec3};
-    use mogen_core::{AlphaMode, Material, Mesh, NodeId, SceneGraph, Transform};
+    use mogen_core::{AlphaMode, Material, Mesh, NodeId, SceneGraph, Span, Transform};
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
@@ -641,6 +642,83 @@
         replace_selection(&mut st, Some(imported));
         assert!(st.selected.is_empty());
         assert!(st.selected_paths.is_empty());
+    }
+
+    /// Build a tiny scene whose nodes carry hand-rolled `source_span`s so
+    /// the offset-lookup tests can pick precise byte positions without
+    /// running the real DSL parser. Layout (byte offsets in brackets):
+    ///   `[0..40] group "outer" { [10..30] box "inner" { } }`
+    /// — a parent span that fully contains a child span. The third node
+    /// (`imported`) is a sibling of `inner` whose `origin = Some(...)` to
+    /// exercise the imported-skip rule.
+    fn scene_with_overlapping_spans() -> (SceneGraph, NodeId, NodeId, NodeId) {
+        let mut scene = SceneGraph::new();
+        let outer = scene.add_root("outer", "group", Transform::IDENTITY);
+        let inner = scene.add_child(outer, "inner", "box", Transform::IDENTITY);
+        let imported = scene.add_child(outer, "imported", "box", Transform::IDENTITY);
+        scene.nodes[outer.0 as usize].source_span = Some(Span::new(0, 40));
+        scene.nodes[inner.0 as usize].source_span = Some(Span::new(10, 30));
+        // Picked to overlap `inner`'s range so the deepest-by-length tiebreak
+        // genuinely depends on whether we let an imported span participate.
+        scene.nodes[imported.0 as usize].source_span = Some(Span::new(15, 25));
+        scene.nodes[imported.0 as usize].origin = Some(PathBuf::from("other.mog"));
+        (scene, outer, inner, imported)
+    }
+
+    #[test]
+    fn find_deepest_node_at_offset_picks_smallest_containing_span() {
+        // Offset 20 sits inside both the outer group (0..40) and the inner
+        // box (10..30). The deepest match wins so a code-side click on the
+        // child's source line selects the child, not its enclosing group.
+        let (scene, _outer, inner, _imported) = scene_with_overlapping_spans();
+        assert_eq!(find_deepest_node_at_offset(&scene, 20), Some(inner));
+    }
+
+    #[test]
+    fn find_deepest_node_at_offset_skips_imported_nodes() {
+        // The imported sibling's span (15..25) is the smallest one covering
+        // offset 20, but it lives in another file — selecting it would land
+        // the gizmo at byte offsets that don't index the active source.
+        // The lookup must skip it and fall back to the inner user-authored
+        // node instead.
+        let (scene, _outer, inner, _imported) = scene_with_overlapping_spans();
+        assert_eq!(find_deepest_node_at_offset(&scene, 20), Some(inner));
+    }
+
+    #[test]
+    fn find_deepest_node_at_offset_falls_back_to_outer_when_only_outer_contains() {
+        // Offset 5 lands inside the outer group's span but before the inner
+        // child's. The outer group is the only valid candidate.
+        let (scene, outer, _inner, _imported) = scene_with_overlapping_spans();
+        assert_eq!(find_deepest_node_at_offset(&scene, 5), Some(outer));
+    }
+
+    #[test]
+    fn find_deepest_node_at_offset_returns_none_outside_every_span() {
+        // Offset past every node's range — represents a click in trailing
+        // whitespace or a top-level comment. The caller preserves the
+        // existing selection in that case rather than treating it as a
+        // deselect.
+        let (scene, _outer, _inner, _imported) = scene_with_overlapping_spans();
+        assert_eq!(find_deepest_node_at_offset(&scene, 1000), None);
+    }
+
+    #[test]
+    fn find_deepest_node_at_offset_treats_span_end_as_exclusive() {
+        // A caret resting exactly at a node's `span.end` belongs to whatever
+        // structure starts there (or to none). Without the half-open
+        // boundary, two adjacent siblings with `prev.end == next.start`
+        // would both claim the boundary offset and the deepest-by-length
+        // tiebreak would silently pick whichever happened to enumerate last.
+        let mut scene = SceneGraph::new();
+        let a = scene.add_root("a", "box", Transform::IDENTITY);
+        let b = scene.add_root("b", "box", Transform::IDENTITY);
+        scene.nodes[a.0 as usize].source_span = Some(Span::new(0, 10));
+        scene.nodes[b.0 as usize].source_span = Some(Span::new(10, 20));
+        // 9 → still inside `a`.
+        assert_eq!(find_deepest_node_at_offset(&scene, 9), Some(a));
+        // 10 → boundary; belongs to `b`, not `a`.
+        assert_eq!(find_deepest_node_at_offset(&scene, 10), Some(b));
     }
 
     /// Three-sibling scene with three user-authored boxes under one root.


### PR DESCRIPTION
Mirror the existing viewport-click → caret-jump behaviour: as the user
moves the editor caret (click, arrow keys, Find, line ops, …) update
the primary viewport selection to whichever scene node owns the byte
offset under the caret, so the 3D highlight / gizmo / inspector
follows the source position.

Loop avoidance: a viewport pick already sets `pending_caret`; consuming
it pre-arms `last_synced_caret_byte` so the next-frame poll sees no
diff. The new code path never queues `pending_caret` itself, so a
code-side click can't push back into the editor.