### PR TITLE
Add easing curves to animation tracks and templates

### DIFF
--- a/crates/mogen-anim/src/lib.rs
+++ b/crates/mogen-anim/src/lib.rs
@@ -3,26 +3,36 @@
 //! Each template produces a [`Clip`] whose tracks drive node transforms (no
 //! skinning in v1). Templates take a target node id plus parameters and emit
 //! keyframes that the glTF exporter writes as standard TRS channels.
+//!
+//! Easing is applied to the procedural **phase** parameter (the normalised
+//! time `t ∈ [0, 1]` that drives the underlying curve), not as a post-bake
+//! per-segment warp. That gives the visually expected behaviour for one-shot
+//! animations like `open_close` (start slow, end slow) and for loop boundary
+//! ramps. The resulting `Track` carries `easing = Easing::Linear` because the
+//! curve has already been pre-warped — downstream consumers see a dense
+//! LINEAR sampling.
 
 use std::f32::consts::{PI, TAU};
 
 use glam::{Quat, Vec3};
-use mogen_core::{Clip, Interpolation, NodeId, Track, TrackProperty};
+use mogen_core::{Clip, Easing, Interpolation, NodeId, Track, TrackProperty};
 
 /// Continuous rotation at `rpm` around `axis`. Duration is one revolution so
