### PR TITLE
Preview-models toggle, LOD scale on explicit segments, and Studio polish

### DIFF
--- a/crates/mogen-dsl/src/lower/lod.rs
+++ b/crates/mogen-dsl/src/lower/lod.rs
@@ -164,11 +164,15 @@ impl Drop for LodMultiplierGuard {
     }
 }
 
-/// Scale a default segment/ring count by the active LOD multiplier.
+/// Scale a segment/ring/sample count by the active LOD multiplier.
+/// Used for both primitive defaults and author-supplied explicit values
+/// (e.g. `segments_u=64`) so a global `lod_scale` or per-node `lod=`
+/// keeps working on dense surfaces — heightfields, curved planes, lathes —
+/// where authors typically pin the segment count to control noise quality.
 /// Clamped to a sensible floor so circles still close.
-pub(super) fn scaled_default(default: u32, min: u32) -> u32 {
+pub(super) fn scaled_count(value: u32, min: u32) -> u32 {
     let scale = current_lod_scale();
-    let scaled = (default as f32 * scale).round();
+    let scaled = (value as f32 * scale).round();
     if scaled < min as f32 {
         min
     } else {
@@ -178,11 +182,12 @@ pub(super) fn scaled_default(default: u32, min: u32) -> u32 {
 
 /// Icosphere subdivisions are exponential (4× tris per step), so a multiplier
 /// translates to an additive offset of round(log2(scale)). Floor at 0.
-pub(super) fn scaled_subdivisions(default: u32) -> u32 {
+/// Applied to both the implicit default and an author-supplied `subdivisions=`.
+pub(super) fn scaled_subdivisions(value: u32) -> u32 {
     let scale = current_lod_scale();
     if scale <= 0.0 {
-        return default;
+        return value;
     }
     let offset = scale.log2().round() as i32;
-    (default as i32 + offset).max(0) as u32
+    (value as i32 + offset).max(0) as u32
 }

--- a/crates/mogen-dsl/src/lower/primitive.rs
+++ b/crates/mogen-dsl/src/lower/primitive.rs
@@ -17,7 +17,7 @@ use crate::ast::Node;
 use crate::lower::source_dir;
 
 use super::helpers::{resolve_size3, resolve_size_xy, resolve_size_xz};
-use super::lod::{scaled_default, scaled_subdivisions};
+use super::lod::{scaled_count, scaled_subdivisions};
 
 /// Density multiplier for primitive default tessellation when the node
 /// carries a smooth-deformation modifier — `bend_*`, `twist_y`, `noise`,
@@ -45,12 +45,24 @@ fn deform_density(node: &Node) -> u32 {
 /// from primitives whose construction can fail at lowering time (e.g. `mesh`
 /// loading a `.glb` from disk).
 pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh>> {
-    // Multiplier applied to every default tessellation count. 1× when the
+    // Density multiplier for the *default* tessellation count. 1× when the
     // node has no smooth-deform modifier; 2× when it does, so a bent or
-    // melted shape doesn't read as low-poly. Author's explicit `segments=`,
-    // `rings=`, etc. always override.
+    // melted shape doesn't read as low-poly. Only the default branch
+    // multiplies by `dd` — an author-supplied `segments=` is taken at face
+    // value (they already chose the density they want).
     let dd = deform_density(node);
-    let seg_default = |base: u32, min: u32| scaled_default(base * dd, min);
+    // Resolve a tessellation count: explicit author value if present,
+    // otherwise the default × `dd`. Either way, the active LOD scale
+    // (`lod_scale (value=N)` and any compounded `lod=N` overrides) is
+    // applied so authors don't have to drop their `segments_u=64` on dense
+    // heightfields/curved planes just to opt in to LOD scaling.
+    let seg = |attr: &str, base: u32, min: u32| -> u32 {
+        let raw = node
+            .attr_number(attr)
+            .map(|n| n as u32)
+            .unwrap_or(base * dd);
+        scaled_count(raw, min)
+    };
     let m: Mesh = match node.kind.as_str() {
         "box" | "slab" | "post" | "panel" => {
             let s = resolve_size3(node, Vec3::ONE);
@@ -62,14 +74,8 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
         }
         "heightfield" => {
             let s = resolve_size_xz(node, [1.0, 1.0]);
-            let segments_u = node
-                .attr_number("segments_u")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(32, 1));
-            let segments_v = node
-                .attr_number("segments_v")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(32, 1));
+            let segments_u = seg("segments_u", 32, 1);
+            let segments_v = seg("segments_v", 32, 1);
             let amplitude = node.attr_number("amplitude").unwrap_or(0.5);
             let octaves = node
                 .attr_number("octaves")
@@ -108,39 +114,33 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
         "cylinder" => {
             let radius = node.attr_number("radius").unwrap_or(0.5);
             let height = node.attr_number("height").unwrap_or(1.0);
-            let segments = node.attr_number("segments").map(|n| n as u32).unwrap_or_else(|| seg_default(24, 3));
+            let segments = seg("segments", 24, 3);
             cylinder_mesh(radius, height, segments, uv_mode)
         }
         "cone" => {
             let radius = node.attr_number("radius").unwrap_or(0.5);
             let height = node.attr_number("height").unwrap_or(1.0);
-            let segments = node.attr_number("segments").map(|n| n as u32).unwrap_or_else(|| seg_default(24, 3));
+            let segments = seg("segments", 24, 3);
             cone_mesh(radius, height, segments, uv_mode)
         }
         "sphere" => {
             let radius = node.attr_number("radius").unwrap_or(0.5);
-            let rings = node.attr_number("rings").map(|n| n as u32).unwrap_or_else(|| seg_default(16, 2));
-            let segments = node.attr_number("segments").map(|n| n as u32).unwrap_or_else(|| seg_default(24, 3));
+            let rings = seg("rings", 16, 2);
+            let segments = seg("segments", 24, 3);
             sphere_mesh(radius, rings, segments, uv_mode)
         }
         "capsule" => {
             let radius = node.attr_number("radius").unwrap_or(0.5);
             let height = node.attr_number("height").unwrap_or(1.0);
-            let rings = node.attr_number("rings").map(|n| n as u32).unwrap_or_else(|| seg_default(8, 2));
-            let segments = node.attr_number("segments").map(|n| n as u32).unwrap_or_else(|| seg_default(24, 3));
+            let rings = seg("rings", 8, 2);
+            let segments = seg("segments", 24, 3);
             capsule_mesh(radius, height, rings, segments, uv_mode)
         }
         "torus" => {
             let major = node.attr_number("major").unwrap_or(0.5);
             let minor = node.attr_number("minor").unwrap_or(0.15);
-            let major_segments = node
-                .attr_number("major_segments")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(24, 3));
-            let minor_segments = node
-                .attr_number("minor_segments")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(12, 3));
+            let major_segments = seg("major_segments", 24, 3);
+            let minor_segments = seg("minor_segments", 12, 3);
             torus_mesh(major, minor, major_segments, minor_segments, uv_mode)
         }
         "prism" => {
@@ -155,24 +155,25 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
         }
         "disc" => {
             let radius = node.attr_number("radius").unwrap_or(0.5);
-            let segments = node.attr_number("segments").map(|n| n as u32).unwrap_or_else(|| seg_default(24, 3));
+            let segments = seg("segments", 24, 3);
             disc_mesh(radius, segments, uv_mode)
         }
         "icosphere" => {
             let radius = node.attr_number("radius").unwrap_or(0.5);
-            let subdivisions = node
+            // Default base subdivisions follow `dd` (2 with a deform modifier,
+            // 1 otherwise); both default and explicit values then run through
+            // `scaled_subdivisions` so LOD steps the count.
+            let raw = node
                 .attr_number("subdivisions")
                 .map(|n| n as u32)
-                .unwrap_or_else(|| scaled_subdivisions(1 + dd));
+                .unwrap_or(1 + dd);
+            let subdivisions = scaled_subdivisions(raw);
             icosphere_mesh(radius, subdivisions, uv_mode)
         }
         "rounded_box" => {
             let s = resolve_size3(node, Vec3::ONE);
             let radius = node.attr_number("radius").unwrap_or(0.1);
-            let segments = node
-                .attr_number("segments")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(4, 1));
+            let segments = seg("segments", 4, 1);
             rounded_box_mesh([s.x, s.y, s.z], radius, segments, uv_mode)
         }
         "chamfered_box" => {
@@ -207,61 +208,49 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
             let outer = node.attr_number("outer").unwrap_or(0.5);
             let inner = node.attr_number("inner").unwrap_or(0.3);
             let height = node.attr_number("height").unwrap_or(1.0);
-            let segments = node.attr_number("segments").map(|n| n as u32).unwrap_or_else(|| seg_default(24, 3));
+            let segments = seg("segments", 24, 3);
             tube_mesh(outer, inner, height, segments, uv_mode)
         }
         "hemisphere" => {
             let radius = node.attr_number("radius").unwrap_or(0.5);
-            let rings = node.attr_number("rings").map(|n| n as u32).unwrap_or_else(|| seg_default(8, 2));
-            let segments = node.attr_number("segments").map(|n| n as u32).unwrap_or_else(|| seg_default(24, 3));
+            let rings = seg("rings", 8, 2);
+            let segments = seg("segments", 24, 3);
             hemisphere_mesh(radius, rings, segments, uv_mode)
         }
         "half_cylinder" => {
             let radius = node.attr_number("radius").unwrap_or(0.5);
             let height = node.attr_number("height").unwrap_or(1.0);
-            let segments = node.attr_number("segments").map(|n| n as u32).unwrap_or_else(|| seg_default(24, 3));
+            let segments = seg("segments", 24, 3);
             half_cylinder_mesh(radius, height, segments, uv_mode)
         }
         "torus_arc" => {
             let major = node.attr_number("major").unwrap_or(0.5);
             let minor = node.attr_number("minor").unwrap_or(0.15);
             let arc_deg = node.attr_number("arc").unwrap_or(90.0);
-            let major_segments = node
-                .attr_number("major_segments")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(24, 3));
-            let minor_segments = node
-                .attr_number("minor_segments")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(12, 3));
+            let major_segments = seg("major_segments", 24, 3);
+            let minor_segments = seg("minor_segments", 12, 3);
             torus_arc_mesh(major, minor, arc_deg.to_radians(), major_segments, minor_segments, uv_mode)
         }
         "ellipsoid" => {
             let s = resolve_size3(node, Vec3::ONE);
-            let rings = node.attr_number("rings").map(|n| n as u32).unwrap_or_else(|| seg_default(16, 2));
-            let segments = node.attr_number("segments").map(|n| n as u32).unwrap_or_else(|| seg_default(24, 3));
+            let rings = seg("rings", 16, 2);
+            let segments = seg("segments", 24, 3);
             ellipsoid_mesh([s.x, s.y, s.z], rings, segments, uv_mode)
         }
         "superellipsoid" => {
             let s = resolve_size3(node, Vec3::ONE);
             let ew = node.attr_number("ew").unwrap_or(1.0);
             let ns = node.attr_number("ns").unwrap_or(1.0);
-            let rings = node.attr_number("rings").map(|n| n as u32).unwrap_or_else(|| seg_default(16, 2));
-            let segments = node.attr_number("segments").map(|n| n as u32).unwrap_or_else(|| seg_default(24, 3));
+            let rings = seg("rings", 16, 2);
+            let segments = seg("segments", 24, 3);
             superellipsoid_mesh([s.x, s.y, s.z], ew, ns, rings, segments, uv_mode)
         }
         "curved_plane" => {
             let s = resolve_size_xz(node, [1.0, 1.0]);
             let bend_u = node.attr_number("bend_u").unwrap_or(0.0).to_radians();
             let bend_v = node.attr_number("bend_v").unwrap_or(0.0).to_radians();
-            let segments_u = node
-                .attr_number("segments_u")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(12, 1));
-            let segments_v = node
-                .attr_number("segments_v")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(12, 1));
+            let segments_u = seg("segments_u", 12, 1);
+            let segments_v = seg("segments_v", 12, 1);
             curved_plane_mesh(s, bend_u, bend_v, segments_u, segments_v, uv_mode)
         }
         "bezier_patch" => {
@@ -273,14 +262,8 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
                     points.len(),
                 )));
             }
