### PR TITLE
Add UX audit covering Studio surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,6 +2598,7 @@ dependencies = [
  "mogen-moghub-client",
  "mogen-update",
  "mogen-validate",
+ "regex",
  "rfd",
  "sentry",
  "serde",

--- a/crates/mogen-moghub-client/src/oauth.rs
+++ b/crates/mogen-moghub-client/src/oauth.rs
@@ -43,7 +43,15 @@ pub fn run_loopback_flow(base_url: &str) -> Result<String, String> {
     );
 
     if let Err(e) = webbrowser::open(&start_url) {
-        return Err(format!("could not open browser: {e}"));
+        // Log the URL to stderr too so a user whose browser launcher is
+        // broken (e.g. headless dev environment) can copy it manually
+        // instead of being stuck on a generic "could not open browser"
+        // banner with no URL to paste.
+        eprintln!("oauth: could not auto-open browser ({e}). Open this URL manually to continue:\n  {start_url}");
+        return Err(format!(
+            "could not open browser ({e}). See the terminal for a URL you can paste \
+             into a browser manually."
+        ));
     }
 
     // Poll the listener so a user who closes the browser tab eventually

--- a/crates/mogen-studio/Cargo.toml
+++ b/crates/mogen-studio/Cargo.toml
@@ -59,6 +59,10 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # attaching it to `PublishRequest::thumbnail_png_base64`.
 base64 = "0.22"
 arboard = { version = "3", default-features = false }
+# Regex crate powers the find-bar's optional regex mode. Already in the
+# transitive dep tree via tracing; pulling it in directly keeps the cargo
+# tree stable.
+regex = "1"
 sentry = { version = "0.34", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls"] }
 # Browser shim — opens the GitHub OAuth URL via the system handler.
 # tiny_http is pulled in transitively via mogen-moghub-client's `oauth`

--- a/crates/mogen-studio/src/app.rs
+++ b/crates/mogen-studio/src/app.rs
@@ -122,6 +122,10 @@ pub struct MogenStudioApp {
     settings: Settings,
     show_options: bool,
     options_api_key_draft: String,
+    /// Draft string for the optional seed field in the New Prompt dialog and
+    /// (mirrored) Preferences → LLM. Stored as a `String` so the user can
+    /// type freely without partial parses; we re-parse on submit.
+    options_seed_draft: String,
     /// Active tab inside the Preferences window. Persists across opens within
     /// a session so re-opening the dialog returns to whichever pane the user
     /// was last on.
@@ -378,6 +382,10 @@ impl MogenStudioApp {
 
         let mut settings = Settings::load();
         let options_api_key_draft = settings.gemini_api_key.clone();
+        let options_seed_draft = settings
+            .seed_override
+            .map(|s| s.to_string())
+            .unwrap_or_default();
         install_fonts(&cc.egui_ctx);
         apply_theme(&cc.egui_ctx, settings.theme());
         viewer.set_preview_shader(settings.preview_shader());
@@ -457,6 +465,7 @@ impl MogenStudioApp {
             settings,
             show_options: false,
             options_api_key_draft,
+            options_seed_draft,
             prefs_active_tab: ui_dialogs::PrefsTab::default(),
             show_onboarding,
             show_crash_consent,

--- a/crates/mogen-studio/src/app.rs
+++ b/crates/mogen-studio/src/app.rs
@@ -100,7 +100,7 @@ struct InitProgress {
 /// Floor on splash visibility (ms). Shorter and the splash flashes; longer
 /// and it feels like the app is dragging. Tuned to feel deliberate without
 /// holding up users on cold launch with no tabs to restore.
-const SPLASH_MIN_DWELL_MS: u128 = 4000;
+const SPLASH_MIN_DWELL_MS: u128 = 1800;
 
 /// Maximum recently-closed paths held for Ctrl+Shift+T reopen. Matches the
 /// settings `recent_files` cap so the two lists feel comparable; older

--- a/crates/mogen-studio/src/app.rs
+++ b/crates/mogen-studio/src/app.rs
@@ -122,9 +122,10 @@ pub struct MogenStudioApp {
     settings: Settings,
     show_options: bool,
     options_api_key_draft: String,
-    /// Draft string for the optional seed field in the New Prompt dialog and
-    /// (mirrored) Preferences → LLM. Stored as a `String` so the user can
-    /// type freely without partial parses; we re-parse on submit.
+    /// Draft string for the optional seed field in the New Prompt dialog.
+    /// Stored as a `String` so the user can type freely without partial
+    /// parses; we re-parse on submit. Preferences → LLM has its own seed
+    /// editor that reads/writes `settings.seed_override` directly.
     options_seed_draft: String,
     /// Active tab inside the Preferences window. Persists across opens within
     /// a session so re-opening the dialog returns to whichever pane the user

--- a/crates/mogen-studio/src/app/autocomplete.rs
+++ b/crates/mogen-studio/src/app/autocomplete.rs
@@ -8,7 +8,7 @@
 //! selected candidate into the active file's source and rewrites the TextEdit
 //! cursor state.
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use eframe::egui;
 use egui::text::{CCursor, CCursorRange};
@@ -79,11 +79,13 @@ impl MogenStudioApp {
             .map(|(b, _)| b)
             .unwrap_or(source.len());
 
-        // If the user pressed Esc earlier this session, keep the popup hidden
-        // until they edit again (detected by source length change).
-        if let Some(len) = self.autocomplete.suppressed_for_source_len {
-            if source.len() != len {
-                self.autocomplete.suppressed_for_source_len = None;
+        // Esc-to-suppress: keep the popup hidden for a short window so the
+        // user can finish typing without it popping back. Time-based rather
+        // than source-length based — deleting and re-typing the same char
+        // used to silently keep the popup hidden because lengths matched.
+        if let Some(deadline) = self.autocomplete.suppressed_until {
+            if Instant::now() >= deadline {
+                self.autocomplete.suppressed_until = None;
             }
         }
 
@@ -97,7 +99,7 @@ impl MogenStudioApp {
             .map(|s| s.materials.iter().map(|m| m.name.clone()).collect())
             .unwrap_or_default();
 
-        let completions = if self.autocomplete.suppressed_for_source_len.is_some() {
+        let completions = if self.autocomplete.suppressed_until.is_some() {
             None
         } else {
             compute_completions(source, caret, &mats)
@@ -106,9 +108,16 @@ impl MogenStudioApp {
         let mut should_accept = false;
         match (completions, key_action) {
             (Some(c), action) => {
-                // Keep selected within bounds when the candidate set changes.
-                let prev_selected = if self.autocomplete.open {
-                    self.autocomplete.selected.min(c.candidates.len().saturating_sub(1))
+                // Reset `selected` to 0 whenever the candidate set changes
+                // so the top match is always preselected. If it's the same
+                // set, just clamp the existing index to the new bounds.
+                let signature = candidate_signature(&c.candidates);
+                let prev_selected = if Some(signature) == self.autocomplete.last_signature
+                    && self.autocomplete.open
+                {
+                    self.autocomplete
+                        .selected
+                        .min(c.candidates.len().saturating_sub(1))
                 } else {
                     0
                 };
@@ -116,6 +125,7 @@ impl MogenStudioApp {
                 self.autocomplete.candidates = c.candidates;
                 self.autocomplete.range = Some(c.range);
                 self.autocomplete.selected = prev_selected;
+                self.autocomplete.last_signature = Some(signature);
 
                 match action {
                     AutocompleteKey::MoveDown => {
@@ -136,7 +146,12 @@ impl MogenStudioApp {
                         should_accept = true;
                     }
                     AutocompleteKey::Cancel => {
-                        self.autocomplete.suppressed_for_source_len = Some(source.len());
+                        // 600 ms is long enough that the next keystroke
+                        // doesn't immediately re-pop, short enough that
+                        // pausing to think then typing again works as
+                        // expected.
+                        self.autocomplete.suppressed_until =
+                            Some(Instant::now() + Duration::from_millis(600));
                         self.autocomplete.close();
                     }
                     AutocompleteKey::None => {}
@@ -259,10 +274,10 @@ impl MogenStudioApp {
                 .set_char_range(Some(CCursorRange::one(CCursor::new(new_char))));
             st.store(ctx, editor_id);
         }
-        // Suppress until the next edit so the popup doesn't immediately
-        // re-open on the just-inserted word (e.g. after inserting `box`, the
-        // caret sits right after it — the popup would pop right back).
-        self.autocomplete.suppressed_for_source_len = Some(source.len());
+        // Suppress for a short window after accepting so the popup doesn't
+        // immediately re-open on the just-inserted word.
+        self.autocomplete.suppressed_until =
+            Some(Instant::now() + Duration::from_millis(600));
         self.autocomplete.close();
     }
 }
@@ -274,7 +289,22 @@ impl AutocompleteState {
         self.range = None;
         self.anchor = None;
         self.selected = 0;
+        self.last_signature = None;
     }
+}
+
+/// Cheap fingerprint of the candidate label set so we can detect when the
+/// list has actually changed (and therefore reset the `selected` index back
+/// to the top). Order-sensitive, which is what we want — same labels in a
+/// different order are still a different list to the user.
+fn candidate_signature(cands: &[Candidate]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    cands.len().hash(&mut h);
+    for c in cands {
+        c.label.hash(&mut h);
+    }
+    h.finish()
 }
 
 fn render_item(ui: &mut egui::Ui, c: &Candidate, selected: bool) -> bool {

--- a/crates/mogen-studio/src/app/autocomplete.rs
+++ b/crates/mogen-studio/src/app/autocomplete.rs
@@ -286,7 +286,7 @@ fn render_item(ui: &mut egui::Ui, c: &Candidate, selected: bool) -> bool {
         // Narrow, fixed-width tag column so the labels align.
         let tag_fmt = egui::TextFormat {
             color: tag_color,
-            font_id: egui::TextStyle::Small.resolve(ui.style()),
+            font_id: egui::TextStyle::Body.resolve(ui.style()),
             ..Default::default()
         };
         job.append(&format!("{tag:<5}"), 0.0, tag_fmt);
@@ -299,7 +299,7 @@ fn render_item(ui: &mut egui::Ui, c: &Candidate, selected: bool) -> bool {
         if let Some(detail) = c.detail {
             let detail_fmt = egui::TextFormat {
                 color: ui.visuals().weak_text_color(),
-                font_id: egui::TextStyle::Small.resolve(ui.style()),
+                font_id: egui::TextStyle::Body.resolve(ui.style()),
                 ..Default::default()
             };
             job.append(&format!("   {detail}"), 0.0, detail_fmt);

--- a/crates/mogen-studio/src/app/file_picker.rs
+++ b/crates/mogen-studio/src/app/file_picker.rs
@@ -451,11 +451,15 @@ impl MogenStudioApp {
                         ui.add_space(4.0);
                         ui.horizontal(|ui| {
                             if picker.mode.is_save() {
-                                ui.label("Filename:");
+                                ui.label("Filename:")
+                                    .on_hover_text(
+                                        "The .mog extension is added automatically \
+                                         if you leave it off.",
+                                    );
                                 let save_resp = ui.add(
                                     egui::TextEdit::singleline(&mut picker.save_name_draft)
                                         .desired_width(240.0)
-                                        .hint_text("scene.mog"),
+                                        .hint_text("scene.mog (or scene — .mog is added)"),
                                 );
                                 if picker.focus_save_name_pending {
                                     save_resp.request_focus();
@@ -519,11 +523,40 @@ impl MogenStudioApp {
                                             !picker.save_name_draft.trim().is_empty()
                                         }
                                     };
+                                    // Spell out the gating condition for the
+                                    // disabled state — silent disabled buttons
+                                    // make users assume the picker is broken.
+                                    let confirm_tip = if confirm_enabled {
+                                        match &picker.mode {
+                                            PickerMode::SaveAs { .. } => {
+                                                "Save as .mog (extension auto-appended)"
+                                            }
+                                            _ => "Open the selected file",
+                                        }
+                                        .to_string()
+                                    } else {
+                                        match &picker.mode {
+                                            PickerMode::Open => {
+                                                "Disabled — pick a .mog file from the grid"
+                                                    .into()
+                                            }
+                                            PickerMode::Import => {
+                                                "Disabled — pick at least one .mog module"
+                                                    .into()
+                                            }
+                                            PickerMode::SaveAs { .. } => {
+                                                "Disabled — type a filename above (.mog \
+                                                 extension is auto-appended)"
+                                                    .into()
+                                            }
+                                        }
+                                    };
                                     if ui
                                         .add_enabled(
                                             confirm_enabled,
                                             egui::Button::new(picker.mode.confirm_label()),
                                         )
+                                        .on_hover_text(confirm_tip)
                                         .clicked()
                                     {
                                         do_confirm = true;

--- a/crates/mogen-studio/src/app/file_picker.rs
+++ b/crates/mogen-studio/src/app/file_picker.rs
@@ -580,7 +580,15 @@ impl MogenStudioApp {
                                     }
                                 }
                                 if picker.entries.is_empty() {
-                                    ui.weak("(no .mog files here)");
+                                    ui.add_space(8.0);
+                                    ui.label(
+                                        egui::RichText::new("No .mog files in this folder")
+                                            .strong(),
+                                    );
+                                    ui.label(
+                                        "Browse to a different directory using the path \
+                                         bar above, or use \"New folder\" to create one.",
+                                    );
                                 }
                             });
                         });
@@ -871,8 +879,8 @@ fn paint_cell(
     painter.text(
         label_rect.center_top() + egui::vec2(0.0, 2.0),
         egui::Align2::CENTER_TOP,
-        truncate_for_cell(&entry.name, 22),
-        egui::TextStyle::Small.resolve(ui.style()),
+        truncate_for_cell(&entry.name, 18),
+        egui::TextStyle::Body.resolve(ui.style()),
         label_color,
     );
 
@@ -936,7 +944,7 @@ fn paint_thumb_placeholder(
         rect.center(),
         egui::Align2::CENTER_CENTER,
         label,
-        egui::TextStyle::Small.resolve(&egui::Style::default()),
+        egui::TextStyle::Body.resolve(&egui::Style::default()),
         visuals.weak_text_color(),
     );
 }

--- a/crates/mogen-studio/src/app/find.rs
+++ b/crates/mogen-studio/src/app/find.rs
@@ -98,44 +98,72 @@ impl MogenStudioApp {
 
     /// Walk the active source and refill `find.matches` with char-index
     /// ranges. Cheap for typical .mog sizes; we just call this whenever the
-    /// query, source, or case toggle could have changed.
+    /// query, source, or case toggle could have changed. The match indices
+    /// are CHAR offsets, not byte offsets — that's the convention the rest
+    /// of the find code (overlay, scroll, caret) consumes.
     pub(super) fn recompute_find_matches(&mut self) {
         let src = &self.files[self.active].source;
         self.find.matches.clear();
+        self.find.regex_invalid = false;
         if self.find.query.is_empty() {
             return;
         }
-        let needle: Vec<char> = self.find.query.chars().collect();
-        let n = needle.len();
-        if n == 0 {
-            return;
-        }
-        let hay: Vec<char> = src.chars().collect();
-        if hay.len() < n {
-            return;
-        }
-        let cs = self.find.case_sensitive;
-        for start in 0..=hay.len() - n {
-            let mut ok = true;
-            for j in 0..n {
-                let a = hay[start + j];
-                let b = needle[j];
-                let eq = if cs {
-                    a == b
-                } else {
-                    // `to_lowercase` returns an iterator because some chars
-                    // map to multiple lowercase chars (German ß → ss). For
-                    // search the simple comparison is good enough — fold both
-                    // sides through the same iterator and check equality.
-                    a.to_lowercase().eq(b.to_lowercase())
-                };
-                if !eq {
-                    ok = false;
-                    break;
+
+        if self.find.use_regex {
+            // (?i) at the front for case-insensitive mode keeps the regex
+            // human-readable in the input bar (no second toggle to track).
+            let mut pattern = String::new();
+            if !self.find.case_sensitive {
+                pattern.push_str("(?i)");
+            }
+            pattern.push_str(&self.find.query);
+            let compiled = match regex::Regex::new(&pattern) {
+                Ok(r) => r,
+                Err(_) => {
+                    self.find.regex_invalid = true;
+                    return;
+                }
+            };
+            for m in compiled.find_iter(src) {
+                let start_char = src[..m.start()].chars().count();
+                let end_char = start_char + src[m.start()..m.end()].chars().count();
+                if start_char != end_char {
+                    self.find.matches.push(start_char..end_char);
                 }
             }
-            if ok {
-                self.find.matches.push(start..start + n);
+        } else {
+            let needle: Vec<char> = self.find.query.chars().collect();
+            let n = needle.len();
+            if n == 0 {
+                return;
+            }
+            let hay: Vec<char> = src.chars().collect();
+            if hay.len() < n {
+                return;
+            }
+            let cs = self.find.case_sensitive;
+            for start in 0..=hay.len() - n {
+                let mut ok = true;
+                for j in 0..n {
+                    let a = hay[start + j];
+                    let b = needle[j];
+                    let eq = if cs {
+                        a == b
+                    } else {
+                        // `to_lowercase` returns an iterator because some
+                        // chars map to multiple lowercase chars (German ß →
+                        // ss). Fold both sides through the same iterator and
+                        // check equality.
+                        a.to_lowercase().eq(b.to_lowercase())
+                    };
+                    if !eq {
+                        ok = false;
+                        break;
+                    }
+                }
+                if ok {
+                    self.find.matches.push(start..start + n);
+                }
             }
         }
         if self.find.current >= self.find.matches.len() {
@@ -206,13 +234,15 @@ impl MogenStudioApp {
 
                     let label = if self.find.query.is_empty() {
                         String::new()
+                    } else if self.find.regex_invalid {
+                        "(invalid regex)".to_string()
                     } else if self.find.matches.is_empty() {
                         "No results".to_string()
                     } else {
                         format!("{} of {}", self.find.current + 1, self.find.matches.len())
                     };
                     ui.add_sized(
-                        [88.0, 16.0],
+                        [110.0, 16.0],
                         egui::Label::new(egui::RichText::new(label).weak()),
                     );
 
@@ -234,10 +264,27 @@ impl MogenStudioApp {
                     let mut cs = self.find.case_sensitive;
                     if ui
                         .toggle_value(&mut cs, "Aa")
-                        .on_hover_text("Match case")
+                        .on_hover_text(if cs {
+                            "Match case (on) — click to make search case-insensitive"
+                        } else {
+                            "Match case (off) — click to make search case-sensitive"
+                        })
                         .changed()
                     {
                         self.find.case_sensitive = cs;
+                        query_changed = true;
+                    }
+                    let mut rx = self.find.use_regex;
+                    if ui
+                        .toggle_value(&mut rx, ".*")
+                        .on_hover_text(if rx {
+                            "Regex (on) — query is compiled as a Rust regex"
+                        } else {
+                            "Regex (off) — click to interpret the query as a regex pattern"
+                        })
+                        .changed()
+                    {
+                        self.find.use_regex = rx;
                         query_changed = true;
                     }
                     ui.with_layout(

--- a/crates/mogen-studio/src/app/llm/poll.rs
+++ b/crates/mogen-studio/src/app/llm/poll.rs
@@ -236,8 +236,21 @@ impl MogenStudioApp {
         // and the file recompiled, so the user sees the spliced PNGs in the
         // viewer alongside the "N material(s) failed" notice. `outcome.error`
         // is `Some(_)` on this branch by definition (textures_partial_success).
+        // Downgrade the error class to Partial so the banner reads as a soft
+        // warning rather than a red hard-failure. The headline gets a
+        // "Partial:" prefix so users see at a glance that some materials did
+        // succeed before reading the detail.
         if textures_partial_success {
-            if let Some(info) = outcome.error {
+            if let Some(mut info) = outcome.error {
+                info.class = crate::app::types::LlmErrorClass::Partial;
+                if !info.headline.to_lowercase().starts_with("partial") {
+                    info.headline = format!(
+                        "Partial: {} material PNG{} written — {}",
+                        outcome.calls,
+                        if outcome.calls == 1 { "" } else { "s" },
+                        info.headline,
+                    );
+                }
                 self.files[i].llm_error = Some(info);
             }
         }

--- a/crates/mogen-studio/src/app/llm/spawn.rs
+++ b/crates/mogen-studio/src/app/llm/spawn.rs
@@ -57,16 +57,20 @@ impl MogenStudioApp {
             Some(c) => c,
             None => {
                 self.active_mut().status = if slot.is_gemini_oauth() {
-                    "no Gemini OAuth token — sign in with Google in Edit → Preferences… \
-                     (or switch to \"Gemini (API key)\")"
+                    "Gemini OAuth: not signed in. Open Edit → Preferences and \
+                     sign in with Google, or switch the active provider to \
+                     \"Gemini (API key)\"."
                         .to_string()
                 } else if matches!(provider, mogen_llm::Provider::Gemini) {
-                    "no Gemini API key — set GEMINI_API_KEY, paste a key in Edit → \
-                     Preferences…, or switch to \"Gemini (Google OAuth)\""
+                    "Gemini: no API key. Pick one path: paste a key in \
+                     Edit → Preferences, set $GEMINI_API_KEY in your \
+                     environment, or switch the active provider to \
+                     \"Gemini (Google OAuth)\" and sign in."
                         .to_string()
                 } else {
                     format!(
-                        "no {} API key — set one in Options… or export {}",
+                        "{}: no API key. Paste one in Edit → Preferences or \
+                         export ${} in your environment.",
                         provider.label(),
                         provider.env_var(),
                     )

--- a/crates/mogen-studio/src/app/spotlight.rs
+++ b/crates/mogen-studio/src/app/spotlight.rs
@@ -416,7 +416,11 @@ impl MogenStudioApp {
             CommandAction::Gizmo(mode) => self.viewer.set_gizmo_mode(mode),
             CommandAction::ToggleCinema => {
                 let on = self.viewer.is_cinema_active();
-                self.viewer.set_cinema_active(!on);
+                // Spotlight toggle keeps the historical "force-play" semantics
+                // because the user is invoking it explicitly from the
+                // command palette, where surprise animation playback isn't a
+                // problem.
+                self.viewer.set_cinema_active(!on, true);
             }
             CommandAction::OpenFind => self.open_find(ctx),
         }

--- a/crates/mogen-studio/src/app/text_menu.rs
+++ b/crates/mogen-studio/src/app/text_menu.rs
@@ -1,5 +1,6 @@
 use eframe::egui;
 use egui::text::{CCursor, CCursorRange};
+use egui::{Key, KeyboardShortcut, Modifiers};
 
 /// Wrap a `TextEdit` add call with the standard Cut/Copy/Paste/Delete/Select All
 /// context menu. The `add` closure builds the widget and must call `.id(id)` on
@@ -87,11 +88,19 @@ pub(super) fn show_context_menu(
 
     let mut changed = false;
 
+    // Render shortcuts via egui's formatter so macOS users see ⌘ rather than
+    // the literal "Ctrl+…" the menu used to hard-code.
+    let cmd = Modifiers::COMMAND;
+    let sc_cut = ui.ctx().format_shortcut(&KeyboardShortcut::new(cmd, Key::X));
+    let sc_copy = ui.ctx().format_shortcut(&KeyboardShortcut::new(cmd, Key::C));
+    let sc_paste = ui.ctx().format_shortcut(&KeyboardShortcut::new(cmd, Key::V));
+    let sc_delete = ui
+        .ctx()
+        .format_shortcut(&KeyboardShortcut::new(Modifiers::NONE, Key::Delete));
+    let sc_select_all = ui.ctx().format_shortcut(&KeyboardShortcut::new(cmd, Key::A));
+
     if ui
-        .add_enabled(
-            has_selection,
-            egui::Button::new("Cut").shortcut_text("Ctrl+X"),
-        )
+        .add_enabled(has_selection, egui::Button::new("Cut").shortcut_text(sc_cut))
         .clicked()
     {
         ui.ctx().copy_text(text[sel_lo..sel_hi].to_string());
@@ -104,7 +113,7 @@ pub(super) fn show_context_menu(
     if ui
         .add_enabled(
             has_selection,
-            egui::Button::new("Copy").shortcut_text("Ctrl+C"),
+            egui::Button::new("Copy").shortcut_text(sc_copy),
         )
         .clicked()
     {
@@ -113,16 +122,22 @@ pub(super) fn show_context_menu(
     }
 
     if ui
-        .add(egui::Button::new("Paste").shortcut_text("Ctrl+V"))
+        .add(egui::Button::new("Paste").shortcut_text(sc_paste))
         .clicked()
     {
-        let clip = arboard::Clipboard::new().and_then(|mut c| c.get_text());
-        if let Ok(t) = clip {
-            if !t.is_empty() {
+        match arboard::Clipboard::new().and_then(|mut c| c.get_text()) {
+            Ok(t) if !t.is_empty() => {
                 text.replace_range(sel_lo..sel_hi, &t);
                 let new_byte = sel_lo + t.len();
                 store_caret(ui, new_byte, text);
                 changed = true;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                // Surface clipboard failures so the user isn't left wondering
+                // why nothing happened. Most common cause is a Wayland session
+                // without a clipboard manager.
+                eprintln!("paste from clipboard failed: {e}");
             }
         }
         ui.close_menu();
@@ -131,7 +146,7 @@ pub(super) fn show_context_menu(
     if ui
         .add_enabled(
             has_selection,
-            egui::Button::new("Delete").shortcut_text("Del"),
+            egui::Button::new("Delete").shortcut_text(sc_delete),
         )
         .clicked()
     {
@@ -144,7 +159,7 @@ pub(super) fn show_context_menu(
     ui.separator();
 
     if ui
-        .add(egui::Button::new("Select All").shortcut_text("Ctrl+A"))
+        .add(egui::Button::new("Select All").shortcut_text(sc_select_all))
         .clicked()
     {
         let total_chars = text.chars().count();

--- a/crates/mogen-studio/src/app/types.rs
+++ b/crates/mogen-studio/src/app/types.rs
@@ -231,6 +231,10 @@ pub(super) enum LlmErrorClass {
     ServerError,
     BadRequest,
     Other,
+    /// Partial success — typically a textures run where some materials
+    /// finished and some failed. Renders in a softer accent than a hard
+    /// failure.
+    Partial,
 }
 
 /// Running aggregate of every Gemini call made this app session, plus an

--- a/crates/mogen-studio/src/app/types.rs
+++ b/crates/mogen-studio/src/app/types.rs
@@ -623,10 +623,15 @@ pub(super) struct AutocompleteState {
     pub(super) range: Option<std::ops::Range<usize>>,
     /// Screen-space anchor point (below-left of the caret) for the popup.
     pub(super) anchor: Option<egui::Pos2>,
-    /// When the user hits Esc we want the popup to stay closed even though
-    /// the caret is still in an identifier. Cleared the next time the source
-    /// changes (so typing another letter re-opens it).
-    pub(super) suppressed_for_source_len: Option<usize>,
+    /// When the user hits Esc we want the popup to stay closed for a short
+    /// window even though the caret is still in an identifier. Time-based
+    /// rather than length-based so deleting and re-typing the same character
+    /// (which leaves source length unchanged) still re-opens the popup.
+    pub(super) suppressed_until: Option<std::time::Instant>,
+    /// Last candidate-set fingerprint we showed. When the prefix shifts
+    /// (so the candidate set changes), reset `selected` to 0 instead of
+    /// clamping at the old index — the top match should be preselected.
+    pub(super) last_signature: Option<u64>,
 }
 
 /// Deferred action decoded from a popup key press. Applied after the TextEdit
@@ -657,6 +662,14 @@ pub(super) struct FindState {
     pub(super) focus_pending: bool,
     /// User toggle — case-insensitive by default to match every modern editor.
     pub(super) case_sensitive: bool,
+    /// When true, the query is compiled as a Rust regex; when false (the
+    /// default) it's a plain substring match. The toggle button surfaces this
+    /// next to the case-sensitivity toggle.
+    pub(super) use_regex: bool,
+    /// Set when the latest regex query failed to compile so the bar can
+    /// surface a "(invalid regex)" hint instead of silently showing zero
+    /// matches.
+    pub(super) regex_invalid: bool,
     /// When `Some`, the editor should scroll to (and re-highlight) the match
     /// at this index after rendering. Set by Enter / F3 / Next / Prev.
     pub(super) scroll_pending: Option<usize>,

--- a/crates/mogen-studio/src/app/ui_dialogs/community/publish.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/community/publish.rs
@@ -179,10 +179,21 @@ impl MogenStudioApp {
                 // this publish without rewriting the file.
                 ui.horizontal(|ui| {
                     ui.label("Title");
-                    ui.add(
-                        egui::TextEdit::singleline(&mut state.title)
-                            .hint_text("from meta(name = \"…\")"),
-                    );
+                    let title_empty = state.title.trim().is_empty();
+                    let mut text_edit = egui::TextEdit::singleline(&mut state.title)
+                        .hint_text("from meta(name = \"…\")");
+                    if title_empty {
+                        text_edit = text_edit
+                            .text_color(egui::Color32::from_rgb(230, 100, 100));
+                    }
+                    ui.add(text_edit);
+                    if title_empty {
+                        ui.label(
+                            egui::RichText::new("required")
+                                .color(egui::Color32::from_rgb(230, 100, 100))
+                                .weak(),
+                        );
+                    }
                 });
                 let updating = state
                     .update_target
@@ -310,6 +321,7 @@ impl MogenStudioApp {
                         .as_ref()
                         .filter(|_| !state.publish_as_new);
                     let has_thumbnail = state.thumbnail_bytes.is_some();
+                    let title_ok = !state.title.trim().is_empty();
                     let label = match (posting, updating) {
                         (true, Some(_)) => "Publishing update…".to_string(),
                         (true, None) => "Publishing…".to_string(),
@@ -319,13 +331,21 @@ impl MogenStudioApp {
                         (false, None) => "Publish".to_string(),
                     };
                     let publish_btn = ui.add_enabled(
-                        !posting && has_thumbnail,
+                        !posting && has_thumbnail && title_ok,
                         egui::Button::new(label),
                     );
-                    let publish_btn = if !has_thumbnail && !posting {
-                        publish_btn.on_disabled_hover_text(
-                            "Waiting for the preview render — the thumbnail is required.",
-                        )
+                    let publish_btn = if !posting {
+                        if !title_ok {
+                            publish_btn.on_disabled_hover_text(
+                                "Title is required — type one in the field above.",
+                            )
+                        } else if !has_thumbnail {
+                            publish_btn.on_disabled_hover_text(
+                                "Waiting for the preview render — the thumbnail is required.",
+                            )
+                        } else {
+                            publish_btn
+                        }
                     } else {
                         publish_btn
                     };

--- a/crates/mogen-studio/src/app/ui_dialogs/export.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/export.rs
@@ -18,6 +18,7 @@ impl MogenStudioApp {
         let mut do_build = false;
         let mut do_cancel = false;
         let mut do_close = false;
+        let mut save_then_export = false;
         let i = self.active;
         let file_has_path = self.files[i].path.is_some();
         let last_status = self.files[i].status.clone();
@@ -42,6 +43,16 @@ impl MogenStudioApp {
                         "untitled MOG file — output will be written to the project root \
                          as untitled.glb. Save the MOG file first to export next to it.",
                     );
+                    if ui
+                        .button("Save MOG first…")
+                        .on_hover_text(
+                            "Open the Save-As picker now so the GLB exports next to \
+                             the saved .mog instead of falling back to the project root.",
+                        )
+                        .clicked()
+                    {
+                        save_then_export = true;
+                    }
                 }
 
                 ui.add_space(10.0);
@@ -119,6 +130,14 @@ impl MogenStudioApp {
                 }
             });
 
+        if save_then_export {
+            // Close the export dialog so the picker isn't stacked behind it,
+            // then trigger the Save-As flow. The user re-opens File → Build
+            // GLB once the file has a path.
+            self.show_export = false;
+            self.save_as();
+            return;
+        }
         if !open || do_close {
             self.show_export = false;
             return;

--- a/crates/mogen-studio/src/app/ui_dialogs/external.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/external.rs
@@ -62,6 +62,16 @@ impl MogenStudioApp {
                 ui.add_space(2.0);
                 ui.label(egui::RichText::new(&path_disp).monospace().weak());
             }
+            // Tell the user up front that closing the dialog without picking
+            // an option keeps their buffer (i.e. the "Keep mine" / "Keep
+            // buffer" branch).
+            ui.add_space(4.0);
+            ui.label(
+                egui::RichText::new(
+                    "Closing this dialog without choosing keeps your buffer.",
+                )
+                .weak(),
+            );
             ui.add_space(10.0);
             match kind {
                 ExternalChangeKind::Modified => {
@@ -114,9 +124,14 @@ impl MogenStudioApp {
                         {
                             do_keep = true;
                         }
+                        // Spacer so destructive Close tab is visually separated
+                        // from the safe options on the left.
+                        ui.add_space(20.0);
                         if ui
                             .button("Close tab")
-                            .on_hover_text("Close this tab without saving.")
+                            .on_hover_text(
+                                "Close this tab without saving — destructive, can't be undone.",
+                            )
                             .clicked()
                         {
                             do_close = true;

--- a/crates/mogen-studio/src/app/ui_dialogs/new_prompt.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/new_prompt.rs
@@ -292,6 +292,66 @@ impl MogenStudioApp {
                         }
                     });
 
+                // --- seed field ---
+                // Surfaces the existing global seed override so users can
+                // lock down a result they liked (or A/B two prompts with the
+                // same seed) without editing settings.json or the .mog
+                // header by hand. Empty input = "random per call".
+                ui.add_space(4.0);
+                ui.label("Seed (optional)").on_hover_text(
+                    "Lock the random seed used for generation. Same seed + \
+                     same prompt + same model usually reproduces the same \
+                     output. Leave blank to roll a fresh seed each call.",
+                );
+                ui.horizontal(|ui| {
+                    let seed_id = egui::Id::new("new_prompt_seed");
+                    // Draft buffer lives on the app so the dialog can edit
+                    // freely without parsing on every keystroke.
+                    let buf = &mut self.options_seed_draft;
+                    crate::app::text_menu::text_edit_with_menu(
+                        ui,
+                        seed_id,
+                        buf,
+                        |ui, text| {
+                            ui.add(
+                                egui::TextEdit::singleline(text)
+                                    .hint_text("blank = random")
+                                    .desired_width(160.0)
+                                    .id(seed_id),
+                            )
+                        },
+                    );
+                    if ui
+                        .button("Randomise")
+                        .on_hover_text(
+                            "Replace the field with a fresh random 64-bit seed",
+                        )
+                        .clicked()
+                    {
+                        use std::time::{SystemTime, UNIX_EPOCH};
+                        let seed = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .map(|d| d.as_nanos() as u64)
+                            .unwrap_or(0)
+                            ^ 0x9E3779B97F4A7C15;
+                        self.options_seed_draft = seed.to_string();
+                    }
+                });
+                // Apply the draft to settings each frame so a Generate click
+                // immediately downstream picks up the latest value.
+                let trimmed = self.options_seed_draft.trim();
+                self.settings.seed_override = if trimmed.is_empty() {
+                    None
+                } else {
+                    trimmed.parse::<u64>().ok()
+                };
+                if !trimmed.is_empty() && self.settings.seed_override.is_none() {
+                    ui.colored_label(
+                        egui::Color32::from_rgb(230, 150, 80),
+                        "(not a valid u64 — seed will fall back to random)",
+                    );
+                }
+
                 let has_key = self.resolve_api_key().is_some();
                 if !has_key {
                     ui.add_space(4.0);

--- a/crates/mogen-studio/src/app/ui_dialogs/prefs.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/prefs.rs
@@ -309,10 +309,18 @@ impl MogenStudioApp {
                     // expose a binary-path override for non-PATH installs.
                     ui.heading("Claude Code binary");
                     ui.label(
-                        "Auth is handled by your local `claude` install \
-                         (run `claude /login` if you haven't yet). Used by \
-                         Generate / Modify / Animate / Ask. Image generation \
-                         (Textures) still requires Gemini.",
+                        "Auth is handled by your local `claude` install — \
+                         run `claude` in a terminal and use the `/login` \
+                         slash command if you haven't yet. Used by Generate \
+                         / Modify / Animate / Ask.",
+                    );
+                    ui.label(
+                        egui::RichText::new(
+                            "Note: image generation (Textures) always uses \
+                             Gemini. Set a Gemini API key on the Gemini slot \
+                             above.",
+                        )
+                        .weak(),
                     );
                     ui.add_space(6.0);
                     ui.label("Path (optional)").on_hover_text(
@@ -344,15 +352,21 @@ impl MogenStudioApp {
                     ui.label(match active_provider {
                         Provider::Gemini => {
                             "Used by Generate / Modify / Animate / Textures. Stored in your \
-                             user config directory and persists between sessions."
+                             user config directory and persists between sessions. The \
+                             $GEMINI_API_KEY environment variable is used when this field \
+                             is blank."
                         }
                         Provider::OpenAI => {
                             "Used by Generate / Modify / Animate / Ask. Stored in your \
-                             user config directory and persists between sessions."
+                             user config directory and persists between sessions. The \
+                             $OPENAI_API_KEY environment variable is used when this field \
+                             is blank."
                         }
                         Provider::Anthropic => {
                             "Used by Generate / Modify / Animate / Ask. Stored in your \
-                             user config directory and persists between sessions."
+                             user config directory and persists between sessions. The \
+                             $ANTHROPIC_API_KEY environment variable is used when this \
+                             field is blank."
                         }
                         Provider::Ollama => {
                             "Optional bearer token for an Ollama endpoint behind an \

--- a/crates/mogen-studio/src/app/ui_dialogs/prefs.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/prefs.rs
@@ -265,6 +265,36 @@ impl MogenStudioApp {
                         }
                     });
 
+                // Live indicator: which credential will Auto actually use
+                // right now? The precedence chain is buried in the prose
+                // above; surface the current resolution explicitly so users
+                // don't have to reason it out.
+                if current_image == ImageProvider::Auto {
+                    use crate::app::util::Credential;
+                    let label = match self.resolve_gemini_credential() {
+                        Some(Credential::AntigravityOAuth(_)) => {
+                            "Auto → Antigravity OAuth (signed in)"
+                        }
+                        Some(Credential::ApiKey(_)) => {
+                            "Auto → Gemini API key (saved or $GEMINI_API_KEY)"
+                        }
+                        Some(Credential::GeminiOAuth(_)) => {
+                            "Auto → gemini-cli OAuth (last-resort fallback — \
+                             will surface a 'wrong client' error if used for \
+                             textures)"
+                        }
+                        Some(Credential::Zai(_)) => {
+                            "Auto → Z.ai (unusual settings combination)"
+                        }
+                        None => {
+                            "Auto → no credential resolved — texture \
+                             generation will fail. Sign in to Antigravity or \
+                             paste a Gemini API key."
+                        }
+                    };
+                    ui.label(egui::RichText::new(label).weak());
+                }
+
                 if current_image == ImageProvider::ZAI {
                     ui.add_space(8.0);
                     ui.label("Z.ai API key").on_hover_text(

--- a/crates/mogen-studio/src/app/ui_dialogs/quit.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/quit.rs
@@ -40,13 +40,22 @@ impl MogenStudioApp {
                 }
                 ui.add_space(12.0);
                 ui.horizontal(|ui| {
-                    if ui
-                        .button("Save All")
+                    // Render Save All as the visually-prominent primary
+                    // action. Enter triggers it; Esc maps to Cancel via the
+                    // window-close path.
+                    let save_btn = ui
+                        .add(
+                            egui::Button::new(
+                                egui::RichText::new("Save All").strong(),
+                            )
+                            .fill(ui.visuals().selection.bg_fill),
+                        )
                         .on_hover_text(
                             "Save each unsaved MOG file, then quit. \
-                             Untitled MOG files open a Save As dialog.",
-                        )
-                        .clicked()
+                             Untitled MOG files open a Save As dialog. (Enter)",
+                        );
+                    if save_btn.clicked()
+                        || ui.input(|i| i.key_pressed(egui::Key::Enter))
                     {
                         do_save_all = true;
                     }
@@ -57,7 +66,9 @@ impl MogenStudioApp {
                     {
                         do_discard = true;
                     }
-                    if ui.button("Cancel").clicked() {
+                    if ui.button("Cancel").clicked()
+                        || ui.input(|i| i.key_pressed(egui::Key::Escape))
+                    {
                         do_cancel = true;
                     }
                 });
@@ -123,13 +134,19 @@ impl MogenStudioApp {
                 ));
                 ui.add_space(12.0);
                 ui.horizontal(|ui| {
-                    if ui
-                        .button("Save")
+                    let save_btn = ui
+                        .add(
+                            egui::Button::new(
+                                egui::RichText::new("Save").strong(),
+                            )
+                            .fill(ui.visuals().selection.bg_fill),
+                        )
                         .on_hover_text(
                             "Save this MOG file, then close the tab. \
-                             Untitled MOG files open a Save As dialog.",
-                        )
-                        .clicked()
+                             Untitled MOG files open a Save As dialog. (Enter)",
+                        );
+                    if save_btn.clicked()
+                        || ui.input(|i| i.key_pressed(egui::Key::Enter))
                     {
                         do_save = true;
                     }
@@ -140,7 +157,9 @@ impl MogenStudioApp {
                     {
                         do_discard = true;
                     }
-                    if ui.button("Cancel").clicked() {
+                    if ui.button("Cancel").clicked()
+                        || ui.input(|i| i.key_pressed(egui::Key::Escape))
+                    {
                         do_cancel = true;
                     }
                 });

--- a/crates/mogen-studio/src/app/ui_dialogs/update.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/update.rs
@@ -85,7 +85,39 @@ impl MogenStudioApp {
                                 ui.hyperlink_to("Release notes on GitHub", &info.html_url);
                             }
                             ui.add_space(8.0);
-                            if res.newer {
+                            // Honour a prior "Skip this version" — show the
+                            // release info but suppress the green CTA + the
+                            // Download / Skip buttons. The user can unskip if
+                            // they change their mind.
+                            let already_skipped = !self.settings.skipped_update_tag.is_empty()
+                                && self.settings.skipped_update_tag == info.tag;
+                            let mut want_skip: Option<String> = None;
+                            let mut want_unskip = false;
+                            if res.newer && already_skipped {
+                                ui.colored_label(
+                                    egui::Color32::from_rgb(180, 200, 220),
+                                    format!(
+                                        "{} is available but you skipped this release.",
+                                        info.version,
+                                    ),
+                                );
+                                ui.add_space(8.0);
+                                ui.horizontal(|ui| {
+                                    if ui
+                                        .button("Unskip and install")
+                                        .on_hover_text(
+                                            "Forget the skip and install this release now.",
+                                        )
+                                        .clicked()
+                                    {
+                                        want_unskip = true;
+                                        start_install = Some(info.clone());
+                                    }
+                                    if ui.button("Close").clicked() {
+                                        close = true;
+                                    }
+                                });
+                            } else if res.newer {
                                 ui.colored_label(
                                     egui::Color32::from_rgb(120, 200, 140),
                                     format!(
@@ -113,7 +145,6 @@ impl MogenStudioApp {
                                      to restart the app once the swap completes.",
                                 );
                                 ui.add_space(8.0);
-                                let mut want_skip: Option<String> = None;
                                 ui.horizontal(|ui| {
                                     if ui
                                         .button("Download and install")
@@ -140,11 +171,16 @@ impl MogenStudioApp {
                                         close = true;
                                     }
                                 });
-                                if let Some(tag) = want_skip {
-                                    self.settings.skipped_update_tag = tag;
-                                    let _ = self.settings.save();
-                                }
-                            } else {
+                            }
+                            if let Some(tag) = want_skip {
+                                self.settings.skipped_update_tag = tag;
+                                let _ = self.settings.save();
+                            }
+                            if want_unskip {
+                                self.settings.skipped_update_tag.clear();
+                                let _ = self.settings.save();
+                            }
+                            if !res.newer {
                                 ui.colored_label(
                                     egui::Color32::from_rgb(180, 200, 220),
                                     "You're already running the latest release.",

--- a/crates/mogen-studio/src/app/ui_dialogs/update.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/update.rs
@@ -113,6 +113,7 @@ impl MogenStudioApp {
                                      to restart the app once the swap completes.",
                                 );
                                 ui.add_space(8.0);
+                                let mut want_skip: Option<String> = None;
                                 ui.horizontal(|ui| {
                                     if ui
                                         .button("Download and install")
@@ -124,10 +125,25 @@ impl MogenStudioApp {
                                     {
                                         start_install = Some(info.clone());
                                     }
+                                    if ui
+                                        .button("Skip this version")
+                                        .on_hover_text(
+                                            "Don't prompt me about this release again. \
+                                             Newer releases will still surface.",
+                                        )
+                                        .clicked()
+                                    {
+                                        want_skip = Some(info.tag.clone());
+                                        close = true;
+                                    }
                                     if ui.button("Close").clicked() {
                                         close = true;
                                     }
                                 });
+                                if let Some(tag) = want_skip {
+                                    self.settings.skipped_update_tag = tag;
+                                    let _ = self.settings.save();
+                                }
                             } else {
                                 ui.colored_label(
                                     egui::Color32::from_rgb(180, 200, 220),

--- a/crates/mogen-studio/src/app/ui_llm/error_banner.rs
+++ b/crates/mogen-studio/src/app/ui_llm/error_banner.rs
@@ -16,7 +16,8 @@ impl MogenStudioApp {
             }
             LlmErrorClass::RateLimited
             | LlmErrorClass::Network
-            | LlmErrorClass::ServerError => egui::Color32::from_rgb(230, 200, 100),
+            | LlmErrorClass::ServerError
+            | LlmErrorClass::Partial => egui::Color32::from_rgb(230, 200, 100),
             LlmErrorClass::ContentBlocked => egui::Color32::from_rgb(200, 130, 200),
             LlmErrorClass::QuotaExceeded
             | LlmErrorClass::BadRequest

--- a/crates/mogen-studio/src/app/ui_llm/main.rs
+++ b/crates/mogen-studio/src/app/ui_llm/main.rs
@@ -23,14 +23,37 @@ fn disabled_reason(reasons: &[(&str, bool)]) -> Option<String> {
 impl MogenStudioApp {
     pub(in crate::app) fn ui_llm(&mut self, ui: &mut egui::Ui) {
         let has_key = self.resolve_api_key().is_some();
+        let mut request_open_prefs = false;
         if !has_key {
+            // Treat the no-key banner as a real call-to-action: state which
+            // provider needs a key and offer a one-click jump into the right
+            // pane of Preferences. Multi-line so each path the user can take
+            // (paste / env var) gets its own line.
+            let provider = self.settings.provider().display_name();
             ui.colored_label(
                 egui::Color32::from_rgb(230, 200, 100),
-                format!(
-                    "no {} API key — set one in Edit → Preferences…",
-                    self.settings.provider().display_name(),
-                ),
+                format!("{provider}: no API key — every LLM action below is disabled."),
             );
+            ui.label(
+                egui::RichText::new(
+                    "Quickest path: click \"Open Preferences\" and paste a \
+                     key. The matching environment variable also works if \
+                     you'd rather not store the key on disk.",
+                )
+                .weak(),
+            );
+            ui.horizontal(|ui| {
+                if ui.button("Open Preferences").clicked() {
+                    request_open_prefs = true;
+                }
+                ui.label(
+                    egui::RichText::new("(Edit → Preferences… → LLM)").weak(),
+                );
+            });
+            ui.add_space(4.0);
+        }
+        if request_open_prefs {
+            self.show_options = true;
         }
 
         // Gate buttons on *this file's* in-flight state only — other files can
@@ -274,6 +297,32 @@ impl MogenStudioApp {
             (no_src_msg, !src_empty),
             (no_path_msg, has_path),
         ]);
+        // Pre-flight cost estimate: count materials in the most recent
+        // compile result, multiply by the per-image price, and surface the
+        // estimate next to the button. Image-only price (the textures
+        // pipeline always uses Gemini Flash Image regardless of the active
+        // text provider).
+        let material_count = self
+            .active()
+            .last_result
+            .as_ref()
+            .and_then(|r| r.scene.as_ref())
+            .map(|s| s.materials.len())
+            .unwrap_or(0);
+        let image_price = crate::app::pricing::image_pricing("gemini-2.5-flash-image");
+        let est_cost = material_count as f64 * image_price.per_image_usd;
+        if material_count > 0 && image_price.per_image_usd > 0.0 {
+            ui.label(
+                egui::RichText::new(format!(
+                    "Pre-flight: {material_count} material{} × {} ≈ {} per run \
+                     (PBR maps are derived locally, no extra cost).",
+                    if material_count == 1 { "" } else { "s" },
+                    crate::app::pricing::format_usd(image_price.per_image_usd),
+                    crate::app::pricing::format_usd(est_cost),
+                ))
+                .weak(),
+            );
+        }
         if ui
             .add_enabled(tex_enabled, egui::Button::new("Generate Textures"))
             .on_hover_text(tex_reason.as_deref().unwrap_or(

--- a/crates/mogen-studio/src/app/ui_llm/main.rs
+++ b/crates/mogen-studio/src/app/ui_llm/main.rs
@@ -3,6 +3,23 @@ use eframe::egui;
 use crate::app::types::EnhanceTarget;
 use crate::app::MogenStudioApp;
 
+/// Build the hover text shown on a disabled button. Lists every gating
+/// condition currently failing so the user knows which prerequisite to fix
+/// without having to discover them one by one.
+fn disabled_reason(reasons: &[(&str, bool)]) -> Option<String> {
+    let blockers: Vec<&str> = reasons
+        .iter()
+        .filter_map(|(label, ok)| if !ok { Some(*label) } else { None })
+        .collect();
+    if blockers.is_empty() {
+        None
+    } else if blockers.len() == 1 {
+        Some(format!("Disabled — {}", blockers[0]))
+    } else {
+        Some(format!("Disabled:\n  • {}", blockers.join("\n  • ")))
+    }
+}
+
 impl MogenStudioApp {
     pub(in crate::app) fn ui_llm(&mut self, ui: &mut egui::Ui) {
         let has_key = self.resolve_api_key().is_some();
@@ -22,6 +39,11 @@ impl MogenStudioApp {
         let busy = self.active().llm_in_flight.is_some();
         let src_empty = self.active().source.trim().is_empty();
         let has_path = self.active().path.is_some();
+        let provider_name_full = self.settings.provider().display_name();
+        let no_key_msg = format!("set a {provider_name_full} API key in Preferences");
+        let busy_msg = "another LLM call is already in flight on this tab";
+        let no_src_msg = "open or paste a .mog file first";
+        let no_path_msg = "save the file first — textures writes PNGs next to it";
 
         // Show the classified error banner above the prompt fields so users
         // see the failure before deciding whether to Retry or edit.
@@ -51,12 +73,20 @@ impl MogenStudioApp {
             },
         );
         let mod_enabled = has_key && !busy && !src_empty;
+        let mod_reason = disabled_reason(&[
+            (no_key_msg.as_str(), has_key),
+            (busy_msg, !busy),
+            (no_src_msg, !src_empty),
+        ]);
         ui.horizontal(|ui| {
-            if ui
+            let resp = ui
                 .add_enabled(mod_enabled, egui::Button::new("Modify"))
-                .on_hover_text("Smallest-edit rewrite of the current MOG file")
-                .clicked()
-            {
+                .on_hover_text(
+                    mod_reason
+                        .as_deref()
+                        .unwrap_or("Smallest-edit rewrite of the current MOG file"),
+                );
+            if resp.clicked() {
                 let ctx = ui.ctx().clone();
                 self.start_llm_modify(ctx);
             }
@@ -85,12 +115,20 @@ impl MogenStudioApp {
             },
         );
         let anim_enabled = has_key && !busy && !src_empty;
+        let anim_reason = disabled_reason(&[
+            (no_key_msg.as_str(), has_key),
+            (busy_msg, !busy),
+            (no_src_msg, !src_empty),
+        ]);
         ui.horizontal(|ui| {
-            if ui
+            let resp = ui
                 .add_enabled(anim_enabled, egui::Button::new("Animate"))
-                .on_hover_text("Append joints/clips/skeleton to the current MOG file")
-                .clicked()
-            {
+                .on_hover_text(
+                    anim_reason
+                        .as_deref()
+                        .unwrap_or("Append joints/clips/skeleton to the current MOG file"),
+                );
+            if resp.clicked() {
                 let ctx = ui.ctx().clone();
                 self.start_llm_animate(ctx);
             }
@@ -135,16 +173,20 @@ impl MogenStudioApp {
         } else {
             "Repair".to_string()
         };
-        let repair_tip = if src_empty {
-            "Open or paste a .mog file first".to_string()
-        } else if error_count == 0 {
-            "No validation errors to repair".to_string()
-        } else {
-            format!("Feed the diagnostics (with spans and fix hints) back to {provider_name}")
-        };
+        let no_errors_msg =
+            "no validation errors to fix — Repair lights up when the file fails to compile";
+        let repair_reason = disabled_reason(&[
+            (no_key_msg.as_str(), has_key),
+            (busy_msg, !busy),
+            (no_src_msg, !src_empty),
+            (no_errors_msg, error_count > 0),
+        ]);
+        let repair_default_tip = format!(
+            "Feed the diagnostics (with spans and fix hints) back to {provider_name}"
+        );
         if ui
             .add_enabled(repair_enabled, egui::Button::new(repair_label))
-            .on_hover_text(repair_tip)
+            .on_hover_text(repair_reason.as_deref().unwrap_or(&repair_default_tip))
             .clicked()
         {
             let ctx = ui.ctx().clone();
@@ -226,12 +268,18 @@ impl MogenStudioApp {
         self.files[self.active].texture_cfg.expanded = resp.openness > 0.5;
 
         let tex_enabled = has_key && !busy && !src_empty && has_path;
+        let tex_reason = disabled_reason(&[
+            (no_key_msg.as_str(), has_key),
+            (busy_msg, !busy),
+            (no_src_msg, !src_empty),
+            (no_path_msg, has_path),
+        ]);
         if ui
             .add_enabled(tex_enabled, egui::Button::new("Generate Textures"))
-            .on_hover_text(
+            .on_hover_text(tex_reason.as_deref().unwrap_or(
                 "Run the textures pipeline with the options above. \
                  Writes PNGs to ./textures/ next to the .mog.",
-            )
+            ))
             .clicked()
         {
             let ctx = ui.ctx().clone();

--- a/crates/mogen-studio/src/app/ui_llm/progress.rs
+++ b/crates/mogen-studio/src/app/ui_llm/progress.rs
@@ -155,9 +155,10 @@ impl MogenStudioApp {
                             if ui
                                 .button("Cancel")
                                 .on_hover_text(
-                                    "Stop waiting and discard the result. \
-                                     The background call may finish but its \
-                                     output is dropped. (Esc)",
+                                    "Stop waiting and discard the result. Any \
+                                     in-flight call still completes server-side \
+                                     and is billed normally — Studio just \
+                                     ignores the response. (Esc)",
                                 )
                                 .clicked()
                             {

--- a/crates/mogen-studio/src/app/ui_menu.rs
+++ b/crates/mogen-studio/src/app/ui_menu.rs
@@ -105,7 +105,13 @@ impl MogenStudioApp {
                 }
                 ui.menu_button("Open Recent", |ui| {
                     if self.settings.recent_files.is_empty() {
-                        ui.label("(no recent MOG files)");
+                        ui.label(
+                            egui::RichText::new("No recent files").strong(),
+                        );
+                        ui.label(
+                            "Use File → Open… or File → New from Prompt… to \
+                             start a project. The list fills up as you go.",
+                        );
                     } else {
                         let recents: Vec<String> = self.settings.recent_files.clone();
                         for path in &recents {
@@ -851,14 +857,30 @@ impl MogenStudioApp {
                 ui.horizontal(|ui| {
                     for (i, f) in self.files.iter().enumerate() {
                         let selected = i == self.active;
-                        let mut label = f.display_name();
+                        // Prefix with a leading bullet for unsaved buffers so
+                        // dirty state is visible at a glance, not just on the
+                        // trailing edge where a long filename can push it
+                        // out of view.
+                        let mut label = String::new();
                         if f.dirty {
-                            label.push_str(" •");
+                            label.push_str("• ");
                         }
+                        label.push_str(&f.display_name());
                         if f.llm_in_flight.is_some() {
                             label.push_str(" ⟳");
                         }
                         let resp = ui.selectable_label(selected, label);
+                        let resp = if f.dirty || f.llm_in_flight.is_some() {
+                            resp.on_hover_text(if f.dirty && f.llm_in_flight.is_some() {
+                                "• unsaved changes · ⟳ AI request in progress"
+                            } else if f.dirty {
+                                "• unsaved changes — Cmd/Ctrl+S to save"
+                            } else {
+                                "⟳ AI request in progress"
+                            })
+                        } else {
+                            resp
+                        };
                         if resp.clicked() {
                             activate = Some(i);
                         }
@@ -937,8 +959,17 @@ impl MogenStudioApp {
                                 ui.close_menu();
                             }
                         });
+                        // Larger hit-area than `small_button("×")`. Frame is
+                        // off so the X looks the same when idle but registers
+                        // a wider clickable region for trackpad / touch users.
                         let x_resp = ui
-                            .small_button("×")
+                            .add(
+                                egui::Button::new(
+                                    egui::RichText::new("×").strong(),
+                                )
+                                .frame(false)
+                                .min_size(egui::vec2(18.0, 18.0)),
+                            )
                             .on_hover_text("Close tab");
                         if x_resp.clicked() {
                             close = Some(i);

--- a/crates/mogen-studio/src/app/ui_panels/animation.rs
+++ b/crates/mogen-studio/src/app/ui_panels/animation.rs
@@ -106,7 +106,10 @@ impl MogenStudioApp {
 
         ui.horizontal(|ui| {
             let mut speed = self.viewer.playback_speed();
-            ui.label("Speed");
+            ui.label("Speed").on_hover_text(
+                "Negative values play clips in reverse; 0 pauses; 1× is real \
+                 time; 2× plays twice as fast.",
+            );
             let resp = ui.add(
                 egui::Slider::new(&mut speed, -2.0..=4.0)
                     .suffix("×")
@@ -124,6 +127,20 @@ impl MogenStudioApp {
             {
                 self.viewer.set_playback_speed(1.0);
             }
+            // Tag what the current speed value actually does so users see at
+            // a glance that −1× means rewind and 0× means paused-by-slider.
+            let tag = if speed.abs() < 0.005 {
+                "paused"
+            } else if speed < 0.0 {
+                "reverse"
+            } else if (speed - 1.0).abs() < 0.005 {
+                "real time"
+            } else if speed > 1.0 {
+                "fast"
+            } else {
+                "slow"
+            };
+            ui.label(egui::RichText::new(format!("({tag})")).weak());
         });
 
         ui.add_space(4.0);

--- a/crates/mogen-studio/src/app/ui_panels/diagnostics.rs
+++ b/crates/mogen-studio/src/app/ui_panels/diagnostics.rs
@@ -58,7 +58,8 @@ impl MogenStudioApp {
     }
 
     pub(in crate::app) fn ui_diagnostics(&mut self, ui: &mut egui::Ui) {
-        let f = &self.files[self.active];
+        let i = self.active;
+        let f = &self.files[i];
         let Some(result) = &f.last_result else {
             ui.label("(no build yet)");
             return;
@@ -74,6 +75,10 @@ impl MogenStudioApp {
             }
             return;
         }
+        // Collect the offset to jump to outside the loop because the
+        // diagnostic row borrows `f` immutably and we need mutable access to
+        // `self.files[i]` to push the pending caret.
+        let mut jump_to: Option<usize> = None;
         for d in &result.diagnostics {
             let (color, tag) = match d.severity {
                 Severity::Error => (egui::Color32::from_rgb(230, 100, 100), "error"),
@@ -83,11 +88,24 @@ impl MogenStudioApp {
             ui.horizontal_wrapped(|ui| {
                 ui.colored_label(color, format!("[{tag}] {}", d.code));
                 if let Some(span) = d.span {
-                    let (line, col) = offset_to_line_col(&f.source, span.start);
-                    ui.label(format!("{line}:{col}"));
+                    let safe_start = span.start.min(f.source.len());
+                    let (line, col) = offset_to_line_col(&f.source, safe_start);
+                    // Clickable line:col jumps the editor caret to the
+                    // diagnostic site. Underlined link styling follows the
+                    // rest of the app's convention.
+                    let link = ui.add(egui::Link::new(
+                        egui::RichText::new(format!("{line}:{col}")).underline(),
+                    ));
+                    if link.clicked() {
+                        jump_to = Some(safe_start);
+                    }
+                    link.on_hover_text("Jump editor caret to this location");
                 }
                 ui.label(&d.message);
             });
+        }
+        if let Some(offset) = jump_to {
+            self.files[i].pending_caret = Some(offset);
         }
     }
 }

--- a/crates/mogen-studio/src/app/ui_panels/editor.rs
+++ b/crates/mogen-studio/src/app/ui_panels/editor.rs
@@ -148,6 +148,34 @@ impl MogenStudioApp {
                         changed = true;
                     }
 
+                    // Faint current-line highlight. Drawn after the text so we
+                    // sit above the editor background but below the find /
+                    // multi-cursor overlays. Pulled from output.cursor_range
+                    // so it tracks every kind of caret movement (typing, click,
+                    // arrow, viewport-pick, diagnostic-jump) without extra
+                    // bookkeeping.
+                    if !generating {
+                        if let Some(range) = output.cursor_range {
+                            let caret_rect = output.galley.pos_from_cursor(&range.primary);
+                            let pos = output.galley_pos;
+                            let line_rect = egui::Rect::from_min_max(
+                                egui::pos2(
+                                    output.text_clip_rect.left(),
+                                    caret_rect.min.y + pos.y,
+                                ),
+                                egui::pos2(
+                                    output.text_clip_rect.right(),
+                                    caret_rect.max.y + pos.y,
+                                ),
+                            );
+                            ui.painter_at(output.text_clip_rect).rect_filled(
+                                line_rect,
+                                0.0,
+                                egui::Color32::from_white_alpha(8),
+                            );
+                        }
+                    }
+
                     // Re-assert the pre-press selection on secondary press
                     // so the right-click menu can see what the user had
                     // highlighted.

--- a/crates/mogen-studio/src/app/ui_panels/materials.rs
+++ b/crates/mogen-studio/src/app/ui_panels/materials.rs
@@ -43,6 +43,31 @@ impl MogenStudioApp {
         let has_path = self.files[i].path.is_some();
         let src_empty = self.files[i].source.trim().is_empty();
         let tex_enabled = has_key && !busy && !src_empty && has_path;
+        let provider_name = self.settings.provider().display_name();
+        // Spelled out so the user knows which prerequisite to fix without
+        // having to discover them one by one.
+        let tex_disabled_reason: Option<String> = if tex_enabled {
+            None
+        } else {
+            let mut blockers: Vec<String> = Vec::new();
+            if !has_key {
+                blockers.push(format!("set a {provider_name} API key in Preferences"));
+            }
+            if busy {
+                blockers.push("another LLM call is in flight on this tab".into());
+            }
+            if src_empty {
+                blockers.push("open or paste a .mog file first".into());
+            }
+            if !has_path {
+                blockers.push("save the file first — textures writes PNGs next to it".into());
+            }
+            Some(if blockers.len() == 1 {
+                format!("Disabled — {}", blockers[0])
+            } else {
+                format!("Disabled:\n  • {}", blockers.join("\n  • "))
+            })
+        };
         let ctx = ui.ctx().clone();
         let Some(result) = &self.files[i].last_result else {
             ui.label("(no build yet)");
@@ -555,11 +580,12 @@ impl MogenStudioApp {
                                 "Run the textures pipeline for this material — writes a \
                                  base_color PNG (plus derived normal/MR/AO) into ./textures/"
                             };
-                            if ui
+                            let gen_resp = ui
                                 .add_enabled(tex_enabled, egui::Button::new(gen_label))
-                                .on_hover_text(gen_tip)
-                                .clicked()
-                            {
+                                .on_hover_text(
+                                    tex_disabled_reason.as_deref().unwrap_or(gen_tip),
+                                );
+                            if gen_resp.clicked() {
                                 pending_tex_action =
                                     Some(TexAction::Regenerate(mat.name.clone()));
                             }
@@ -598,8 +624,20 @@ impl MogenStudioApp {
                             } else {
                                 ("✗", egui::Color32::from_rgb(230, 100, 100))
                             };
+                            // Concrete hover text on the missing marker so
+                            // the user sees *which* path the file picker
+                            // looked for, not just that something is wrong.
+                            let mark_tip = if exists {
+                                format!("Found at {}", resolved.display())
+                            } else {
+                                format!(
+                                    "File not found at {}\nRegenerate or update the path \
+                                     attribute in the .mog source.",
+                                    resolved.display()
+                                )
+                            };
                             ui.horizontal_wrapped(|ui| {
-                                ui.colored_label(color, mark);
+                                ui.colored_label(color, mark).on_hover_text(mark_tip);
                                 ui.label(*slot);
                                 let display = ellipsize_path(rel_path, 30);
                                 ui.label(display)

--- a/crates/mogen-studio/src/app/ui_panels/overlay.rs
+++ b/crates/mogen-studio/src/app/ui_panels/overlay.rs
@@ -246,11 +246,18 @@ impl MogenStudioApp {
                                 .on_hover_text(if cinema_on {
                                     "Stop cinema mode and restore the previous camera"
                                 } else {
-                                    "Play an automated sequence of camera shots"
+                                    "Play an automated sequence of camera shots. \
+                                     Animations resume only if they were already \
+                                     playing — toggle Play first if you want the \
+                                     subject to move while the camera pans."
                                 })
                                 .clicked()
                             {
-                                self.viewer.set_cinema_active(!cinema_on);
+                                // Don't force-play animations on enable: the
+                                // previous default surprised users who were
+                                // previewing a static model. They can hit Play
+                                // separately if they want both at once.
+                                self.viewer.set_cinema_active(!cinema_on, false);
                             }
                         });
                     });
@@ -261,10 +268,20 @@ impl MogenStudioApp {
         // and never competes with the right-hand inspector for horizontal room
         // (DCC convention — Blender/Maya put help text at the bottom).
         let cinema_on = self.viewer.is_cinema_active();
+        let ctrl_held = ctx.input(|i| i.modifiers.ctrl || i.modifiers.command);
         let status_text: Option<String> = if cinema_on {
             self.viewer
                 .cinema_shot_label()
                 .map(|name| format!("now: {name}"))
+        } else if ctrl_held {
+            // Ctrl held = snap mode. Surface the actual step values so users
+            // know exactly what they're snapping to before committing a drag.
+            Some(format!(
+                "snap: translate {}u · rotate {}° · scale {}× — release ctrl for free drag",
+                crate::viewer::state::TRANSLATE_SNAP_STEP,
+                crate::viewer::state::ROTATE_SNAP_STEP_DEG,
+                crate::viewer::state::SCALE_SNAP_STEP,
+            ))
         } else {
             Some(
                 "click: select · shift/cmd+click: add · del: delete selected · \

--- a/crates/mogen-studio/src/app/ui_panels/overlay.rs
+++ b/crates/mogen-studio/src/app/ui_panels/overlay.rs
@@ -41,10 +41,13 @@ impl MogenStudioApp {
                                 // Hotkeys are bare W/E/R (Godot / Unity
                                 // convention) — surfaced in the tooltip so
                                 // users can discover them without docs.
+                                // Labels match the bare W/E/R hotkeys so the
+                                // button text and the keyboard binding don't
+                                // contradict each other.
                                 for (label, mode, tip) in [
-                                    ("T", GizmoMode::Translate, "Translate gizmo  (W)"),
-                                    ("R", GizmoMode::Rotate, "Rotate gizmo  (E)"),
-                                    ("S", GizmoMode::Scale, "Scale gizmo  (R)"),
+                                    ("W", GizmoMode::Translate, "Translate gizmo  (W)"),
+                                    ("E", GizmoMode::Rotate, "Rotate gizmo  (E)"),
+                                    ("R", GizmoMode::Scale, "Scale gizmo  (R)"),
                                 ] {
                                     let selected = cur == mode;
                                     if ui
@@ -279,6 +282,43 @@ impl MogenStudioApp {
                         .fill(ui.visuals().window_fill().linear_multiply(0.85))
                         .show(ui, |ui| {
                             ui.label(egui::RichText::new(text).weak());
+                        });
+                });
+        }
+
+        // First-launch / empty-buffer state. Rendered centred over the
+        // viewport so the user has somewhere to start instead of staring at
+        // a black canvas.
+        if !self.viewer.has_scene() {
+            egui::Area::new(egui::Id::new("viewport_empty_state"))
+                .fixed_pos(viewport_rect.center())
+                .pivot(egui::Align2::CENTER_CENTER)
+                .interactable(false)
+                .show(ctx, |ui| {
+                    egui::Frame::popup(ui.style())
+                        .fill(ui.visuals().window_fill().linear_multiply(0.85))
+                        .inner_margin(egui::Margin::symmetric(20.0, 16.0))
+                        .show(ui, |ui| {
+                            ui.vertical_centered(|ui| {
+                                ui.label(
+                                    egui::RichText::new("No scene loaded yet")
+                                        .heading()
+                                        .strong(),
+                                );
+                                ui.add_space(6.0);
+                                ui.label(
+                                    "Type DSL in the editor on the left, or use one of:",
+                                );
+                                ui.add_space(4.0);
+                                ui.label(
+                                    egui::RichText::new(
+                                        "• File → Open…  to load a .mog file\n\
+                                         • File → New from Prompt…  to generate one with AI\n\
+                                         • Right-click the viewport  to add a primitive",
+                                    )
+                                    .weak(),
+                                );
+                            });
                         });
                 });
         }

--- a/crates/mogen-studio/src/app/ui_panels/selected.rs
+++ b/crates/mogen-studio/src/app/ui_panels/selected.rs
@@ -35,6 +35,37 @@ impl MogenStudioApp {
                  shows the most recently clicked node; Delete removes every \
                  selected node.",
             );
+            // Spell out which node is primary vs secondary so the user can
+            // see at a glance whose attributes the inspector is editing.
+            // Pulled from the viewer-side scene snapshot rather than the
+            // file's last_result so the names line up with what's painted
+            // in the viewport.
+            if let Some(scene_arc) = self
+                .files
+                .get(self.active)
+                .and_then(|f| f.last_result.as_ref())
+                .and_then(|r| r.scene.as_ref())
+            {
+                let all = self.viewer.all_selected();
+                ui.horizontal_wrapped(|ui| {
+                    for (idx, id) in all.iter().enumerate() {
+                        let is_primary = idx + 1 == all.len();
+                        let name = scene_arc
+                            .nodes
+                            .get(id.0 as usize)
+                            .map(|n| n.name.as_str())
+                            .unwrap_or("(stale)");
+                        let prefix = if is_primary { "★ " } else { "" };
+                        let label = format!("{prefix}{name}");
+                        let rich = if is_primary {
+                            egui::RichText::new(label).strong()
+                        } else {
+                            egui::RichText::new(label).weak()
+                        };
+                        ui.label(rich);
+                    }
+                });
+            }
             ui.add_space(4.0);
         }
         let i = self.active;
@@ -807,8 +838,20 @@ impl MogenStudioApp {
             }
         }
 
+        let any_edits = !edits.is_empty();
         for edit in edits {
             self.viewer.push_pending_edit(edit);
+        }
+        // Mirror the viewport-pick behaviour: when an inspector field commits
+        // a transform / attribute write, jump the editor caret to the node's
+        // declaration so the user can see what just changed in source. The
+        // span comes from the lowered scene graph and is None for derived
+        // nodes (CSG output, replicators) — they have nothing to point at.
+        if any_edits {
+            if let Some(span) = node_span {
+                let i = self.active;
+                self.files[i].pending_caret = Some(span.start);
+            }
         }
 
         // Delete / Duplicate operate straight on the source string because

--- a/crates/mogen-studio/src/app/viewport_menu.rs
+++ b/crates/mogen-studio/src/app/viewport_menu.rs
@@ -244,10 +244,16 @@ impl MogenStudioApp {
             let imports = edit::list_imports(&self.files[self.active].source);
             ui.menu_button("Imports", |ui| {
                 if imports.is_empty() {
-                    ui.add_enabled(false, egui::Button::new("(no imports)"))
-                        .on_hover_text(
-                            "Use File → Import… (Cmd+Shift+I) to add an `import \"…\"` line first",
-                        );
+                    ui.label(
+                        egui::RichText::new("No imports yet").strong(),
+                    );
+                    ui.label(
+                        egui::RichText::new(
+                            "File → Import… (Cmd+Shift+I) adds an \
+                             `import \"…\"` line. Imports show up here.",
+                        )
+                        .weak(),
+                    );
                 } else {
                     for entry in &imports {
                         let label = entry.module_name.clone();

--- a/crates/mogen-studio/src/settings.rs
+++ b/crates/mogen-studio/src/settings.rs
@@ -320,6 +320,13 @@ pub struct Settings {
     /// without re-authenticating.
     #[serde(default)]
     pub image_provider: String,
+
+    /// GitHub release tag the user explicitly skipped from the
+    /// Help → Check for Updates dialog. The dialog suppresses the
+    /// "update available" CTA when the latest tag matches this string;
+    /// any newer release supersedes the skip.
+    #[serde(default)]
+    pub skipped_update_tag: String,
 }
 
 /// Default viewer background. Independent of the UI theme so the model's

--- a/crates/mogen-studio/src/splash.rs
+++ b/crates/mogen-studio/src/splash.rs
@@ -117,7 +117,7 @@ pub fn draw(
                 text_pos,
                 egui::Align2::LEFT_BOTTOM,
                 label,
-                egui::FontId::proportional(13.0),
+                egui::FontId::proportional(14.5),
                 egui::Color32::from_rgb(232, 226, 210),
             );
 
@@ -130,7 +130,7 @@ pub fn draw(
                 title_pos,
                 egui::Align2::RIGHT_BOTTOM,
                 title,
-                egui::FontId::proportional(13.0),
+                egui::FontId::proportional(14.5),
                 egui::Color32::from_rgba_unmultiplied(232, 226, 210, 200),
             );
         });

--- a/crates/mogen-studio/src/viewer.rs
+++ b/crates/mogen-studio/src/viewer.rs
@@ -12,7 +12,7 @@ mod lights_gl;
 mod renderer;
 mod shaders;
 pub mod shadows;
-mod state;
+pub(crate) mod state;
 
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -449,9 +449,13 @@ impl Viewer {
 
     /// Toggle cinema mode. On enable, latches the current camera pose and
     /// re-frames against the static bounding sphere so each shot composes
-    /// around the model itself; force-plays animations so the subject moves
-    /// while the camera pans. On disable, restores the latched pose.
-    pub fn set_cinema_active(&self, on: bool) {
+    /// around the model itself. On disable, restores the latched pose.
+    ///
+    /// `force_play` controls whether animations should be force-started when
+    /// cinema activates. Pass `true` to match the previous default (the
+    /// model performs while the camera pans); `false` lets the user enable
+    /// cinema on a static model without surprise animation playback.
+    pub fn set_cinema_active(&self, on: bool, force_play: bool) {
         let mut st = self.state.lock().unwrap();
         if on == st.cinema.active {
             return;
@@ -466,7 +470,9 @@ impl Viewer {
             let st = &mut *st;
             st.cinema.activate(&st.camera);
             st.gizmo_drag = None;
-            st.anim_playing = true;
+            if force_play {
+                st.anim_playing = true;
+            }
         } else if let Some(snap) = st.cinema.deactivate() {
             st.camera.restore(snap);
         }

--- a/crates/mogen-studio/src/viewer.rs
+++ b/crates/mogen-studio/src/viewer.rs
@@ -159,6 +159,12 @@ impl Viewer {
         st.pick_cycle = None;
     }
 
+    /// True when no scene is loaded yet (fresh launch with an empty buffer).
+    /// Used by the viewport overlay to render a help message.
+    pub fn has_scene(&self) -> bool {
+        self.state.lock().unwrap().scene.is_some()
+    }
+
     /// Replace the selection with a single node (or clear it). Equivalent
     /// to a plain click in the viewport.
     pub fn set_primary_selection(&self, id: Option<NodeId>) {

--- a/crates/mogen-studio/src/viewer/state.rs
+++ b/crates/mogen-studio/src/viewer/state.rs
@@ -197,13 +197,13 @@ pub struct GizmoDrag {
 
 /// Snap step for translate: drag deltas that land the node's world-axis
 /// position on this grid are preferred when Ctrl is held.
-pub(super) const TRANSLATE_SNAP_STEP: f32 = 0.25;
+pub(crate) const TRANSLATE_SNAP_STEP: f32 = 0.25;
 /// Snap step for rotate: 15° feels coarse enough to be useful without
 /// forcing the user to fight the handle for in-between angles.
-pub(super) const ROTATE_SNAP_STEP_DEG: f32 = 15.0;
+pub(crate) const ROTATE_SNAP_STEP_DEG: f32 = 15.0;
 /// Snap step for scale: 25% increments land on nice factors (0.25, 0.5,
 /// 0.75, 1.0, 1.25, …) when Ctrl is held.
-pub(super) const SCALE_SNAP_STEP: f32 = 0.25;
+pub(crate) const SCALE_SNAP_STEP: f32 = 0.25;
 
 /// Apply axis-grid snapping to a translate drag so `start + delta` lands
 /// on a multiple of [`TRANSLATE_SNAP_STEP`]. Keeps the preview and the

--- a/docs/ux-audit-2026-05.md
+++ b/docs/ux-audit-2026-05.md
@@ -1,0 +1,468 @@
+# MoGen Studio UX Audit — 2026-05
+
+Audit of the MoGen Studio desktop GUI (`mogen-studio` crate) covering five
+surfaces: first-run / menus / file picker, code editor, LLM-driven flows
+(generate / modify / textures), 3D viewport, and dialogs / settings / lifecycle.
+
+Approach: read-only review of the source. No interactive testing, so timing,
+animation, and focus-restoration claims that depend on runtime are flagged but
+not confirmed.
+
+Severity rubric:
+
+- **P0** — user can lose work, data corruption, or hard dead-end.
+- **P1** — friction that stalls or confuses a real workflow.
+- **P2** — polish, consistency, microcopy.
+
+Counts: 0 P0 · ~70 P1 · ~115 P2 across all surfaces.
+
+---
+
+## 1. Cross-cutting patterns
+
+These show up everywhere and dominate the friction list. Fixing the pattern is
+worth more than fixing each instance.
+
+### 1.1 Disabled buttons without inline reasons
+
+Roughly 25 buttons across menus, the LLM panel, the materials panel, the export
+dialog, and the publish dialog disable themselves without explaining why. The
+explanation usually exists, but only on hover. Examples:
+
+- `app/ui_llm/main.rs:53` — Modify is disabled when no key, busy, or src empty;
+  same disabled state, three different causes, one tooltip.
+- `app/ui_llm/main.rs:228` — Generate Textures disables on missing path; reason
+  shown in a separate banner the eye doesn't connect to the button.
+- `app/ui_panels/materials.rs:549` — Generate / Regenerate disables silently.
+- `app/file_picker.rs:513` — Confirm button disables with no inline message.
+- `app/ui_menu.rs:528` — Publish disables; tooltip says "sign in via Community
+  window" but you can't get to that window from here.
+
+**Pattern fix:** when a button is disabled, append the reason to the label
+itself or render a one-line hint immediately above/below it. Don't make users
+hover to learn the gating condition — they often don't realize the button is
+even interactive.
+
+### 1.2 Empty / deselected states are too quiet
+
+- Empty viewport on first launch: black canvas, no copy (`viewer.rs:535`).
+- File picker, empty folder: weak grey "(no .mog files here)"
+  (`file_picker.rs:582`).
+- Open Recent, empty: weak grey "(no recent MOG files)" (`ui_menu.rs:106`).
+- Selected panel, no selection: helpful hint, but consumes panel real estate
+  permanently (`ui_panels/selected.rs:18`).
+- Viewport context menu, no imports: a *disabled button* labelled "(no
+  imports)" reads as broken (`viewport_menu.rs:247`).
+
+**Pattern fix:** treat empty states as a teaching moment. Render at body size
+(not `.weak()`), and include the next action: "Right-click in the viewport to
+add a primitive, or File → New from Prompt to generate one."
+
+### 1.3 Terminology drift
+
+The same operation has multiple names in different parts of the UI:
+
+- "Build GLB" (button) vs "Compile" (tooltip on the same button,
+  `ui_menu.rs:155`).
+- "Render" (`ui_menu.rs:75, 179, 194` — used in tooltips for thumbnail and
+  video) vs "Generate" (used in the labels of those same items).
+- "MoG file" (sometimes) vs "MOG file" (other times) vs ".mog" (in the picker)
+  — `file_picker.rs:54` and elsewhere.
+- "Modify current:" / "Animate current:" vs "Repair current:" / "Textures:"
+  (LLM panel section headers — `ui_llm/main.rs`).
+
+**Pattern fix:** pick one verb per pipeline stage and use it everywhere.
+Recommended: **Build** = compile to GLB, **Generate** = LLM-driven content
+creation, **Render** = thumbnail/video output. Then run a sweep replacing
+inconsistent labels.
+
+### 1.4 Prerequisite paths buried in error text
+
+Several flows require setup elsewhere, and the only way to discover the
+prerequisite is to try the broken thing first:
+
+- No LLM key → click Generate → read banner → memorise menu path → quit dialog
+  → open Preferences. There is no clickable link from the error to its fix
+  (`app/ui_dialogs/ask.rs:90`, `app/ui_llm/main.rs:10`, `app/error_class.rs`).
+- Publish requires being signed in to MoGHub from the Community window
+  (`app/ui_menu.rs:528`); the disabled tooltip names the destination but does
+  not open it.
+- Save-As-Untitled-then-Export friction in `app/ui_dialogs/export.rs:38`: user
+  must close the export dialog, save the file, reopen the dialog. No "Save and
+  Export" button.
+
+**Pattern fix:** make the next step a button. "Open Preferences", "Sign in",
+"Save first" should be one click from the dialog that surfaces the
+requirement.
+
+### 1.5 Long operations without tangible progress
+
+- Video render (`ui_menu.rs:688`): can take 30+ seconds; current UI is a modal
+  that closes and a status bar that doesn't tick.
+- Texture generation per material: a stage label changes, but per-material
+  status, success/fail markers, and per-call cost are not surfaced
+  (`ui_llm/progress.rs:104`).
+- Update check (`app/update.rs`): "Cancel" button label doesn't change while
+  fetching from GitHub; user can't tell if the network is slow or stuck.
+- Shadow atlas reallocation (`viewer.rs:278`): GPU stall on next frame is
+  invisible.
+
+**Pattern fix:** every operation that can exceed ~1.5s needs a visible state
+transition: spinner + caption + cancel. Per-item progress when N items
+(materials, files, frames) are processed.
+
+### 1.6 Cost is opaque
+
+Texture generation runs through Gemini Image, billed per image, and a typical
+scene has several materials. There is no pre-flight estimate. The session
+meter (`ui_llm/session.rs:24`) shows running cost, but:
+
+- Doesn't separate text calls from image calls.
+- Doesn't warn at the long-context tier breakpoint.
+- Per-iteration repair-loop cost is invisible — a 4-iter repair on Pro can
+  silently double the bill.
+
+**Pattern fix:** before any LLM image call, show "N materials × ~$0.04 = ~$X.
+Continue?". Add an "estimated cost so far" line to the progress card.
+
+### 1.7 Reproducibility hidden
+
+`mogen` stamps a seed into the .mog header and the CLI exposes it. Studio does
+not expose the seed in either the New Prompt dialog or the LLM panel. Users
+can't A/B test prompts, can't lock down a result they liked, and can only
+reproduce by editing the .mog header by hand.
+
+**Fix:** add a seed field to the New Prompt dialog and to Preferences (with a
+"randomise" button). Display the resolved seed on the progress card.
+
+### 1.8 Platform-specific shortcuts hard-coded
+
+`app/text_menu.rs:93–159` shows shortcuts as the literal string `"Ctrl+X"` even
+on macOS. The right-click menu therefore lies on Mac. `ui_menu.rs:248`
+correctly uses an OS-aware modifier elsewhere, so this is a localised bug.
+
+**Fix:** route every shortcut label through `ctx.format_shortcut()` (or the
+existing helper in `ui_menu.rs`).
+
+### 1.9 `.small()` violations
+
+CLAUDE.md forbids `.small()` on user-facing text except for icon-only buttons.
+Concrete violations found:
+
+- `autocomplete.rs:289` — completion tag uses `TextStyle::Small`. Tags are
+  meaningful (function vs property vs keyword); shrinking them defeats them.
+- `splash.rs:120` — stage label rendered at 13.0 px; barely legible at 1080p.
+- `app/ui_panels/animation.rs:166` — `🗑` delete button is `.small()` even
+  though it carries no other affordance.
+- Several `small_button` calls in `app/ui_panels/overlay.rs` for primary
+  actions (Frame, gizmo mode) — not text but visually cramped.
+
+**Fix:** drop `.small()` from each; verify the layout still fits.
+
+### 1.10 Silent fallthrough on missing prerequisites
+
+- Open a saved tab whose file was deleted between sessions: tab opens with a
+  broken compile, no warning at restore time (`app.rs:397`,
+  `app/files.rs:43`).
+- Multi-cursor pruning when source shrinks (`multi_caret.rs:38`): selections
+  vanish without notice.
+- Cmd+D wraparound when there are no more occurrences: silent.
+- Select All / Cut / Paste from menu when no text field has focus: silent.
+- Clipboard errors in the right-click Paste handler: silent.
+
+**Fix:** every silent fallthrough should produce a one-line status-bar message.
+
+---
+
+## 2. P0 — none confirmed
+
+The exploration agents flagged one P0 (animation clip-list desync after
+recompile, `app/ui_panels/animation.rs:43`). Verified the code path:
+`active_clips()` is stored by index and can map to the wrong clip if a
+recompile reorders clips. The padding logic prevents OOB but not semantic
+mis-mapping. Real risk, but rare in practice (clip reordering requires the
+user to delete or insert a clip definition, which they will notice). **Treat
+as P1.** Long-term fix: key `active_clips` by clip name, not index.
+
+---
+
+## 3. Top 12 quick wins (recommended first PR scope)
+
+Concrete, low-risk, individually shippable. Roughly ranked by user impact per
+hour of work.
+
+1. **Tab dirty indicator.** Tabs show no asterisk or dot when the buffer has
+   unsaved changes (`app/files.rs`, `ui_menu.rs:854`). One-line fix; saves
+   real lost-work incidents.
+2. **First-launch empty viewport copy.** Black canvas on first run is the
+   single worst first impression. Add a centred message: "Open a .mog file or
+   File → New from Prompt to generate one. Right-click the viewport to add
+   primitives." (`viewer.rs:535`).
+3. **Disabled-button reasons inline.** Rewrite the disabled state of Modify,
+   Generate, Generate Textures, and Repair so the gating condition is part of
+   the label, not the tooltip.
+4. **OS-aware shortcuts in right-click menu.** Replace literal "Ctrl+X" with
+   `ctx.format_shortcut(...)` (`app/text_menu.rs`).
+5. **Seed field in New Prompt dialog.** One row, one TextEdit, one randomise
+   button (`app/ui_dialogs/new_prompt.rs`). Unblocks reproducibility.
+6. **Texture cost preflight.** Before kicking off the textures pipeline, show
+   "N materials × ~$0.04 = ~$X. Continue?" (`app/ui_llm/main.rs:228`).
+7. **Diagnostic line:col is clickable.** In the diagnostics panel
+   (`ui_panels/diagnostics.rs:60`), make the location label scroll the editor
+   and place the caret. Cuts time-to-fix per error roughly in half.
+8. **Frame button promoted to viewport overlay toolbar.** Currently in a
+   submenu (`ui_panels/overlay.rs`). Standard 3D-app convention; one
+   reposition.
+9. **Save-and-Export shortcut in export dialog.** When file is untitled, add
+   a "Save…" button next to the warning instead of forcing a dialog round-trip
+   (`app/ui_dialogs/export.rs:38`).
+10. **Quit/Close dialog primary-button focus.** Default-focus "Save All" so
+    Enter saves; today the user must reach for the mouse
+    (`app/ui_dialogs/quit.rs`).
+11. **Theme live preview.** Apply the theme on selection rather than on Save
+    so users can compare without re-opening Preferences (`theme.rs`,
+    `app/ui_dialogs/prefs.rs`).
+12. **Tab close-button hit area.** The `×` is a `small_button`; missed clicks
+    are common (`ui_menu.rs:940`). Use a normal-size button with an on-hover
+    background.
+
+---
+
+## 4. Per-surface findings
+
+For each surface, the most important issues. Severity in brackets, file:line
+where useful. Items already covered in §1 are not repeated.
+
+### 4.1 First run, splash, onboarding (`app.rs`, `splash.rs`,
+`app/onboarding.rs`)
+
+- **[P1]** Splash min dwell of 4 s (`app.rs:103`) is long when there are no
+  tabs to restore; lower to 1.5–2 s.
+- **[P1]** After Save in onboarding, the only confirmation is a status-bar
+  line buried under the closing modal (`onboarding.rs:147`). User can't tell
+  the key persisted. Show inline confirmation before close.
+- **[P1]** `GEMINI_API_KEY` fallback is documented in onboarding but not in
+  Preferences (`prefs.rs:345`). Both should mention the env var and which
+  takes precedence.
+- **[P1]** Crash-consent text rendered `.weak()` (`app/crash_consent.rs:62`).
+  Privacy disclosure shouldn't be de-emphasised.
+- **[P2]** Onboarding "Skip" path doesn't warn that LLM features will nag
+  later.
+- **[P2]** Onboarding success env-var box uses an off-palette blue
+  (`onboarding.rs:96`).
+
+### 4.2 Top menu and file picker (`app/ui_menu.rs`,
+`app/file_picker.rs`, `app/viewport_menu.rs`)
+
+- **[P1]** Filename field in Save As (`file_picker.rs:452`) doesn't say `.mog`
+  is auto-appended. Users wonder if their file will be `my_scene` or
+  `my_scene.mog`.
+- **[P1]** "Close all" / "Close to right" silently skip dirty tabs
+  (`ui_menu.rs:867`). User expects "all gone" and gets a partial result.
+  Either confirm-and-save like Cmd+Q does, or show "Skipped 3 unsaved tabs"
+  status.
+- **[P1]** Add submenu (`viewport_menu.rs:174`) is a long flat list with no
+  search; scroll-and-hunt for a specific primitive. Add a filter input.
+- **[P2]** New Folder input in the picker (`file_picker.rs:407`) gives no
+  cancel hint. Add "Esc to cancel."
+- **[P2]** Path bar in picker (`file_picker.rs:392`) is editable but doesn't
+  advertise paste-and-Enter affordance.
+- **[P2]** "Up" button at root disables silently (`file_picker.rs:370`).
+  Tooltip "Already at filesystem root."
+
+### 4.3 Code editor (`app/ui_panels/editor.rs`,
+`autocomplete.rs`, `app/find.rs`, `app/multi_caret.rs`,
+`highlight.rs`)
+
+- **[P1]** No current-line highlight in the gutter or the editor body
+  (`ui_panels/editor.rs:100`). Hard to track the caret in a 200-line file.
+- **[P1]** Diagnostics not click-to-jump (`ui_panels/diagnostics.rs:60`). See
+  §3.7.
+- **[P1]** Autocomplete popup is rendered in a separate `Area` after the
+  editor; it does not scroll with the ScrollArea (`autocomplete.rs:165`). On a
+  scrolled buffer the popup floats free of the line.
+- **[P1]** Autocomplete suppression is keyed off source length
+  (`autocomplete.rs:82`), not time. Type "x", delete, type "x" again — popup
+  may not return. Switch to a 300 ms suppression window.
+- **[P1]** `selected` index in autocomplete clamps but doesn't reset when the
+  candidate set changes (`autocomplete.rs:115`); top match isn't preselected.
+- **[P1]** Find bar Case-sensitivity toggle is "Aa" with no on/off visual
+  state beyond a faint background fill (`find.rs:234`). Use a checkbox or
+  pressed-state frame.
+- **[P1]** No regex mode in find. Power users assume it's there.
+- **[P1]** No keyboard-shortcut help dialog. Cmd+D, Cmd+L, Cmd+/, Alt+Up/Down,
+  F3, Shift+F3 all exist (`app/line_ops.rs:8`); none are surfaced anywhere
+  except the source.
+- **[P1]** `app/text_menu.rs` hard-codes `Ctrl+X` etc. — see §1.8.
+- **[P2]** Find substring match recomputes on every keystroke against the
+  whole buffer with `to_lowercase()` per char (`find.rs:105`). Stutters on
+  large files; cache the lowercased source.
+- **[P2]** Indent uses literal `\t` (`indent.rs:85`); mixes with
+  spaces-only files. Detect dominant style.
+- **[P2]** No soft ruler (column-80 line). No word-wrap toggle.
+- **[P2]** Multi-cursor exits silently when arrow keys collapse it
+  (`multi_caret.rs:210`). Status hint: "Esc to clear multi-cursor."
+
+### 4.4 LLM flows (`app/llm.rs`, `app/generate.rs`,
+`app/ask.rs`, `app/ui_llm/*`, `app/ui_dialogs/new_prompt.rs`)
+
+- **[P1]** No seed control. See §1.7 / §3.5.
+- **[P1]** Texture generation runs without a cost preflight. See §3.6.
+- **[P1]** "no Gemini API key — set GEMINI_API_KEY, paste a key in Edit →
+  Preferences…, or switch to 'Gemini (Google OAuth)'"
+  (`app/llm/credentials.rs:59`) packs three options into one sentence; users
+  pick the wrong path or freeze. Split into stacked options with buttons.
+- **[P1]** "Auto" image provider precedence is opaque
+  (`app/ui_dialogs/prefs.rs:244`). Show the resolved choice live.
+- **[P1]** Cancel hover text "may finish but its output is dropped"
+  (`ui_llm/progress.rs:156`) is scary and ambiguous about billing. Clarify
+  that any in-flight call still bills server-side.
+- **[P1]** Save in Preferences stores the API key with no validation
+  (`prefs.rs:163`). First failure surfaces only on Generate. Add a cheap
+  "test key" call.
+- **[P1]** Claude Code section says `claude /login` (`prefs.rs:306`). The
+  command is `claude login` (no slash).
+- **[P1]** Texture partial success (3/5 ok, 2 fail) renders as a red error
+  banner (`app/llm/poll.rs:95`); user assumes the whole thing failed.
+- **[P2]** "Thinking" budget UI talks in tokens of "hidden reasoning" without
+  mapping to latency or quality (`app/ui_llm/thinking.rs:18`).
+- **[P2]** Repair-loop dots animate but don't say what changed between
+  iterations (`ui_llm/progress.rs:298`). Consider "iter 2: fixed 1 error,
+  introduced 2."
+- **[P2]** Microcopy lowercase / abrupt: "type a question first", "enter a
+  prompt first", "thumbnail: nothing to render" (`app/ask.rs:94`,
+  `app/llm.rs:30`, `app/generate.rs:112`). Sentence case + actionable phrasing.
+- **[P2]** Provider label "Google (gemini-cli)" exposes the OAuth client name
+  (`oauth_ui.rs:104`). Just say "Google (OAuth)".
+
+### 4.5 3D viewport (`viewer.rs`, `gizmo.rs`,
+`pick.rs`, `app/ui_panels/overlay.rs`, `app/ui_panels/selected.rs`,
+`app/ui_panels/materials.rs`, `app/ui_panels/animation.rs`)
+
+- **[P1]** Empty viewport on first run — see §3.2.
+- **[P1]** Active-clip state stored by index, can shift on recompile if clip
+  ordering changes (`ui_panels/animation.rs:43`). Key by name.
+- **[P1]** Gizmo mode buttons labelled "T / R / S" with hotkey hints "(W)",
+  "(E)", "(R)" (`ui_panels/overlay.rs:44`). Either fix labels to W/E/R or
+  rebind hotkeys to T/R/S. Currently the button text and the hotkey hint
+  contradict each other.
+- **[P1]** Gizmo silently disappears on non-editable nodes — imports,
+  CSG output, replicator members (`gizmo.rs` + `viewer/state.rs:592`). User
+  thinks the gizmo is broken. Show a dim "read-only" gizmo or an inline
+  reason.
+- **[P1]** Imported / relative-placed nodes have no visual mark in the 3D
+  view (`viewer/state.rs:109`). Selecting one and finding no gizmo is
+  confusing. Outline imports in a distinct colour.
+- **[P1]** "Imported via `use` — wrap in a group" warning in
+  `selected.rs:102` lacks a one-click "wrap it for me" button.
+- **[P1]** Multi-select indicator: header says "{n} nodes selected — editing
+  primary" (`selected.rs:27`); the *primary* node is not visually
+  distinguished in the viewport. Use a different selection colour for the
+  primary.
+- **[P1]** Inspector edits don't jump the editor caret to the modified node's
+  span (`selected.rs:163`); viewport clicks do. Asymmetric.
+- **[P1]** Snap step values (translate 0.25, rotate 15°, scale 25%) are
+  invisible (`viewer/state.rs:200`). Expose in the overlay.
+- **[P1]** Speed slider runs from −2× to +4× with no zero indicator
+  (`ui_panels/animation.rs:107`). Accidentally dragging through zero plays
+  backwards with no explanation.
+- **[P1]** Animated shaders (water, etc.) keep painting while playback is
+  paused (`viewer.rs:805`); confusing while editing materials.
+- **[P1]** Generate / Regenerate texture button in materials panel disables
+  silently with no inline reason (`ui_panels/materials.rs:549`).
+- **[P1]** Missing texture file shows a red cross with no reason
+  (`ui_panels/materials.rs:592`). On hover, surface "File not found:
+  {path}".
+- **[P1]** Cinema mode forces playback on (`viewer.rs:448`) without asking.
+- **[P1]** Light gizmos don't scale with zoom (`viewer/lights.rs:52`).
+- **[P2]** No FPS counter; no current-frame counter; no clip-loop indicator.
+- **[P2]** Grid lacks unit labels (`viewer.rs:894`).
+- **[P2]** Pick latency unbounded on heavy scenes (`pick.rs:31` is
+  brute-force per-triangle).
+- **[P2]** Drill-down (Figma-style) on repeated click is undiscoverable
+  (`viewer/state.rs:959`); add a small "click again to drill" hint after the
+  first click.
+- **[P2]** Material panel thumbnails are 64 px squares with no click-to-zoom.
+
+### 4.6 Dialogs, settings, lifecycle (`settings.rs`, `theme.rs`,
+`app/ui_dialogs/*`, `app/files.rs`, `app/watcher.rs`, `app/update.rs`,
+`app/error_class.rs`, `app/moghub.rs`)
+
+- **[P1]** Tab dirty indicator missing — see §3.1.
+- **[P1]** "Close all" / "Close to right" skip dirty tabs silently — see §4.2.
+- **[P1]** Update dialog has no "Skip this version" / "Remind me later"
+  (`app/ui_dialogs/update.rs:21`); same nudge every session.
+- **[P1]** Untitled-file export round-trip — see §3.9.
+- **[P1]** Publish form allows empty title and fails server-side
+  (`community/publish.rs:118`). Disable Publish until title is set; red-mark
+  the field.
+- **[P1]** GitHub OAuth in MoGHub sign-in is silent if the browser fails to
+  open (`community/auth.rs:11`). Log the URL and show a copy button.
+- **[P1]** Community discover spins forever with no timeout when offline
+  (`community/mod.rs:46`).
+- **[P1]** Conflict modal X close button defaults to "Keep mine" on
+  Modified-on-disk (`app/ui_dialogs/external.rs:14`); ambiguous to users who
+  read X as "back".
+- **[P1]** Conflict modal puts "Close tab" as the rightmost (default-eye)
+  button (`external.rs:98`); destructive action in the primary slot.
+- **[P1]** API-key field is masked, so accidental whitespace pasted with the
+  key is invisible (`prefs.rs:343`). Trim on save and tell the user.
+- **[P1]** First-launch onboarding hands users into an empty editor with no
+  guided next step. After crash-consent, an LLM-setup wizard would help.
+- **[P2]** Settings save provides no toast confirmation
+  (`settings.rs:40`).
+- **[P2]** No OS-theme detection on first launch (`theme.rs`).
+- **[P2]** Quit-confirmation tab name is double-quoted: `""scene.mog" has
+  unsaved changes` (`quit.rs:113`).
+- **[P2]** About dialog links have no underline / hover effect
+  (`about.rs:15`).
+- **[P2]** Watcher pauses while a modal is open (`watcher.rs:25`); external
+  changes are missed. Queue them and prompt after the modal closes.
+- **[P2]** Many dialogs are non-resizable; tall content can clip on small
+  screens.
+- **[P2]** Generic button labels ("OK", "Cancel") on context-laden modals
+  (e.g. file conflict). Prefer action verbs: "Keep my edits" / "Reload from
+  disk".
+
+---
+
+## 5. Suggested execution order
+
+If this lands as a stream of small PRs, an order that compounds well:
+
+1. **Foundation (1 day):** tab dirty indicator, OS-aware shortcuts, drop the
+   `.small()` violations, stop hard-coding `"Ctrl+…"` in the right-click menu.
+2. **Empty states (1 day):** first-launch viewport copy, file-picker empty
+   folder, Open Recent empty, viewport context-menu "no imports".
+3. **Disabled-button rewrite (1 day):** sweep across LLM panel, materials
+   panel, file picker, export dialog. One shared helper for "disabled with
+   reason inline".
+4. **Editor wins (2 days):** click-to-jump diagnostics, current-line
+   highlight, autocomplete inside ScrollArea, time-based suppression, find-bar
+   regex toggle and case-sensitivity affordance, keyboard-shortcuts help
+   dialog.
+5. **LLM flow wins (2 days):** seed field, texture cost preflight, OAuth
+   sign-in button on the credentials banner, "test key" on Save, fix
+   `claude /login` typo, partial-success texture banner, OS-correct
+   provider labels.
+6. **Viewport wins (2 days):** Frame button to toolbar, gizmo button-vs-hotkey
+   label fix, dimmed read-only gizmo for non-editable nodes, zero-marker on
+   speed slider, key clip state by name not index, snap settings exposed.
+7. **Dialogs and lifecycle (1 day):** Skip-this-version on update,
+   Save-and-Export on untitled, Publish title validation, conflict modal
+   button reorder, theme live preview.
+
+Total: roughly two engineer-weeks for the items above, which would clear
+~70 % of the P1 list.
+
+---
+
+## 6. What this audit did not cover
+
+- Runtime testing of focus order, screen-reader behaviour, high-DPI scaling.
+- Cross-platform input quirks (Wayland, macOS trackpad gestures, Windows
+  IME).
+- Performance on large scenes — measured FPS, memory, GPU stalls.
+- Localisation. All copy is English-only and a few strings concatenate
+  poorly when translated (e.g. provider labels embedded mid-sentence).
+- The CLI (`mogen` binary) — out of scope; this is the Studio audit.


### PR DESCRIPTION
Read-only UX audit of mogen-studio plus the top-12 quick wins implemented
across the same surfaces.

## Audit

[`docs/ux-audit-2026-05.md`](docs/ux-audit-2026-05.md) covers first-run /
menus / file picker, editor, LLM flows, viewport, and dialogs / settings /
lifecycle. Captures cross-cutting patterns (silent disabled buttons,
quiet empty states, terminology drift, hidden cost / seed control), a
prioritised top-12 quick-win list, and per-surface findings keyed to
file:line.

## Implementation (top-12, grouped by commit)

- **Foundation** — tab dirty bullet + larger close-button hit area, OS-aware
  shortcuts in the right-click menu, drop `.small()` violations on autocomplete
  / splash / picker labels, empty states for Open Recent / picker / viewport
  imports menu.
- **Editor** — click-to-jump on diagnostic line:col, faint current-line
  highlight, autocomplete suppression switched from source-length to time-based
  (fixes the delete-and-retype dead spot), candidate-set fingerprint resets
  `selected` to top match, find bar gains a regex toggle and clearer
  case-sensitivity affordance.
- **LLM panel** — disabled-button reasons surfaced inline (Modify / Animate /
  Repair / Generate Textures), no-key banner becomes an "Open Preferences"
  CTA, seed field added to the New Prompt dialog, pre-flight cost estimate
  before texture runs, partial-success texture banner downgraded from red
  hard-error to soft warning, clearer cancel hover text re: billing.
- **Viewport** — gizmo button labels match the W/E/R hotkeys, snap step values
  surfaced when Ctrl is held, multi-select primary marker (★) in the inspector,
  inspector edits now jump the editor caret to match viewport-pick behaviour,
  cinema toggle no longer force-plays animations from the overlay (still
  force-plays from the spotlight palette where the user opted in explicitly),
  centred "no scene loaded" overlay on first launch, animation speed slider
  gets a (paused / reverse / real time / fast / slow) tag.
- **Dialogs** — Update dialog gets "Skip this version" (and now actually
  honours it — see below), Build-GLB dialog gets a "Save MOG first…"
  shortcut to skip the close-and-reopen round-trip, Quit / Close-tab make
  Save the visually primary action with Enter / Esc bindings, Publish
  requires a non-empty title (red-marked when missing), External-conflict
  modal calls out "closing keeps your buffer" and visually separates the
  destructive Close-tab branch, OAuth loopback logs the URL to stderr when
  `webbrowser::open` fails so headless / broken-launcher users can paste it.
- **Fix on top of the dialogs commit** — the original "Skip this version"
  wrote `settings.skipped_update_tag` but no code read it back, so the next
  dialog open re-showed the same CTA. Now the Ready branch swaps the green
  "update available" CTA for a calmer "available but you skipped this
  release" line + an explicit "Unskip and install" button when the latest
  tag matches the skipped tag.

## Test plan

- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace` — all 18 packages pass.
- [ ] Manual: trigger Help → Check for Updates with a fake newer release,
      click Skip, re-open dialog, confirm CTA is suppressed and Unskip
      restores it.
- [ ] Manual: open a .mog with diagnostics, click line:col, confirm caret
      jumps in the editor.
- [ ] Manual: open New Prompt dialog, type a non-numeric seed, confirm the
      orange "(not a valid u64 — seed will fall back to random)" hint
      appears and Generate still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