-/// the clip loops seamlessly. Five keyframes avoid shortest-arc ambiguity
-/// between q(0) and q(2π).
-pub fn spin(name: &str, target: NodeId, axis: Vec3, rpm: f32) -> Clip {
+/// the clip loops seamlessly. With `Easing::Linear` we use the historical
+/// 5-sample track (avoids shortest-arc ambiguity between q(0) and q(2π));
+/// non-linear easing densifies to 32 samples so the phase warp is visible.
+pub fn spin(name: &str, target: NodeId, axis: Vec3, rpm: f32, easing: Easing) -> Clip {
     let rpm = rpm.max(1e-3);
     let duration = 60.0 / rpm;
     let axis = axis.normalize_or(Vec3::Y);
-    let steps = 4; // 5 samples including the endpoint.
+    let steps = if easing.is_linear() { 4 } else { 32 };
     let mut times = Vec::with_capacity(steps + 1);
     let mut values = Vec::with_capacity(steps + 1);
     for i in 0..=steps {
         let t = (i as f32) / (steps as f32);
         times.push(t * duration);
-        let q = Quat::from_axis_angle(axis, t * TAU);
+        let phase = easing.apply(t);
+        let q = Quat::from_axis_angle(axis, phase * TAU);
         values.push([q.x, q.y, q.z, q.w]);
     }
     Clip {
@@ -32,6 +42,7 @@ pub fn spin(name: &str, target: NodeId, axis: Vec3, rpm: f32) -> Clip {
             node: target,
             property: TrackProperty::Rotation,
             interpolation: Interpolation::Linear,
+            easing: Easing::Linear,
             times,
             values,
         }],
@@ -39,13 +50,49 @@ pub fn spin(name: &str, target: NodeId, axis: Vec3, rpm: f32) -> Clip {
     }
 }
 
-/// Hinge-style open/close: angle 0 → `angle_deg` → 0 over `seconds`.
-pub fn open_close(name: &str, target: NodeId, axis: Vec3, angle_deg: f32, seconds: f32) -> Clip {
+/// Hinge-style open/close: angle 0 → `angle_deg` → 0 over `seconds`. With
+/// non-linear easing, samples the eased phase densely so the curve is
+/// visible (e.g. `ease_in_out_back` overshoots near the apex).
+pub fn open_close(
+    name: &str,
+    target: NodeId,
+    axis: Vec3,
+    angle_deg: f32,
+    seconds: f32,
+    easing: Easing,
+) -> Clip {
     let seconds = seconds.max(1e-3);
     let axis = axis.normalize_or(Vec3::Y);
     let half = angle_deg.to_radians();
-    let q0 = Quat::IDENTITY;
-    let qh = Quat::from_axis_angle(axis, half);
+    let (times, values) = if easing.is_linear() {
+        let q0 = Quat::IDENTITY;
+        let qh = Quat::from_axis_angle(axis, half);
+        (
+            vec![0.0, seconds * 0.5, seconds],
+            vec![
+                [q0.x, q0.y, q0.z, q0.w],
+                [qh.x, qh.y, qh.z, qh.w],
+                [q0.x, q0.y, q0.z, q0.w],
+            ],
+        )
+    } else {
+        let steps = 32;
+        let mut times = Vec::with_capacity(steps + 1);
+        let mut values = Vec::with_capacity(steps + 1);
+        for i in 0..=steps {
+            let t = (i as f32) / (steps as f32);
+            times.push(t * seconds);
+            // Triangle phase 0→1→0 that easing warps in each half.
+            let tri = if t < 0.5 {
+                easing.apply(t * 2.0)
+            } else {
+                easing.apply((1.0 - t) * 2.0)
+            };
+            let q = Quat::from_axis_angle(axis, tri * half);
+            values.push([q.x, q.y, q.z, q.w]);
+        }
+        (times, values)
+    };
     Clip {
         name: name.to_string(),
         duration: seconds,
@@ -53,20 +100,26 @@ pub fn open_close(name: &str, target: NodeId, axis: Vec3, angle_deg: f32, second
             node: target,
             property: TrackProperty::Rotation,
             interpolation: Interpolation::Linear,
-            times: vec![0.0, seconds * 0.5, seconds],
-            values: vec![
-                [q0.x, q0.y, q0.z, q0.w],
-                [qh.x, qh.y, qh.z, qh.w],
-                [q0.x, q0.y, q0.z, q0.w],
-            ],
+            easing: Easing::Linear,
+            times,
+            values,
         }],
         origin: None,
     }
 }
 
 /// Sinusoidal rotation around `axis`, oscillating ±`amplitude_deg` at `hz`.
-/// Samples 16 keyframes per cycle; duration is one cycle.
-pub fn wave(name: &str, target: NodeId, axis: Vec3, amplitude_deg: f32, hz: f32) -> Clip {
+/// Samples 16 keyframes per cycle; duration is one cycle. Easing warps the
+/// in-cycle phase, so e.g. `ease_in_out` produces an asymmetric wobble that
+/// dwells at the extremes.
+pub fn wave(
+    name: &str,
+    target: NodeId,
+    axis: Vec3,
+    amplitude_deg: f32,
+    hz: f32,
+    easing: Easing,
+) -> Clip {
     let hz = hz.max(1e-3);
     let duration = 1.0 / hz;
     let axis = axis.normalize_or(Vec3::Z);
@@ -77,7 +130,8 @@ pub fn wave(name: &str, target: NodeId, axis: Vec3, amplitude_deg: f32, hz: f32)
     for i in 0..=samples {
         let t = (i as f32) / (samples as f32);
         times.push(t * duration);
-        let angle = amp * (t * TAU).sin();
+        let phase = easing.apply(t);
+        let angle = amp * (phase * TAU).sin();
         let q = Quat::from_axis_angle(axis, angle);
         values.push([q.x, q.y, q.z, q.w]);
     }
@@ -88,6 +142,7 @@ pub fn wave(name: &str, target: NodeId, axis: Vec3, amplitude_deg: f32, hz: f32)
             node: target,
             property: TrackProperty::Rotation,
             interpolation: Interpolation::Linear,
+            easing: Easing::Linear,
             times,
             values,
         }],
@@ -98,7 +153,14 @@ pub fn wave(name: &str, target: NodeId, axis: Vec3, amplitude_deg: f32, hz: f32)
 /// Bird/wing flap: wave-like oscillation, but biased to a single-direction
 /// up-beat + down-beat profile. Currently identical to `wave` around `axis`;
 /// reserved for asymmetric profiles.
-pub fn flap(name: &str, target: NodeId, axis: Vec3, amplitude_deg: f32, hz: f32) -> Clip {
+pub fn flap(
+    name: &str,
+    target: NodeId,
+    axis: Vec3,
+    amplitude_deg: f32,
+    hz: f32,
+    easing: Easing,
+) -> Clip {
     // Asymmetric profile: 60% up-stroke, 40% down-stroke. Sample analytically.
     let hz = hz.max(1e-3);
     let duration = 1.0 / hz;
@@ -110,8 +172,13 @@ pub fn flap(name: &str, target: NodeId, axis: Vec3, amplitude_deg: f32, hz: f32)
     for i in 0..=samples {
         let t = (i as f32) / (samples as f32);
         times.push(t * duration);
+        let warped = easing.apply(t);
         // Skewed sinusoid: faster up (0..0.6), slower down (0.6..1.0).
-        let phase = if t < 0.6 { (t / 0.6) * PI } else { PI + ((t - 0.6) / 0.4) * PI };
+        let phase = if warped < 0.6 {
+            (warped / 0.6) * PI
+        } else {
+            PI + ((warped - 0.6) / 0.4) * PI
+        };
         let angle = amp * phase.sin();
         let q = Quat::from_axis_angle(axis, angle);
         values.push([q.x, q.y, q.z, q.w]);
@@ -123,6 +190,7 @@ pub fn flap(name: &str, target: NodeId, axis: Vec3, amplitude_deg: f32, hz: f32)
             node: target,
             property: TrackProperty::Rotation,
             interpolation: Interpolation::Linear,
+            easing: Easing::Linear,
             times,
             values,
         }],
@@ -132,7 +200,7 @@ pub fn flap(name: &str, target: NodeId, axis: Vec3, amplitude_deg: f32, hz: f32)
 
 /// Subtle breathing idle: scales the target uniformly by ±`amplitude`
 /// at `hz`, returning to 1.0 at the loop boundary.
-pub fn idle(name: &str, target: NodeId, amplitude: f32, hz: f32) -> Clip {
+pub fn idle(name: &str, target: NodeId, amplitude: f32, hz: f32, easing: Easing) -> Clip {
     let hz = hz.max(1e-3);
     let duration = 1.0 / hz;
     let samples = 16;
@@ -141,7 +209,8 @@ pub fn idle(name: &str, target: NodeId, amplitude: f32, hz: f32) -> Clip {
     for i in 0..=samples {
         let t = (i as f32) / (samples as f32);
         times.push(t * duration);
-        let s = 1.0 + amplitude * (t * TAU).sin();
+        let phase = easing.apply(t);
+        let s = 1.0 + amplitude * (phase * TAU).sin();
         values.push([s, s, s, 0.0]);
     }
     Clip {
@@ -151,6 +220,7 @@ pub fn idle(name: &str, target: NodeId, amplitude: f32, hz: f32) -> Clip {
             node: target,
             property: TrackProperty::Scale,
             interpolation: Interpolation::Linear,
+            easing: Easing::Linear,
             times,
             values,
         }],

--- a/crates/mogen-core/src/anim.rs
+++ b/crates/mogen-core/src/anim.rs
@@ -1,4 +1,4 @@
-use glam::Vec3;
+use glam::{Quat, Vec3};
 use serde::{Deserialize, Serialize};
 
 use crate::NodeId;
@@ -46,15 +46,217 @@ pub enum Interpolation {
     Step,
 }
 
+/// Easing curve applied between (or across) keyframes. v1 bakes easing into
+/// dense LINEAR keyframes during lowering — glTF samplers themselves only
+/// support `LINEAR`/`STEP`/`CUBICSPLINE`, so a non-linear easing is realised by
+/// densifying the track and pre-evaluating the curve. Templates apply easing
+/// to their procedural phase parameter; authored `track`s ease the value
+/// between consecutive user keyframes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Easing {
+    #[default]
+    Linear,
+    EaseIn,
+    EaseOut,
+    EaseInOut,
+    EaseInCubic,
+    EaseOutCubic,
+    EaseInOutCubic,
+    EaseInSine,
+    EaseOutSine,
+    EaseInOutSine,
+    EaseInBack,
+    EaseOutBack,
+    EaseInOutBack,
+    EaseInBounce,
+    EaseOutBounce,
+    EaseInOutBounce,
+}
+
+impl Easing {
+    /// Map a normalised time `t ∈ [0, 1]` to the eased fraction.
+    pub fn apply(self, t: f32) -> f32 {
+        let t = t.clamp(0.0, 1.0);
+        match self {
+            Easing::Linear => t,
+            Easing::EaseIn => t * t,
+            Easing::EaseOut => {
+                let u = 1.0 - t;
+                1.0 - u * u
+            }
+            Easing::EaseInOut => {
+                if t < 0.5 {
+                    2.0 * t * t
+                } else {
+                    let u = 1.0 - t;
+                    1.0 - 2.0 * u * u
+                }
+            }
+            Easing::EaseInCubic => t * t * t,
+            Easing::EaseOutCubic => {
+                let u = 1.0 - t;
+                1.0 - u * u * u
+            }
+            Easing::EaseInOutCubic => {
+                if t < 0.5 {
+                    4.0 * t * t * t
+                } else {
+                    let u = 1.0 - t;
+                    1.0 - 4.0 * u * u * u
+                }
+            }
+            Easing::EaseInSine => 1.0 - (t * std::f32::consts::FRAC_PI_2).cos(),
+            Easing::EaseOutSine => (t * std::f32::consts::FRAC_PI_2).sin(),
+            Easing::EaseInOutSine => 0.5 * (1.0 - (std::f32::consts::PI * t).cos()),
+            Easing::EaseInBack => {
+                const C1: f32 = 1.70158;
+                const C3: f32 = C1 + 1.0;
+                C3 * t * t * t - C1 * t * t
+            }
+            Easing::EaseOutBack => {
+                const C1: f32 = 1.70158;
+                const C3: f32 = C1 + 1.0;
+                let u = t - 1.0;
+                1.0 + C3 * u * u * u + C1 * u * u
+            }
+            Easing::EaseInOutBack => {
+                const C1: f32 = 1.70158;
+                const C2: f32 = C1 * 1.525;
+                if t < 0.5 {
+                    let f = 2.0 * t;
+                    0.5 * (f * f * ((C2 + 1.0) * f - C2))
+                } else {
+                    let f = 2.0 * t - 2.0;
+                    0.5 * (f * f * ((C2 + 1.0) * f + C2) + 2.0)
+                }
+            }
+            Easing::EaseInBounce => 1.0 - bounce_out(1.0 - t),
+            Easing::EaseOutBounce => bounce_out(t),
+            Easing::EaseInOutBounce => {
+                if t < 0.5 {
+                    0.5 * (1.0 - bounce_out(1.0 - 2.0 * t))
+                } else {
+                    0.5 * (1.0 + bounce_out(2.0 * t - 1.0))
+                }
+            }
+        }
+    }
+
+    pub fn is_linear(&self) -> bool {
+        matches!(self, Easing::Linear)
+    }
+
+    /// Parse a DSL identifier or string. Accepts the canonical `snake_case`
+    /// form plus a few common aliases so casual prompts ("ease", "in_out")
+    /// still resolve.
+    pub fn from_str(s: &str) -> Option<Easing> {
+        Some(match s {
+            "linear" | "none" => Easing::Linear,
+            "ease" | "ease_in" | "in" => Easing::EaseIn,
+            "ease_out" | "out" => Easing::EaseOut,
+            "ease_in_out" | "in_out" => Easing::EaseInOut,
+            "ease_in_cubic" | "in_cubic" => Easing::EaseInCubic,
+            "ease_out_cubic" | "out_cubic" => Easing::EaseOutCubic,
+            "ease_in_out_cubic" | "in_out_cubic" => Easing::EaseInOutCubic,
+            "ease_in_sine" | "in_sine" => Easing::EaseInSine,
+            "ease_out_sine" | "out_sine" => Easing::EaseOutSine,
+            "ease_in_out_sine" | "in_out_sine" => Easing::EaseInOutSine,
+            "ease_in_back" | "in_back" => Easing::EaseInBack,
+            "ease_out_back" | "out_back" => Easing::EaseOutBack,
+            "ease_in_out_back" | "in_out_back" => Easing::EaseInOutBack,
+            "ease_in_bounce" | "in_bounce" => Easing::EaseInBounce,
+            "ease_out_bounce" | "out_bounce" => Easing::EaseOutBounce,
+            "ease_in_out_bounce" | "in_out_bounce" => Easing::EaseInOutBounce,
+            _ => return None,
+        })
+    }
+}
+
+fn bounce_out(t: f32) -> f32 {
+    const N1: f32 = 7.5625;
+    const D1: f32 = 2.75;
+    if t < 1.0 / D1 {
+        N1 * t * t
+    } else if t < 2.0 / D1 {
+        let t = t - 1.5 / D1;
+        N1 * t * t + 0.75
+    } else if t < 2.5 / D1 {
+        let t = t - 2.25 / D1;
+        N1 * t * t + 0.9375
+    } else {
+        let t = t - 2.625 / D1;
+        N1 * t * t + 0.984375
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Track {
     pub node: NodeId,
     pub property: TrackProperty,
     pub interpolation: Interpolation,
+    /// Easing applied between consecutive user-authored keyframes. The
+    /// lowering pipeline calls [`Track::bake_easing`] at the end of each
+    /// `clip`/template lower step, which densifies the track and resets this
+    /// to [`Easing::Linear`] — by the time a `Track` reaches the exporter or
+    /// renderer it always carries already-eased values under LINEAR sampling.
+    /// Kept on the type (with a serde default for back-compat) so authoring
+    /// tools can round-trip the directive.
+    #[serde(default, skip_serializing_if = "Easing::is_linear")]
+    pub easing: Easing,
     pub times: Vec<f32>,
     /// For Translation/Scale, each entry is `[x, y, z, 0]`.
     /// For Rotation, each entry is the quaternion `[x, y, z, w]`.
     pub values: Vec<[f32; 4]>,
+}
+
+impl Track {
+    /// Bake `easing` into dense LINEAR keyframes. No-op for `Easing::Linear`
+    /// or single-keyframe tracks. After baking, `easing` is reset to `Linear`
+    /// so the operation is idempotent.
+    pub fn bake_easing(&mut self) {
+        if self.easing.is_linear() || self.times.len() < 2 {
+            self.easing = Easing::Linear;
+            return;
+        }
+        const SAMPLES_PER_SEGMENT: usize = 16;
+        let easing = self.easing;
+        let prop = self.property;
+        let mut new_times = Vec::with_capacity((self.times.len() - 1) * SAMPLES_PER_SEGMENT + 1);
+        let mut new_values = Vec::with_capacity(new_times.capacity());
+        new_times.push(self.times[0]);
+        new_values.push(self.values[0]);
+        for i in 0..self.times.len() - 1 {
+            let t0 = self.times[i];
+            let t1 = self.times[i + 1];
+            let v0 = self.values[i];
+            let v1 = self.values[i + 1];
+            for k in 1..=SAMPLES_PER_SEGMENT {
+                let f = k as f32 / SAMPLES_PER_SEGMENT as f32;
+                let eased = easing.apply(f);
+                let t = t0 + f * (t1 - t0);
+                let v = match prop {
+                    TrackProperty::Rotation => {
+                        let q0 = Quat::from_xyzw(v0[0], v0[1], v0[2], v0[3]);
+                        let q1 = Quat::from_xyzw(v1[0], v1[1], v1[2], v1[3]);
+                        let q = q0.slerp(q1, eased);
+                        [q.x, q.y, q.z, q.w]
+                    }
+                    TrackProperty::Translation | TrackProperty::Scale => [
+                        v0[0] + (v1[0] - v0[0]) * eased,
+                        v0[1] + (v1[1] - v0[1]) * eased,
+                        v0[2] + (v1[2] - v0[2]) * eased,
+                        v0[3] + (v1[3] - v0[3]) * eased,
+                    ],
+                };
+                new_times.push(t);
+                new_values.push(v);
+            }
+        }
+        self.times = new_times;
+        self.values = new_values;
+        self.easing = Easing::Linear;
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -68,4 +270,115 @@ pub struct Clip {
     /// what's shown to the user — runtime export ignores it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub origin: Option<std::path::PathBuf>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn easing_endpoints_are_pinned() {
+        for e in [
+            Easing::Linear,
+            Easing::EaseIn,
+            Easing::EaseOut,
+            Easing::EaseInOut,
+            Easing::EaseInCubic,
+            Easing::EaseOutCubic,
+            Easing::EaseInOutCubic,
+            Easing::EaseInSine,
+            Easing::EaseOutSine,
+            Easing::EaseInOutSine,
+            Easing::EaseInBack,
+            Easing::EaseOutBack,
+            Easing::EaseInOutBack,
+            Easing::EaseInBounce,
+            Easing::EaseOutBounce,
+            Easing::EaseInOutBounce,
+        ] {
+            assert!(e.apply(0.0).abs() < 1e-4, "{e:?} f(0) != 0");
+            assert!((e.apply(1.0) - 1.0).abs() < 1e-4, "{e:?} f(1) != 1");
+        }
+    }
+
+    #[test]
+    fn ease_in_out_is_symmetric_at_half() {
+        for e in [
+            Easing::EaseInOut,
+            Easing::EaseInOutCubic,
+            Easing::EaseInOutSine,
+        ] {
+            let v = e.apply(0.5);
+            assert!((v - 0.5).abs() < 1e-3, "{e:?} f(0.5) ≈ 0.5, got {v}");
+        }
+    }
+
+    #[test]
+    fn ease_in_lags_linear_at_quarter() {
+        // Quadratic ease_in must be below the diagonal in the first half.
+        assert!(Easing::EaseIn.apply(0.25) < 0.25);
+        // Mirror: ease_out leads.
+        assert!(Easing::EaseOut.apply(0.25) > 0.25);
+    }
+
+    #[test]
+    fn bake_easing_densifies_two_keyframes() {
+        let mut t = Track {
+            node: NodeId(0),
+            property: TrackProperty::Translation,
+            interpolation: Interpolation::Linear,
+            easing: Easing::EaseInOut,
+            times: vec![0.0, 1.0],
+            values: vec![[0.0; 4], [10.0, 0.0, 0.0, 0.0]],
+        };
+        t.bake_easing();
+        assert_eq!(t.easing, Easing::Linear);
+        // 1 + 16 samples per segment.
+        assert_eq!(t.times.len(), 17);
+        assert!((t.times[0] - 0.0).abs() < 1e-6);
+        assert!((t.times[16] - 1.0).abs() < 1e-6);
+        // Mid-segment x-value lags 50% under ease_in_out — at t=0.25 the
+        // eased fraction is 2*0.25^2 = 0.125, so x ≈ 1.25.
+        let i_quarter = 4; // sample at f=0.25
+        assert!((t.values[i_quarter][0] - 1.25).abs() < 1e-3);
+    }
+
+    #[test]
+    fn bake_easing_is_noop_for_linear() {
+        let mut t = Track {
+            node: NodeId(0),
+            property: TrackProperty::Translation,
+            interpolation: Interpolation::Linear,
+            easing: Easing::Linear,
+            times: vec![0.0, 1.0],
+            values: vec![[0.0; 4], [1.0, 0.0, 0.0, 0.0]],
+        };
+        t.bake_easing();
+        assert_eq!(t.times.len(), 2);
+    }
+
+    #[test]
+    fn bake_easing_is_idempotent() {
+        let mut t = Track {
+            node: NodeId(0),
+            property: TrackProperty::Translation,
+            interpolation: Interpolation::Linear,
+            easing: Easing::EaseIn,
+            times: vec![0.0, 1.0],
+            values: vec![[0.0; 4], [1.0, 0.0, 0.0, 0.0]],
+        };
+        t.bake_easing();
+        let after_first = t.times.len();
+        t.bake_easing();
+        assert_eq!(t.times.len(), after_first, "second bake must be a no-op");
+    }
+
+    #[test]
+    fn easing_from_str_canonical_and_aliases() {
+        assert_eq!(Easing::from_str("linear"), Some(Easing::Linear));
+        assert_eq!(Easing::from_str("ease_in_out"), Some(Easing::EaseInOut));
+        assert_eq!(Easing::from_str("in_out"), Some(Easing::EaseInOut));
+        assert_eq!(Easing::from_str("ease"), Some(Easing::EaseIn));
+        assert_eq!(Easing::from_str("bogus"), None);
+    }
 }

--- a/crates/mogen-core/src/lib.rs
+++ b/crates/mogen-core/src/lib.rs
@@ -11,7 +11,7 @@ pub mod skin;
 pub mod transform;
 
 pub use aabb::{node_world_aabb, subtree_local_aabb, Aabb};
-pub use anim::{Clip, Interpolation, Joint, JointKind, Track, TrackProperty};
+pub use anim::{Clip, Easing, Interpolation, Joint, JointKind, Track, TrackProperty};
 pub use connector::Connector;
 pub use diagnostic::{has_errors, Diagnostic, Severity, Span};
 pub use graph::{AttachBinding, ConformBinding, NodeId, SceneGraph, SceneNode};

--- a/crates/mogen-dsl/src/anim_lower.rs
+++ b/crates/mogen-dsl/src/anim_lower.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, bail, Result};
 use glam::{Quat, Vec3};
 
 use mogen_core::{
-    Clip, Interpolation, Joint, JointKind, NodeId, SceneGraph, Track, TrackProperty,
+    Clip, Easing, Interpolation, Joint, JointKind, NodeId, SceneGraph, Track, TrackProperty,
 };
 use mogen_anim as anim;
 
@@ -111,10 +111,11 @@ fn lower_track(
         .name
         .clone()
         .ok_or_else(|| anyhow!("track requires a target name (joint or node)"))?;
+    let easing = parse_easing_attr(node)?;
 
     // Resolve target: prefer joint match, fall back to bare node match.
     if let Some(joint) = graph.find_joint(&target_name).cloned() {
-        return lower_joint_track(node, &joint, duration);
+        return lower_joint_track(node, &joint, duration, easing);
     }
 
     let Some(node_id) = find_node_scoped(graph, &target_name, use_id) else {
@@ -135,16 +136,24 @@ fn lower_track(
     };
     let axis = node.attr_vec3("axis").unwrap_or(Vec3::Y);
     let (times, values) = sample_track(node, duration, property, axis)?;
-    Ok(Track {
+    let mut track = Track {
         node: node_id,
         property,
         interpolation: Interpolation::Linear,
+        easing,
         times,
         values,
-    })
+    };
+    track.bake_easing();
+    Ok(track)
 }
 
-fn lower_joint_track(node: &Node, joint: &Joint, duration: f32) -> Result<Track> {
+fn lower_joint_track(
+    node: &Node,
+    joint: &Joint,
+    duration: f32,
+    easing: Easing,
+) -> Result<Track> {
     let (property, axis) = match joint.kind {
         JointKind::Hinge | JointKind::Rotor | JointKind::Ball => {
             (TrackProperty::Rotation, joint.axis)
@@ -152,12 +161,32 @@ fn lower_joint_track(node: &Node, joint: &Joint, duration: f32) -> Result<Track>
         JointKind::Slider => (TrackProperty::Translation, joint.axis),
     };
     let (times, values) = sample_track(node, duration, property, axis)?;
-    Ok(Track {
+    let mut track = Track {
         node: joint.pivot,
         property,
         interpolation: Interpolation::Linear,
+        easing,
         times,
         values,
+    };
+    track.bake_easing();
+    Ok(track)
+}
+
+/// Read `easing=<ident|string>` and resolve it to an [`Easing`]. Missing
+/// attribute → [`Easing::Linear`]. Unknown spelling → error so typos surface
+/// at lower time rather than silently degrading to linear.
+fn parse_easing_attr(node: &Node) -> Result<Easing> {
+    let Some(s) = string_or_ident(node.attr("easing")) else {
+        return Ok(Easing::Linear);
+    };
+    Easing::from_str(&s).ok_or_else(|| {
+        anyhow!(
+            "unknown easing `{s}` (expected linear|ease_in|ease_out|ease_in_out|\
+             ease_in_cubic|ease_out_cubic|ease_in_out_cubic|ease_in_sine|ease_out_sine|\
+             ease_in_out_sine|ease_in_back|ease_out_back|ease_in_out_back|\
+             ease_in_bounce|ease_out_bounce|ease_in_out_bounce)"
+        )
     })
 }
 
@@ -266,6 +295,7 @@ pub fn lower_template(node: &Node, graph: &mut SceneGraph) -> Result<()> {
         .map(|j| j.axis)
         .unwrap_or(Vec3::Y);
     let axis = node.attr_vec3("axis").unwrap_or(axis_default);
+    let easing = parse_easing_attr(node)?;
 
     let multi = targets.len() > 1;
     for (i, target) in targets.into_iter().enumerate() {
@@ -277,27 +307,27 @@ pub fn lower_template(node: &Node, graph: &mut SceneGraph) -> Result<()> {
         let mut clip = match node.kind.as_str() {
             "spin" => {
                 let rpm = node.attr_number("rpm").unwrap_or(60.0);
-                anim::spin(&name, target, axis, rpm)
+                anim::spin(&name, target, axis, rpm, easing)
             }
             "open_close" => {
                 let angle = node.attr_number("angle").unwrap_or(90.0);
                 let seconds = node.attr_number("seconds").unwrap_or(1.0);
-                anim::open_close(&name, target, axis, angle, seconds)
+                anim::open_close(&name, target, axis, angle, seconds, easing)
             }
             "wave" => {
                 let amp = node.attr_number("amplitude").unwrap_or(15.0);
                 let hz = node.attr_number("hz").unwrap_or(1.0);
-                anim::wave(&name, target, axis, amp, hz)
+                anim::wave(&name, target, axis, amp, hz, easing)
             }
             "flap" => {
                 let amp = node.attr_number("amplitude").unwrap_or(30.0);
                 let hz = node.attr_number("hz").unwrap_or(2.0);
-                anim::flap(&name, target, axis, amp, hz)
+                anim::flap(&name, target, axis, amp, hz, easing)
             }
             "idle" => {
                 let amp = node.attr_number("amplitude").unwrap_or(0.02);
                 let hz = node.attr_number("hz").unwrap_or(0.5);
-                anim::idle(&name, target, amp, hz)
+                anim::idle(&name, target, amp, hz, easing)
             }
             other => bail!("unknown animation template `{other}`"),
         };
@@ -594,6 +624,79 @@ mod tests {
             Some(target),
             "spin track must target the fan's hub, not the chair's"
         );
+    }
+
+    #[test]
+    fn track_easing_densifies_keyframes() {
+        // ease_in_out on a 2-keyframe track should produce 17 dense keys
+        // (1 + 16 per segment) and lag below the linear midpoint at t=0.25.
+        let g = lower(&parse(
+            r#"
+            scene { box "h" (size=[0.1, 0.1, 0.1]) }
+            clip "c" (seconds=1.0) {
+              track "h" (prop=rotation, axis=[1, 0, 0], easing=ease_in_out, from=0, to=90)
+            }
+            "#,
+        ).expect("parse")).expect("lower");
+        let t = &g.clips[0].tracks[0];
+        assert_eq!(t.times.len(), 17, "ease_in_out should densify to 17 keys");
+        assert_eq!(t.easing, mogen_core::Easing::Linear, "easing must reset to Linear after bake");
+        // Quarter-time keyframe sits at t=0.25 with eased fraction 0.125.
+        assert!((t.times[4] - 0.25).abs() < 1e-3);
+    }
+
+    #[test]
+    fn track_easing_back_overshoots_endpoints() {
+        // ease_out_back overshoots above 1.0 mid-segment for a translation track.
+        let g = lower(&parse(
+            r#"
+            scene { box "b" (size=[0.1, 0.1, 0.1]) }
+            clip "c" (seconds=1.0) {
+              track "b" (prop=translation, axis=[1, 0, 0], easing=ease_out_back, from=0, to=1)
+            }
+            "#,
+        ).expect("parse")).expect("lower");
+        let t = &g.clips[0].tracks[0];
+        let max_x = t.values.iter().map(|v| v[0]).fold(f32::MIN, f32::max);
+        assert!(
+            max_x > 1.001,
+            "ease_out_back should overshoot 1.0, got max x = {}",
+            max_x,
+        );
+    }
+
+    #[test]
+    fn track_easing_unknown_value_errors() {
+        let err = lower(&parse(
+            r#"
+            scene { box "h" (size=[0.1, 0.1, 0.1]) }
+            clip "c" (seconds=1.0) {
+              track "h" (prop=rotation, easing=bouncy_thing, from=0, to=90)
+            }
+            "#,
+        ).expect("parse")).unwrap_err();
+        assert!(format!("{err}").contains("unknown easing"));
+    }
+
+    #[test]
+    fn template_open_close_easing_warps_phase() {
+        // open_close with linear easing has 3 keyframes; with ease_in_out it
+        // densifies to 33 to capture the warp.
+        let linear = lower(&parse(
+            r#"
+            scene { box "lid" (size=[0.5, 0.05, 0.5]) }
+            open_close "swing" (target="lid", axis=[1, 0, 0], angle=90, seconds=1.0)
+            "#,
+        ).expect("parse")).expect("lower");
+        assert_eq!(linear.clips[0].tracks[0].times.len(), 3);
+
+        let eased = lower(&parse(
+            r#"
+            scene { box "lid" (size=[0.5, 0.05, 0.5]) }
+            open_close "swing" (target="lid", axis=[1, 0, 0], angle=90, seconds=1.0, easing=ease_in_out)
+            "#,
+        ).expect("parse")).expect("lower");
+        assert_eq!(eased.clips[0].tracks[0].times.len(), 33);
     }
 
     #[test]

--- a/crates/mogen-export/tests/fbx.rs
+++ b/crates/mogen-export/tests/fbx.rs
@@ -19,7 +19,7 @@ use fbxcel::tree::any::AnyTree;
 use fbxcel::tree::v7400::{NodeHandle, Tree};
 
 use mogen_core::{
-    Clip, Interpolation, Light, LightKind, Material, Mesh, SceneGraph, Skin,
+    Clip, Easing, Interpolation, Light, LightKind, Material, Mesh, SceneGraph, Skin,
     TextureRef, Track, TrackProperty, Transform,
 };
 use mogen_geom::box_mesh;
@@ -547,6 +547,7 @@ fn translation_animation_emits_stack_layer_curve_node_and_three_axes() {
             node: id,
             property: TrackProperty::Translation,
             interpolation: Interpolation::Linear,
+            easing: Easing::Linear,
             times: vec![0.0, 0.5, 1.0],
             values: vec![[0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
         }],
@@ -648,6 +649,7 @@ fn step_interpolation_emits_constant_key_attr_flag() {
             node: id,
             property: TrackProperty::Translation,
             interpolation: Interpolation::Step,
+            easing: Easing::Linear,
             times: vec![0.0, 1.0],
             values: vec![[0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]],
         }],
@@ -690,6 +692,7 @@ fn rotation_track_emits_euler_degrees() {
             node: id,
             property: TrackProperty::Rotation,
             interpolation: Interpolation::Linear,
+            easing: Easing::Linear,
             times: vec![0.0],
             values: vec![[q.x, q.y, q.z, q.w]],
         }],

--- a/crates/mogen-validate/src/ast_checks/schema.rs
+++ b/crates/mogen-validate/src/ast_checks/schema.rs
@@ -168,11 +168,11 @@ pub fn attrs_for_kind(kind: &str) -> &'static [&'static str] {
         "array" => &["count", "around", "start_angle"],
         "joint" => &["type", "axis", "limits", "pivot"],
         "clip" => &["seconds"],
-        "track" => &["prop", "axis", "from", "to", "keys"],
-        "spin" => &["target", "axis", "rpm"],
-        "open_close" => &["target", "axis", "angle", "seconds"],
-        "wave" | "flap" => &["target", "axis", "amplitude", "hz"],
-        "idle" => &["target", "amplitude", "hz"],
+        "track" => &["prop", "axis", "from", "to", "keys", "easing"],
+        "spin" => &["target", "axis", "rpm", "easing"],
+        "open_close" => &["target", "axis", "angle", "seconds", "easing"],
+        "wave" | "flap" => &["target", "axis", "amplitude", "hz", "easing"],
+        "idle" => &["target", "amplitude", "hz", "easing"],
         "skeleton" => &[],
         "bone" => &["envelope"],
         "attach" => &["parent", "child", "socket", "plug", "offset", "twist"],
@@ -398,6 +398,12 @@ pub(super) fn attr_type(kind: &str, attr: &str) -> Option<&'static str> {
         | ("flap", "hz")
         | ("idle", "amplitude")
         | ("idle", "hz") => "number",
+        ("track", "easing")
+        | ("spin", "easing")
+        | ("open_close", "easing")
+        | ("wave", "easing")
+        | ("flap", "easing")
+        | ("idle", "easing") => "string",
         ("bone", "envelope") => "number",
         ("attach", "parent") | ("attach", "child")
         | ("attach", "socket") | ("attach", "plug") => "string",

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -1280,6 +1280,37 @@ clip "open" (seconds=1.0) {
   interpolates linearly between them. This is what the stdlib walk / run
   / jump clips use to drive bones with hand-tuned curves.
 
+### Easing
+
+Every `track` and procedural template accepts an optional `easing=` attribute
+that selects a non-linear interpolation curve. glTF samplers themselves only
+support LINEAR / STEP / CUBICSPLINE, so MoGen bakes the easing curve into a
+dense LINEAR sampling at lower time — the resulting `.glb` plays back the
+same in any compliant viewer (Godot, Blender, Three.js, glTF-Validator).
+
+For an authored `track`, easing is applied between consecutive user
+keyframes (so `keys=[[0, 0], [1, 90]]` with `easing=ease_in_out` produces a
+smooth S-curve from 0° to 90°). For a template, easing warps the procedural
+phase parameter — e.g. `open_close (..., easing=ease_in_out_back)` opens
+slowly, overshoots, and settles back.
+
+| name | shape |
+|---|---|
+| `linear` (default) | t |
+| `ease_in` / `ease_out` / `ease_in_out` | quadratic |
+| `ease_in_cubic` / `ease_out_cubic` / `ease_in_out_cubic` | cubic |
+| `ease_in_sine` / `ease_out_sine` / `ease_in_out_sine` | half-cosine |
+| `ease_in_back` / `ease_out_back` / `ease_in_out_back` | overshoots the endpoint |
+| `ease_in_bounce` / `ease_out_bounce` / `ease_in_out_bounce` | multi-stage bounce |
+
+```
+clip "hop" (seconds=0.6) {
+  track "body" (prop=translation, axis=[0, 1, 0],
+                easing=ease_out_bounce, from=0, to=0.4)
+}
+spin "fan" (target="rotor", rpm=120, easing=ease_in_out_sine)
+```
+
 ### Procedural templates
 
 One-line declarations that expand into a full clip. They all take a
@@ -1287,11 +1318,11 @@ One-line declarations that expand into a full clip. They all take a
 
 | template | extra attrs | effect |
 |---|---|---|
-| `spin` | `axis`, `rpm` (60) | continuous rotation |
-| `open_close` | `axis`, `angle` (90), `seconds` (1.0) | 0° → angle → 0° swing |
-| `wave` | `axis`, `amplitude` (15°), `hz` (1.0) | sinusoidal wobble |
-| `flap` | `axis`, `amplitude` (30°), `hz` (2.0) | faster wobble, bigger amplitude |
-| `idle` | `amplitude` (0.02 m), `hz` (0.5) | tiny translation breathe |
+| `spin` | `axis`, `rpm` (60), `easing` | continuous rotation |
+| `open_close` | `axis`, `angle` (90), `seconds` (1.0), `easing` | 0° → angle → 0° swing |
+| `wave` | `axis`, `amplitude` (15°), `hz` (1.0), `easing` | sinusoidal wobble |
+| `flap` | `axis`, `amplitude` (30°), `hz` (2.0), `easing` | faster wobble, bigger amplitude |
+| `idle` | `amplitude` (0.02 m), `hz` (0.5), `easing` | tiny translation breathe |
 
 When the target is a joint, its `axis` is used by default; when it's a node,
 pass `axis` explicitly.


### PR DESCRIPTION
## Summary

Authored `track`s and procedural templates (`spin` / `open_close` / `wave` /
`flap` / `idle`) now accept an optional `easing=` attribute selecting a
non-linear curve. glTF samplers only support `LINEAR` / `STEP` /
`CUBICSPLINE`, so lowering bakes the easing into a dense `LINEAR` sampling —
the resulting `.glb` plays back identically in any compliant viewer (Godot,
Blender, Three.js, glTF-Validator).

- **Authored tracks** ease per-segment between user keyframes. `Track::bake_easing`
  densifies each segment to 16 samples with linear time spacing and pre-eased
  values, then resets the track's `easing` field to `Linear` so the operation
  is idempotent and exporters see a uniform contract.
- **Templates** apply easing to their procedural *phase* parameter (the
  normalised time `t ∈ [0, 1]` that drives the underlying curve) rather than
  post-baking, which matches expectations for one-shot motions like
  `open_close` (start slow, end slow) and loop-boundary ramps.
- **Sixteen Penner curves**: `linear`, plus `ease_in*` / `ease_out*` /
  `ease_in_out*` variants of quadratic, cubic, sine, back (with overshoot),
  and bounce. `Easing::from_str` accepts canonical `snake_case` plus a few
  aliases (`in`, `out`, `in_out`, `ease`).

Misspellings surface at lower-time as `unknown easing \`...\`` rather than
silently degrading to linear.

## Files

- `crates/mogen-core/src/anim.rs` — `Easing` enum, `Track::bake_easing`,
  curve unit tests.
- `crates/mogen-anim/src/lib.rs` — templates take `Easing`, apply it to phase.
- `crates/mogen-dsl/src/anim_lower.rs` — `parse_easing_attr`, calls
  `bake_easing` on authored / joint tracks.
- `crates/mogen-validate/src/ast_checks/schema.rs` — adds `easing` to the
  attr allowlist for `track` / `spin` / `open_close` / `wave` / `flap` /
  `idle` (auto-flows into the LLM system instruction).
- `crates/mogen-export/tests/fbx.rs` — fixture `Track` literals updated for
  the new field.
- `docs/dsl.md` — easing section with curve table and usage examples.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — all crate test groups pass (1100+ tests)
- [x] New unit tests in `mogen-core` cover endpoint pinning (every curve
  pins `f(0)=0`, `f(1)=1`), in/out symmetry at `t=0.5` for the `*_in_out`
  family, and `bake_easing` densification + idempotence
- [x] New lowering tests in `mogen-dsl` cover authored-track densification
  (17 keys for ease_in_out two-keyframe), back-curve overshoot on
  translation, template phase warping (33 keys for `open_close` with
  ease_in_out vs 3 with linear), and unknown-easing error path
- [x] LLM prompt allowlist tests still pass — `easing` flows through
  automatically from the validator schema

https://claude.ai/code/session_01CtvHW8rHLNh4ZtDehnermq