-            let segments_u = node
-                .attr_number("segments_u")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(12, 1));
-            let segments_v = node
-                .attr_number("segments_v")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(12, 1));
+            let segments_u = seg("segments_u", 12, 1);
+            let segments_v = seg("segments_v", 12, 1);
             bezier_patch_mesh(&points, segments_u, segments_v, uv_mode)
         }
         "metaball" => {
@@ -308,14 +291,8 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
                 },
             };
             let blend = node.attr_number("blend").unwrap_or(0.0);
-            let rings = node
-                .attr_number("rings")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(12, 2));
-            let segments = node
-                .attr_number("segments")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(16, 3));
+            let rings = seg("rings", 12, 2);
+            let segments = seg("segments", 16, 3);
             metaball_mesh(&points, &radii, blend, rings, segments, uv_mode)
         }
         "wall" => {
@@ -341,7 +318,7 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
             let profile = node
                 .attr_list_pair("profile")
                 .unwrap_or_else(|| vec![[0.0, -0.5], [0.5, 0.0], [0.0, 0.5]]);
-            let segments = node.attr_number("segments").map(|n| n as u32).unwrap_or_else(|| seg_default(24, 3));
+            let segments = seg("segments", 24, 3);
             let cap_ends = node.attr_number("cap_ends").map(|n| n != 0.0).unwrap_or(true);
             lathe_mesh(&profile, segments, cap_ends, uv_mode)
         }
@@ -360,14 +337,8 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
             } else {
                 vec![node.attr_number("radius").unwrap_or(0.1)]
             };
-            let segments = node
-                .attr_number("segments")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(12, 3));
-            let samples = node
-                .attr_number("samples")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(8, 2));
+            let segments = seg("segments", 12, 3);
+            let samples = seg("samples", 8, 2);
             let cap_ends = node.attr_number("cap_ends").map(|n| n != 0.0).unwrap_or(true);
             spline_tube_mesh(&points, &radii, segments, samples, cap_ends, uv_mode)
         }
@@ -376,14 +347,8 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
             let height = node.attr_number("height").unwrap_or(1.0);
             let turns = node.attr_number("turns").unwrap_or(3.0);
             let profile_radius = node.attr_number("profile_radius").unwrap_or(0.05);
-            let segments = node
-                .attr_number("segments")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(12, 3));
-            let samples = node
-                .attr_number("samples")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(16, 4));
+            let segments = seg("segments", 12, 3);
+            let samples = seg("samples", 16, 4);
             let cap_ends = node.attr_number("cap_ends").map(|n| n != 0.0).unwrap_or(true);
             let handedness = match node.attr_string("handedness") {
                 Some(s) => match s.to_ascii_lowercase().as_str() {
@@ -413,10 +378,7 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
             } else {
                 vec![node.attr_number("width").unwrap_or(0.1)]
             };
-            let samples = node
-                .attr_number("samples")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(8, 2));
+            let samples = seg("samples", 8, 2);
             // Author writes degrees (per the prompt), the mesh builder takes radians.
             let twist = node.attr_number("twist").unwrap_or(0.0).to_radians();
             spline_ribbon_mesh(&points, &widths, samples, twist, uv_mode)
@@ -449,10 +411,7 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
             let path = node
                 .attr_list_vec3("path")
                 .unwrap_or_else(|| vec![[-0.5, 0.0, 0.0], [0.5, 0.0, 0.0]]);
-            let samples = node
-                .attr_number("samples")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(8, 2));
+            let samples = seg("samples", 8, 2);
             let twist = node.attr_number("twist").unwrap_or(0.0).to_radians();
             // Author-supplied per-control-point modulation lists. `roll` is
             // in degrees per the prompt, converted to radians here so the
@@ -506,10 +465,7 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
             let sections: Vec<Vec<[f32; 2]>> = (0..heights.len())
                 .map(|i| all_points[i * per_section..(i + 1) * per_section].to_vec())
                 .collect();
-            let samples = node
-                .attr_number("samples")
-                .map(|n| n as u32)
-                .unwrap_or_else(|| seg_default(4, 1));
+            let samples = seg("samples", 4, 1);
             let caps = node.attr_number("caps").map(|n| n != 0.0).unwrap_or(true);
             return Some(loft_mesh(&sections, &heights, samples, caps, uv_mode));
         }

--- a/crates/mogen-dsl/src/lower/tests.rs
+++ b/crates/mogen-dsl/src/lower/tests.rs
@@ -848,17 +848,53 @@ fn lod_scale_doubles_default_segment_count() {
 }
 
 #[test]
-fn lod_scale_does_not_override_explicit_segments() {
-    // Explicit per-primitive value wins over the global multiplier.
+fn lod_scale_also_scales_explicit_segments() {
+    // Explicit per-primitive segment counts ride the global multiplier
+    // too — otherwise dense surface primitives (heightfield, curved_plane,
+    // surf-style waves) become LOD-inert. The clamp keeps the count above
+    // each primitive's minimum so circles still close.
     let baseline = lower_src(r#"scene { sphere "s" (radius=0.5, rings=16, segments=24) }"#);
     let scaled = lower_src(
         r#"lod_scale (value=0.25) scene { sphere "s" (radius=0.5, rings=16, segments=24) }"#,
     );
     let base_verts = find_mesh_node(&baseline, "s").mesh.as_ref().unwrap().positions.len();
     let scaled_verts = find_mesh_node(&scaled, "s").mesh.as_ref().unwrap().positions.len();
-    assert_eq!(
-        base_verts, scaled_verts,
-        "explicit segments=24/rings=16 must ignore lod_scale"
+    assert!(
+        scaled_verts < base_verts,
+        "lod_scale=0.25 should reduce explicit rings=16/segments=24 (base={base_verts}, scaled={scaled_verts})"
+    );
+}
+
+#[test]
+fn lod_scale_scales_explicit_heightfield_grid() {
+    // Regression for examples/heightfield_terrain.mog and wave_water.mog —
+    // both pin segments_u/segments_v and would otherwise ignore lod_scale.
+    let baseline = lower_src(
+        r#"scene { heightfield "h" (size=[6, 6], segments_u=64, segments_v=64) }"#,
+    );
+    let halved = lower_src(
+        r#"lod_scale (value=0.5) scene { heightfield "h" (size=[6, 6], segments_u=64, segments_v=64) }"#,
+    );
+    let doubled = lower_src(
+        r#"lod_scale (value=2) scene { heightfield "h" (size=[6, 6], segments_u=64, segments_v=64) }"#,
+    );
+    let verts = |g: &SceneGraph| find_mesh_node(g, "h").mesh.as_ref().unwrap().positions.len();
+    assert!(verts(&halved) < verts(&baseline));
+    assert!(verts(&doubled) > verts(&baseline));
+}
+
+#[test]
+fn lod_scale_clamps_explicit_segments_to_min() {
+    // A vanishing lod_scale must not silently destroy a primitive — every
+    // segment count is floored at its per-primitive minimum (cylinder=3).
+    let g = lower_src(
+        r#"lod_scale (value=0.01) scene { cylinder "c" (radius=0.5, height=1, segments=24) }"#,
+    );
+    let mesh = find_mesh_node(&g, "c").mesh.as_ref().unwrap();
+    // Cylinder side ring + caps; with segments=3 it's still a closed solid.
+    assert!(
+        !mesh.positions.is_empty() && !mesh.indices.is_empty(),
+        "cylinder under lod_scale=0.01 must still produce geometry"
     );
 }
 

--- a/crates/mogen-studio/src/app/types.rs
+++ b/crates/mogen-studio/src/app/types.rs
@@ -360,9 +360,6 @@ pub(super) enum MenuAction {
     OpenUpdate,
     GenerateThumbnail,
     GenerateVideo,
-    /// VS Code–style line / selection ops dispatched against the active
-    /// editor. The same handlers fire from the keyboard in `line_ops.rs`.
-    EditorLineOp(super::line_ops::LineOp),
     OpenDocs,
 }
 

--- a/crates/mogen-studio/src/app/ui_dialogs/new_prompt.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/new_prompt.rs
@@ -6,8 +6,8 @@ use super::prefs::model_presets;
 use crate::app::types::{EnhanceTarget, GenImageInput, MAX_GEN_IMAGE_BYTES};
 use crate::app::MogenStudioApp;
 use crate::settings::{
-    style_label, thinking_level_key, thinking_level_label, ProviderSlot, PROVIDER_SLOTS,
-    STYLE_OPTIONS, THINKING_LEVELS,
+    preview_thinking_model, style_label, thinking_level_key, thinking_level_label,
+    ProviderSlot, PROVIDER_SLOTS, STYLE_OPTIONS, THINKING_LEVELS,
 };
 
 /// Decode the image bytes via the `image` crate, downscale to a thumbnail
@@ -226,7 +226,12 @@ impl MogenStudioApp {
                     .is_some()
                 {
                     let presets = model_presets(active_slot);
-                    let model_default = active_provider.default_model();
+                    let model_default = if self.settings.use_preview_models {
+                        preview_thinking_model(active_provider)
+                            .unwrap_or_else(|| active_provider.default_model())
+                    } else {
+                        active_provider.default_model()
+                    };
                     let mut model_draft = self
                         .settings
                         .thinking_model_field(active_provider)
@@ -263,6 +268,30 @@ impl MogenStudioApp {
                         self.settings.thinking_model_field_mut(active_provider)
                     {
                         *buf = model_draft;
+                    }
+
+                    // --- preview / bleeding-edge toggle ---
+                    // Mirrors the same checkbox in Preferences → LLM. Only
+                    // shown when the active provider has a preview tier worth
+                    // surfacing (Gemini today) and the slot isn't OAuth, which
+                    // already pins to preview tags unconditionally.
+                    if !active_slot.is_gemini_oauth()
+                        && preview_thinking_model(active_provider).is_some()
+                    {
+                        ui.add_space(4.0);
+                        let mut on = self.settings.use_preview_models;
+                        if ui
+                            .checkbox(&mut on, "Use preview / bleeding-edge models")
+                            .on_hover_text(
+                                "When enabled (and no explicit override is set), \
+                                 default to the latest Gemini preview Pro / Flash \
+                                 IDs instead of the stable `*-latest` aliases. \
+                                 Preview models can be deprecated without notice.",
+                            )
+                            .changed()
+                        {
+                            self.settings.use_preview_models = on;
+                        }
                     }
                 }
 

--- a/crates/mogen-studio/src/app/ui_menu.rs
+++ b/crates/mogen-studio/src/app/ui_menu.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use eframe::egui;
 
-use crate::preview_shader::{preview_shader_label, PreviewShader, PREVIEW_SHADERS};
 use crate::settings::DEFAULT_VIEWER_BG_RGB;
 use crate::theme::{apply_theme, theme_label, Theme, THEMES};
 
@@ -335,51 +334,6 @@ impl MogenStudioApp {
                     ui.close_menu();
                 }
                 ui.separator();
-                let alt = Modifiers::ALT;
-                for (label, sc, op, tooltip) in [
-                    (
-                        "Toggle Comment",
-                        KeyboardShortcut::new(cmd, Key::Slash),
-                        super::line_ops::LineOp::ToggleComment,
-                        "Comment or uncomment the selected line(s)",
-                    ),
-                    (
-                        "Select Line",
-                        KeyboardShortcut::new(cmd, Key::L),
-                        super::line_ops::LineOp::SelectLine,
-                        "Extend the selection to the full line",
-                    ),
-                    (
-                        "Delete Line",
-                        KeyboardShortcut::new(cmd_shift, Key::K),
-                        super::line_ops::LineOp::DeleteLine,
-                        "Delete the line(s) covered by the selection",
-                    ),
-                    (
-                        "Move Line Up",
-                        KeyboardShortcut::new(alt, Key::ArrowUp),
-                        super::line_ops::LineOp::MoveUp,
-                        "Swap the current line(s) with the line above",
-                    ),
-                    (
-                        "Move Line Down",
-                        KeyboardShortcut::new(alt, Key::ArrowDown),
-                        super::line_ops::LineOp::MoveDown,
-                        "Swap the current line(s) with the line below",
-                    ),
-                    (
-                        "Select Next Occurrence",
-                        KeyboardShortcut::new(cmd, Key::D),
-                        super::line_ops::LineOp::SelectNext,
-                        "Select the word under the caret, or jump to the next match",
-                    ),
-                ] {
-                    if native_shortcut_menu_item(ui, label, sc, tooltip, true).clicked() {
-                        action = MenuAction::EditorLineOp(op);
-                        ui.close_menu();
-                    }
-                }
-                ui.separator();
                 if shortcut_menu_item(
                     ui,
                     "Preferences…",
@@ -394,7 +348,6 @@ impl MogenStudioApp {
             });
 
             let mut chosen_theme: Option<Theme> = None;
-            let mut chosen_shader: Option<PreviewShader> = None;
             ui.menu_button("View", |ui| {
                 if shortcut_menu_item(
                     ui,
@@ -454,20 +407,6 @@ impl MogenStudioApp {
                     let _ = self.settings.save();
                 }
                 ui.separator();
-                ui.menu_button("Shader", |ui| {
-                    let current = self.settings.preview_shader();
-                    for s in PREVIEW_SHADERS {
-                        let selected = s == current;
-                        if ui
-                            .selectable_label(selected, preview_shader_label(s))
-                            .clicked()
-                            && !selected
-                        {
-                            chosen_shader = Some(s);
-                            ui.close_menu();
-                        }
-                    }
-                });
                 ui.menu_button("Theme", |ui| {
                     let current = self.settings.theme();
                     for t in THEMES {
@@ -513,11 +452,6 @@ impl MogenStudioApp {
             if let Some(t) = chosen_theme {
                 self.settings.set_theme(t);
                 apply_theme(ui.ctx(), t);
-                let _ = self.settings.save();
-            }
-            if let Some(s) = chosen_shader {
-                self.settings.set_preview_shader(s);
-                self.viewer.set_preview_shader(s);
                 let _ = self.settings.save();
             }
 
@@ -699,19 +633,6 @@ impl MogenStudioApp {
                         "generate: another render is already in flight, finish it first".into();
                 } else {
                     self.show_video_options = true;
-                }
-            }
-            MenuAction::EditorLineOp(op) => {
-                let editor_id = self.active_editor_id();
-                let mutated = self.apply_line_op(ctx, editor_id, op);
-                ctx.memory_mut(|m| m.request_focus(editor_id));
-                if mutated {
-                    let i = self.active;
-                    self.files[i].dirty =
-                        self.files[i].source != self.files[i].last_saved_source;
-                    self.files[i].needs_compile = true;
-                    self.files[i].last_edit_at = Some(std::time::Instant::now());
-                    self.break_undo_chain(i);
                 }
             }
             MenuAction::OpenDocs => {

--- a/crates/mogen-validate/src/ast_checks/mod.rs
+++ b/crates/mogen-validate/src/ast_checks/mod.rs
@@ -129,8 +129,9 @@ fn scan_nested_meta(n: &Node, diags: &mut Vec<Diagnostic>) {
 }
 
 /// Warn (not error) when the file's `mogen_version` differs from the version
-/// of the toolchain running the validator. Old files keep building; the
-/// warning nudges authors to refresh.
+/// of the toolchain running the validator at the major-or-minor level. Patch
+/// bumps are silent — they round-trip without semantic change. Old files keep
+/// building; the warning nudges authors to refresh.
 fn check_meta_version(meta: &Node, diags: &mut Vec<Diagnostic>) {
     let current = env!("CARGO_PKG_VERSION");
     let stamped = meta.attrs.iter().find_map(|(k, v)| {
@@ -143,7 +144,7 @@ fn check_meta_version(meta: &Node, diags: &mut Vec<Diagnostic>) {
         }
     });
     if let Some(v) = stamped {
-        if v != current {
+        if differs_at_minor_or_above(v, current) {
             diags.push(
                 Diagnostic::warning(
                     "W0107",
@@ -156,6 +157,25 @@ fn check_meta_version(meta: &Node, diags: &mut Vec<Diagnostic>) {
             );
         }
     }
+}
+
+/// Return true when `stamped` and `current` differ at the major or minor
+/// component (ignoring patch and any pre-release/build suffix). Versions that
+/// don't parse as `MAJOR.MINOR[.…]` fall back to full string comparison so
+/// genuinely malformed values still surface.
+fn differs_at_minor_or_above(stamped: &str, current: &str) -> bool {
+    match (parse_major_minor(stamped), parse_major_minor(current)) {
+        (Some(a), Some(b)) => a != b,
+        _ => stamped != current,
+    }
+}
+
+fn parse_major_minor(v: &str) -> Option<(u64, u64)> {
+    let core = v.split(['-', '+']).next()?;
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    Some((major, minor))
 }
 
 fn walk(

--- a/crates/mogen-validate/src/ast_checks/tests.rs
+++ b/crates/mogen-validate/src/ast_checks/tests.rs
@@ -222,6 +222,32 @@ mod meta_block_tests {
     }
 
     #[test]
+    fn version_patch_difference_is_silent() {
+        // Patch bumps round-trip without semantic change — no warning, even
+        // though the stamped string differs from the current toolchain.
+        let current = env!("CARGO_PKG_VERSION");
+        let (major, minor) = current
+            .split(['-', '+'])
+            .next()
+            .and_then(|core| {
+                let mut parts = core.split('.');
+                let mj: u64 = parts.next()?.parse().ok()?;
+                let mn: u64 = parts.next()?.parse().ok()?;
+                Some((mj, mn))
+            })
+            .expect("CARGO_PKG_VERSION parses as MAJOR.MINOR.…");
+        // Pick a patch number that cannot equal the current full version.
+        let stamped = format!("{major}.{minor}.9999");
+        assert_ne!(stamped, current);
+        let src = format!(r#"meta (mogen_version = "{stamped}") scene {{}}"#);
+        let diags = diags_for(&src);
+        assert!(
+            !diags.iter().any(|d| d.code == "W0107"),
+            "patch-only difference should not warn, got {diags:?}"
+        );
+    }
+
+    #[test]
     fn missing_meta_is_silent() {
         // Optional metadata: no warning for files that omit the block entirely.
         let diags = diags_for(r#"scene { box "b" (size=[1,1,1]) }"#);

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -97,14 +97,14 @@ consumed during lowering.
 
 | directive | value | effect |
 |---|---|---|
-| `lod_scale (value=N)` | number, default `1.0` | multiplies primitive default `segments` / `rings` / `samples`. `0.5` halves them, `2.0` doubles them. `icosphere` `subdivisions` step by `round(log2(N))` instead, since each step quadruples its triangle count. Per-primitive values (`segments=24`, `rings=16`, …) are absolute and are **not** scaled. |
+| `lod_scale (value=N)` | number, default `1.0` | multiplies every primitive `segments` / `rings` / `samples` count — both the implicit defaults *and* author-supplied explicit values like `segments_u=64`. `0.5` halves them, `2.0` doubles them. `icosphere` `subdivisions` step by `round(log2(N))` instead, since each step quadruples its triangle count. Counts are clamped to a per-primitive minimum so circles still close. |
 
 ```
 lod_scale (value=0.5)
 
 scene {
-  sphere "head" (radius=0.5)         // 12 rings, 12 segments (default 16/24 halved)
-  sphere "lod0" (radius=0.5, segments=48, rings=32)  // explicit values keep 48/32
+  sphere "head" (radius=0.5)         // 8 rings, 12 segments (default 16/24 halved)
+  sphere "lod0" (radius=0.5, segments=48, rings=32)  // 16 rings, 24 segments (48/32 halved)
 }
 ```
 
@@ -133,9 +133,12 @@ scene {
 }
 ```
 
-Like `lod_scale`, explicit per-primitive `segments=` / `rings=` /
-`subdivisions=` win over the multiplier — the override only acts on
-defaults.
+`lod=` scales every tessellation count in the marked subtree, including
+explicit per-primitive `segments=` / `rings=` / `subdivisions=`. Use it
+to dial detail on dense surfaces (heightfields, curved planes) without
+having to drop their explicit segment counts. The minimum per-primitive
+floor still applies, so a `lod=0.1` won't collapse a cylinder to fewer
+than three sides.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Surface preview-models toggle in New-from-Prompt** — the dialog now exposes the same checkbox as the prefs panel so users can opt in to preview models on a one-off basis.
- **`lod_scale` now scales explicit segment counts** — `segments_u=64` on a `heightfield`/`curved_plane` used to be LOD-inert. Now `lod_scale` and per-node `lod=` multiply both defaults and explicit values, with a per-primitive floor so circles still close under aggressive downscale. Fixes the regression on `examples/wave_water.mog` and `examples/heightfield_terrain.mog`.
- **Silence `W0107` on patch-only `mogen_version` drift** — same major.minor, different patch shouldn't nag.
- **Trim Studio Edit and View menus** — drop redundant entries that were either dead or duplicated by hotkeys.

## Test plan

- [x] `cargo test --workspace` (all suites green, including new LOD regressions in `mogen-dsl`)
- [ ] Open `examples/heightfield_terrain.mog` in MoGen Studio and confirm the LOD slider visibly changes the heightfield density
- [ ] Open `examples/wave_water.mog` and confirm the wave-deformed planes scale with LOD
- [ ] Trigger New-from-Prompt and confirm the preview-models checkbox toggles the model list
- [ ] Edit a `meta (mogen_version="…")` block to a same-major.minor / different-patch value and confirm no `W0107` is emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)