### PR TITLE
Redesign Preferences dialog and refactor UI styling

### DIFF
--- a/crates/mogen-studio/src/app.rs
+++ b/crates/mogen-studio/src/app.rs
@@ -34,6 +34,7 @@ mod onboarding;
 mod pricing;
 mod publish_textures;
 mod spotlight;
+mod style;
 mod text_menu;
 mod thumbnail;
 mod types;
@@ -376,6 +377,12 @@ pub struct MogenStudioApp {
     /// [`Self::queue_protocol_url`] when launched with a URL on argv,
     /// or by future in-app deep-link surfaces. `None` at steady state.
     moghub_protocol: Option<moghub_open::Flow>,
+
+    /// Two-step confirm latch for the Animation panel's per-clip delete
+    /// button. Holds the clip name on the first click; a second click on
+    /// the same clip commits the delete. Cleared on tab switch, on any
+    /// non-trash interaction in the panel, or after the commit fires.
+    clip_delete_pending: Option<String>,
 }
 
 impl MogenStudioApp {
@@ -529,6 +536,7 @@ impl MogenStudioApp {
             thumbnail_mgr: thumbnail::ThumbnailManager::new(cc.egui_ctx.clone()),
             picker_prev_camera: None,
             moghub_protocol: None,
+            clip_delete_pending: None,
         }
     }
 
@@ -839,27 +847,17 @@ impl eframe::App for MogenStudioApp {
                 egui::ScrollArea::vertical()
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
-                        // CollapsingHeader so users can fold what they don't
-                        // need; keeps the most-actioned section (LLM) reachable
-                        // without scrolling past the other groups. Diagnostics
-                        // now lives in the footer, not here.
-                        egui::CollapsingHeader::new("Selected")
-                            .default_open(true)
-                            .show(ui, |ui| self.ui_selected(ui));
-                        egui::CollapsingHeader::new("Scene")
-                            .default_open(true)
-                            .show(ui, |ui| self.ui_summary(ui));
-                        egui::CollapsingHeader::new("Materials")
-                            .default_open(false)
-                            .show(ui, |ui| self.ui_materials(ui));
+                        // Bold-title sections so the inspector reads as a
+                        // structured panel rather than a flat list of fields.
+                        // LLM stays default-open because it's the most-actioned
+                        // section; diagnostics live in the footer, not here.
+                        style::section(ui, "Selected", true,    |ui| self.ui_selected(ui));
+                        style::section(ui, "Scene",    true,    |ui| self.ui_summary(ui));
+                        style::section(ui, "Materials", false,  |ui| self.ui_materials(ui));
                         if self.has_visible_clips() {
-                            egui::CollapsingHeader::new("Animation")
-                                .default_open(true)
-                                .show(ui, |ui| self.ui_animation(ui));
+                            style::section(ui, "Animation", true, |ui| self.ui_animation(ui));
                         }
-                        egui::CollapsingHeader::new("LLM")
-                            .default_open(true)
-                            .show(ui, |ui| self.ui_llm(ui));
+                        style::section(ui, "LLM",      true,    |ui| self.ui_llm(ui));
                     });
             });
 

--- a/crates/mogen-studio/src/app/style.rs
+++ b/crates/mogen-studio/src/app/style.rs
@@ -1,0 +1,116 @@
+//! Shared visual helpers for Studio dialogs and panels: accent colours
+//! pulled from the active theme, primary-button factory, dim italic
+//! placeholders, framed section blocks, collapsible-section helper, and a
+//! seconds formatter that drops insignificant trailing zeros.
+//!
+//! Accents derive from the live `Visuals` so themes (Dark / Nord / Sunset /
+//! Light / High-Contrast) keep ownership of their palette without a
+//! per-theme constant table.
+
+use eframe::egui;
+
+/// Theme-derived primary-action colour. Mirrors the selection fill so that
+/// "primary button" and "selected slider track / combo row" share a hue.
+pub fn accent_primary(visuals: &egui::Visuals) -> egui::Color32 {
+    visuals.selection.bg_fill
+}
+
+/// Theme-derived informational accent — used for ⓘ glyphs next to
+/// section headings and quiet hints.
+pub fn accent_info(visuals: &egui::Visuals) -> egui::Color32 {
+    visuals.hyperlink_color
+}
+
+/// Theme-derived warning accent. Used for two-step confirm states.
+pub fn accent_warn(visuals: &egui::Visuals) -> egui::Color32 {
+    visuals.warn_fg_color
+}
+
+/// Filled accent button for the canonical action in a row (Save, Modify,
+/// Animate, Refine, Generate, …). Keeps everything else as the default
+/// outline button, so primary stands out.
+pub fn primary_button(ui: &egui::Ui, text: &str) -> egui::Button<'static> {
+    let visuals = &ui.style().visuals;
+    let fill = accent_primary(visuals);
+    let fg = visuals.selection.stroke.color;
+    egui::Button::new(egui::RichText::new(text.to_owned()).color(fg)).fill(fill)
+}
+
+/// Dim italic placeholder text for `TextEdit::hint_text`. The default
+/// hint colour can read as already-typed copy on multiline fields; italic
+/// + weak shifts it visually into "this is a hint".
+pub fn placeholder(text: &str) -> egui::WidgetText {
+    egui::RichText::new(text).italics().weak().into()
+}
+
+/// Inspector-panel section header. `default_open` controls the initial
+/// expansion state; the title renders in bold so the section reads above
+/// body text without changing font size.
+pub fn section<R>(
+    ui: &mut egui::Ui,
+    title: &str,
+    default_open: bool,
+    body: impl FnOnce(&mut egui::Ui) -> R,
+) {
+    ui.add_space(6.0);
+    egui::CollapsingHeader::new(egui::RichText::new(title).strong())
+        .id_salt(("studio_section", title))
+        .default_open(default_open)
+        .show(ui, |ui| {
+            body(ui);
+        });
+}
+
+/// Framed section block for the Preferences dialog. Adds a soft border,
+/// a strong title, and an optional ⓘ tooltip that absorbs long-form copy
+/// so the visible row is just title + controls.
+pub fn framed_section<R>(
+    ui: &mut egui::Ui,
+    title: &str,
+    hint: Option<&str>,
+    body: impl FnOnce(&mut egui::Ui) -> R,
+) -> R {
+    ui.add_space(6.0);
+    let info_color = accent_info(&ui.style().visuals);
+    let resp = egui::Frame::group(ui.style())
+        .inner_margin(egui::Margin::symmetric(10.0, 8.0))
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label(egui::RichText::new(title).strong());
+                if let Some(h) = hint {
+                    ui.label(egui::RichText::new("ⓘ").color(info_color))
+                        .on_hover_text(h);
+                }
+            });
+            ui.add_space(4.0);
+            body(ui)
+        });
+    resp.inner
+}
+
+/// Inline ⓘ + weak-text hint row. Replaces `colored_label` for
+/// informational notes (env-var precedence, "Auto → resolved to …", etc.)
+/// so only true alerts get colour.
+pub fn info_row(ui: &mut egui::Ui, text: &str) {
+    let info_color = accent_info(&ui.style().visuals);
+    ui.horizontal_wrapped(|ui| {
+        ui.label(egui::RichText::new("ⓘ").color(info_color));
+        ui.label(egui::RichText::new(text).weak());
+    });
+}
+
+/// Format a duration in seconds with at most two decimals, dropping
+/// insignificant trailing zeros. `30.0` → `"30 s"`, `1.5` → `"1.5 s"`,
+/// `5.59` → `"5.59 s"`.
+pub fn format_seconds(s: f32) -> String {
+    if !s.is_finite() {
+        return "—".into();
+    }
+    if s.fract().abs() < 0.005 {
+        format!("{:.0} s", s)
+    } else if (s * 10.0).fract().abs() < 0.05 {
+        format!("{:.1} s", s)
+    } else {
+        format!("{:.2} s", s)
+    }
+}

--- a/crates/mogen-studio/src/app/ui_dialogs/prefs.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/prefs.rs
@@ -14,7 +14,7 @@ use crate::theme::{apply_theme, theme_label, Theme, THEMES};
 /// Tab pages inside the Preferences window. Grouped by what the user is
 /// trying to change: anything LLM-shaped (provider, key, models, sampling)
 /// lives in one pane, look-and-feel in another, telemetry in a third.
-#[derive(Copy, Clone, PartialEq, Eq, Default)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Default)]
 pub enum PrefsTab {
     #[default]
     Llm,
@@ -99,31 +99,42 @@ pub(super) fn model_presets(slot: ProviderSlot) -> &'static [&'static str] {
     }
 }
 
-/// One row of the Pricing summary block. Renders the headline rate plus a
-/// dimmer second line for the >200k tier when the model is tiered.
-fn price_row(
+/// Single grid row of the Pricing breakdown table. `tier_long = true` reads
+/// the >200k tier rates; `false` reads the headline rates. Caller is
+/// responsible for `ui.end_row()`.
+fn price_grid_row(
     ui: &mut egui::Ui,
     label: &str,
     model: &str,
     price: crate::app::pricing::TextPricing,
+    tier_long: bool,
 ) {
-    ui.label(egui::RichText::new(format!(
-        "{label}  {model}  in {} · out {} · cached {}",
-        format_per_million(price.input_per_million_usd),
-        format_per_million(price.output_per_million_usd),
-        format_per_million(price.cached_input_per_million_usd),
-    )));
-    if price.is_tiered() {
-        ui.label(
-            egui::RichText::new(format!(
-                "          >200k prompt: in {} · out {} · cached {}",
-                format_per_million(price.input_per_million_usd_long),
-                format_per_million(price.output_per_million_usd_long),
-                format_per_million(price.cached_input_per_million_usd_long),
-            ))
-            .weak(),
-        );
-    }
+    let (in_p, out_p, cached_p) = if tier_long {
+        (
+            price.input_per_million_usd_long,
+            price.output_per_million_usd_long,
+            price.cached_input_per_million_usd_long,
+        )
+    } else {
+        (
+            price.input_per_million_usd,
+            price.output_per_million_usd,
+            price.cached_input_per_million_usd,
+        )
+    };
+    let cell = |s: String| -> egui::RichText {
+        if tier_long {
+            egui::RichText::new(s).weak()
+        } else {
+            egui::RichText::new(s)
+        }
+    };
+    ui.label(cell(label.to_owned()));
+    ui.label(cell(model.to_owned()));
+    ui.label(cell(format_per_million(in_p)));
+    ui.label(cell(format_per_million(out_p)));
+    ui.label(cell(format_per_million(cached_p)));
+    ui.end_row();
 }
 
 impl MogenStudioApp {
@@ -133,35 +144,105 @@ impl MogenStudioApp {
         }
         let mut open = true;
         let mut close_after = false;
+
+        // Backdrop scrim. Sits in the Background order so it covers the
+        // side panels (which would otherwise bleed into a non-resizable
+        // window's edges) but stays under the modal Window itself.
+        let screen = ctx.screen_rect();
+        egui::Area::new(egui::Id::new("prefs_scrim"))
+            .order(egui::Order::Background)
+            .fixed_pos(egui::pos2(0.0, 0.0))
+            .show(ctx, |ui| {
+                ui.painter().rect_filled(
+                    screen,
+                    0.0,
+                    egui::Color32::from_black_alpha(96),
+                );
+            });
+
+        // Adapt the dialog footprint to the host window. On a small
+        // window we want a minimum usable size; on a big window we cap
+        // at a comfortable reading width and let the body scroll for
+        // height overflow.
+        let avail_w = screen.width();
+        let avail_h = screen.height();
+        let max_w = (avail_w - 32.0).clamp(360.0, 720.0);
+        let max_h = (avail_h - 64.0).max(320.0);
+        let default_w = max_w.min(560.0);
+
+        let active_tab_color =
+            crate::app::style::accent_primary(&ctx.style().visuals);
+
         egui::Window::new("Options")
             .open(&mut open)
             .collapsible(false)
-            .resizable(false)
-            .default_width(520.0)
+            .resizable(true)
+            .default_width(default_w)
+            .min_width(360.0)
+            .max_width(max_w)
+            .max_height(max_h)
             .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
             .show(ctx, |ui| {
+                // Tab strip stays outside the scroll area so it always
+                // sticks to the top of the dialog.
                 ui.horizontal(|ui| {
                     for tab in PREFS_TABS {
                         let selected = self.prefs_active_tab == tab;
-                        if ui.selectable_label(selected, tab.label()).clicked() {
+                        let label_text = if selected {
+                            egui::RichText::new(tab.label()).strong()
+                        } else {
+                            egui::RichText::new(tab.label())
+                        };
+                        let resp = ui.selectable_label(selected, label_text);
+                        if resp.clicked() {
                             self.prefs_active_tab = tab;
+                        }
+                        if selected {
+                            // Underline the active tab with the accent so
+                            // the selection is legible across themes.
+                            let r = resp.rect;
+                            ui.painter().line_segment(
+                                [
+                                    egui::pos2(r.left() + 4.0, r.bottom() + 1.0),
+                                    egui::pos2(r.right() - 4.0, r.bottom() + 1.0),
+                                ],
+                                egui::Stroke::new(2.0, active_tab_color),
+                            );
                         }
                     }
                 });
                 ui.separator();
                 ui.add_space(4.0);
 
-                match self.prefs_active_tab {
-                    PrefsTab::Llm => self.prefs_tab_llm(ui),
-                    PrefsTab::Appearance => self.prefs_tab_appearance(ui, ctx),
-                    PrefsTab::Privacy => self.prefs_tab_privacy(ui),
-                }
+                // Body scrolls; footer below stays pinned. Without the
+                // explicit height, the ScrollArea would expand to fit
+                // content and re-introduce the off-screen-clip bug at
+                // small window sizes.
+                let body_height = (max_h - 130.0).max(160.0);
+                egui::ScrollArea::vertical()
+                    .id_salt(("prefs_body", self.prefs_active_tab))
+                    .auto_shrink([false, false])
+                    .max_height(body_height)
+                    .show(ui, |ui| {
+                        match self.prefs_active_tab {
+                            PrefsTab::Llm => self.prefs_tab_llm(ui),
+                            PrefsTab::Appearance => self.prefs_tab_appearance(ui, ctx),
+                            PrefsTab::Privacy => self.prefs_tab_privacy(ui),
+                        }
+                    });
 
-                ui.add_space(12.0);
+                ui.add_space(8.0);
                 ui.separator();
                 ui.add_space(4.0);
+                // Right-aligned cluster, primary Save on the right.
                 ui.horizontal(|ui| {
-                    if ui.button("Save").clicked() {
+                    ui.with_layout(
+                        egui::Layout::right_to_left(egui::Align::Center),
+                        |ui| {
+                            let save = ui.add(
+                                crate::app::style::primary_button(ui, "Save"),
+                            );
+                            if save.clicked() {
                         // The Gemini key uses an editor-buffered draft so the
                         // user can clear/re-paste without instantly mutating
                         // settings; commit it on Save. Other providers' keys
@@ -201,10 +282,12 @@ impl MogenStudioApp {
                                 self.active_mut().status = format!("options: save failed: {e}");
                             }
                         }
-                    }
-                    if ui.button("Cancel").clicked() {
-                        close_after = true;
-                    }
+                            }
+                            if ui.button("Cancel").clicked() {
+                                close_after = true;
+                            }
+                        },
+                    );
                 });
             });
         if !open || close_after {
@@ -213,14 +296,18 @@ impl MogenStudioApp {
     }
 
     fn prefs_tab_llm(&mut self, ui: &mut egui::Ui) {
-        ui.heading("LLM provider");
-                ui.label(
-                    "Backend used for Generate / Modify / Animate / Ask / Prompt \
-                     Enhance. Texture image generation has its own provider \
-                     picker below — Gemini (API key or Antigravity OAuth) or \
-                     Z.ai's `glm-image`.",
-                );
-                ui.add_space(6.0);
+        use crate::app::style;
+
+        // ── Section 1: LLM provider ──
+        style::framed_section(
+            ui,
+            "LLM provider",
+            Some(
+                "Backend used for Generate / Modify / Animate / Ask / Prompt \
+                 Enhance. Texture image generation has its own provider \
+                 picker below.",
+            ),
+            |ui| {
                 let current_slot = self.settings.provider_slot();
                 egui::ComboBox::from_id_salt("opts_provider")
                     .selected_text(current_slot.label())
@@ -236,20 +323,22 @@ impl MogenStudioApp {
                             }
                         }
                     });
+            },
+        );
 
-                ui.add_space(12.0);
-                ui.heading("Image generation provider");
-                ui.label(
-                    "Which surface texture image generation hits. \"Auto\" \
-                     prefers an Antigravity OAuth bundle when one is signed in \
-                     and falls back to a Gemini API key. Force \"Antigravity \
-                     OAuth\" to skip the API-key fallback, or \"Gemini API key\" \
-                     to bypass OAuth — useful when one surface is rate-limited \
-                     (404s / 429s) and you want the other. \"Z.ai (glm-image)\" \
-                     swaps the entire backend to Z.ai's image API — useful when \
-                     Gemini quota is exhausted.",
-                );
-                ui.add_space(6.0);
+        // ── Section 2: Image generation provider ──
+        style::framed_section(
+            ui,
+            "Image generation provider",
+            Some(
+                "Which surface texture image generation hits.\n\n\
+                 Auto: prefer Antigravity OAuth, fall back to Gemini API key.\n\
+                 Antigravity OAuth: skip the API-key fallback.\n\
+                 Gemini API key: bypass OAuth entirely.\n\
+                 Z.ai (glm-image): swap the entire backend.\n\n\
+                 Useful when one surface is rate-limited or quota-exhausted.",
+            ),
+            |ui| {
                 let current_image = self.settings.image_provider();
                 egui::ComboBox::from_id_salt("opts_image_provider")
                     .selected_text(current_image.label())
@@ -267,9 +356,8 @@ impl MogenStudioApp {
                     });
 
                 // Live indicator: which credential will Auto actually use
-                // right now? The precedence chain is buried in the prose
-                // above; surface the current resolution explicitly so users
-                // don't have to reason it out.
+                // right now? The precedence chain is buried in the tooltip;
+                // surface the current resolution as a quiet info row.
                 if current_image == ImageProvider::Auto {
                     use crate::app::util::Credential;
                     let label = match self.resolve_gemini_credential() {
@@ -293,7 +381,7 @@ impl MogenStudioApp {
                              paste a Gemini API key."
                         }
                     };
-                    ui.label(egui::RichText::new(label).weak());
+                    style::info_row(ui, label);
                 }
 
                 if current_image == ImageProvider::ZAI {
@@ -312,7 +400,9 @@ impl MogenStudioApp {
                             ui.add(
                                 egui::TextEdit::singleline(text)
                                     .password(true)
-                                    .hint_text("paste Z.ai key (leave blank to clear)")
+                                    .hint_text(style::placeholder(
+                                        "paste Z.ai key (leave blank to clear)",
+                                    ))
                                     .desired_width(f32::INFINITY)
                                     .id(zai_id),
                             )
@@ -323,254 +413,238 @@ impl MogenStudioApp {
                         .unwrap_or(false)
                     {
                         ui.add_space(4.0);
-                        ui.colored_label(
-                            egui::Color32::from_rgb(150, 180, 230),
-                            "ZAI_API_KEY is also set in your environment — the \
-                             saved key here takes precedence when non-empty.",
+                        style::info_row(
+                            ui,
+                            "ZAI_API_KEY is set in your environment; the saved \
+                             key above takes precedence when non-empty.",
                         );
                     }
                 }
+            },
+        );
 
-                ui.add_space(12.0);
-                let active_slot = self.settings.provider_slot();
-                let active_provider = active_slot.to_provider();
-                if matches!(active_provider, Provider::ClaudeCode) {
-                    // Claude Code authenticates through the user's local
-                    // `claude` CLI install — no key to paste here. We only
-                    // expose a binary-path override for non-PATH installs.
-                    ui.heading("Claude Code binary");
-                    ui.label(
-                        "Auth is handled by your local `claude` install — \
-                         run `claude` in a terminal and use the `/login` \
-                         slash command if you haven't yet. Used by Generate \
-                         / Modify / Animate / Ask.",
-                    );
-                    ui.label(
-                        egui::RichText::new(
-                            "Note: image generation (Textures) always uses \
-                             Gemini. Set a Gemini API key on the Gemini slot \
-                             above.",
-                        )
-                        .weak(),
-                    );
-                    ui.add_space(6.0);
+        // ── Section 3: Auth (provider-conditional) ──
+        let active_slot = self.settings.provider_slot();
+        let active_provider = active_slot.to_provider();
+        if matches!(active_provider, Provider::ClaudeCode) {
+            style::framed_section(
+                ui,
+                "Claude Code binary",
+                Some(
+                    "Auth is handled by your local `claude` install — \
+                     run `claude` in a terminal and use the `/login` \
+                     slash command if you haven't yet. Used by Generate \
+                     / Modify / Animate / Ask.\n\n\
+                     Image generation (Textures) always uses Gemini; \
+                     set a Gemini API key on the Gemini slot above.",
+                ),
+                |ui| {
                     ui.label("Path (optional)").on_hover_text(
-                        "Absolute path to the `claude` binary. Leave blank to \
-                         resolve `claude` from PATH.",
+                        "Absolute path to the `claude` binary. Leave \
+                         blank to resolve `claude` from PATH.",
                     );
                     ui.add(
                         egui::TextEdit::singleline(&mut self.settings.claude_code_path)
-                            .hint_text("claude")
+                            .hint_text(style::placeholder("claude"))
                             .desired_width(f32::INFINITY),
                     );
-                } else if active_slot.is_gemini_oauth() {
-                    // OAuth-only Gemini slot: hide the key field entirely and
-                    // surface the Sign-in flow + status. The saved Gemini API
-                    // key (if any) is preserved on the side — switching back
-                    // to the API-key slot brings it back into view.
-                    self.prefs_gemini_oauth_section(ui);
-                } else {
-                    let key_heading = match active_provider {
-                        Provider::Gemini => "Gemini API key",
-                        Provider::OpenAI => "OpenAI API key",
-                        Provider::Anthropic => "Anthropic API key",
-                        Provider::Ollama => "Ollama API key (optional)",
-                        Provider::Fireworks => "Fireworks AI Firepass API key",
-                        Provider::Zai => "Z.ai API key",
-                        Provider::ClaudeCode => unreachable!(),
-                    };
-                    ui.heading(key_heading);
-                    ui.label(match active_provider {
-                        Provider::Gemini => {
-                            "Used by Generate / Modify / Animate / Textures. Stored in your \
-                             user config directory and persists between sessions. The \
-                             $GEMINI_API_KEY environment variable is used when this field \
-                             is blank."
-                        }
-                        Provider::OpenAI => {
-                            "Used by Generate / Modify / Animate / Ask. Stored in your \
-                             user config directory and persists between sessions. The \
-                             $OPENAI_API_KEY environment variable is used when this field \
-                             is blank."
-                        }
-                        Provider::Anthropic => {
-                            "Used by Generate / Modify / Animate / Ask. Stored in your \
-                             user config directory and persists between sessions. The \
-                             $ANTHROPIC_API_KEY environment variable is used when this \
-                             field is blank."
-                        }
-                        Provider::Ollama => {
-                            "Optional bearer token for an Ollama endpoint behind an \
-                             authenticating proxy. Leave blank for a local install."
-                        }
-                        Provider::Fireworks => {
-                            "Used by Generate / Modify / Animate / Ask. Default model is the \
-                             Fire Pass `kimi-k2p6` router (zero per-token cost on Kimi K2 \
-                             for personal agentic-coding use). Stored in your user config \
-                             directory and persists between sessions."
-                        }
-                        Provider::Zai => {
-                            "Used by Generate / Modify / Animate / Ask. Default model is \
-                             `glm-5.1` (Z.ai's GLM family via the OpenAI-compatible chat API). \
-                             The same key drives the `glm-image` texture path when you set \
-                             Image provider → Z.ai. Stored in your user config directory."
-                        }
-                        Provider::ClaudeCode => unreachable!(),
-                    });
-                    ui.add_space(6.0);
-                    // Show only the field for the active provider to reduce clutter.
-                    // Switching providers above swaps which field is visible here.
-                    let key_id = egui::Id::new(("opts_api_key", active_provider.key()));
-                    let key_buf: &mut String = match active_provider {
-                        Provider::Gemini => &mut self.options_api_key_draft,
-                        Provider::OpenAI => &mut self.settings.openai_api_key,
-                        Provider::Anthropic => &mut self.settings.anthropic_api_key,
-                        Provider::Ollama => &mut self.settings.ollama_api_key,
-                        Provider::Fireworks => &mut self.settings.fireworks_api_key,
-                        Provider::Zai => &mut self.settings.zai_api_key,
-                        Provider::ClaudeCode => unreachable!(),
-                    };
-                    crate::app::text_menu::text_edit_with_menu(
-                        ui,
-                        key_id,
-                        key_buf,
-                        |ui, text| {
-                            ui.add(
-                                egui::TextEdit::singleline(text)
-                                    .password(true)
-                                    .hint_text("paste key (leave blank to clear)")
-                                    .desired_width(f32::INFINITY)
-                                    .id(key_id),
-                            )
-                        },
-                    );
-
-                    if matches!(active_provider, Provider::Ollama) {
-                        ui.add_space(6.0);
-                        ui.label("Ollama base URL (optional)").on_hover_text(
-                            "Override for self-hosted Ollama. Leave blank for the \
-                             library default (http://localhost:11434).",
-                        );
+                },
+            );
+        } else if active_slot.is_gemini_oauth() {
+            // OAuth-only Gemini slot: dedicated layout with sign-in flow.
+            style::framed_section(ui, "Gemini OAuth", None, |ui| {
+                self.prefs_gemini_oauth_section(ui);
+            });
+        } else {
+            let (heading, hint) = match active_provider {
+                Provider::Gemini => (
+                    "Gemini API key",
+                    "Used by Generate / Modify / Animate / Textures. \
+                     Stored in your user config directory and persists \
+                     between sessions. The $GEMINI_API_KEY environment \
+                     variable is used when this field is blank.",
+                ),
+                Provider::OpenAI => (
+                    "OpenAI API key",
+                    "Used by Generate / Modify / Animate / Ask. Stored \
+                     in your user config directory. The $OPENAI_API_KEY \
+                     environment variable is used when this field is blank.",
+                ),
+                Provider::Anthropic => (
+                    "Anthropic API key",
+                    "Used by Generate / Modify / Animate / Ask. Stored \
+                     in your user config directory. The $ANTHROPIC_API_KEY \
+                     environment variable is used when this field is blank.",
+                ),
+                Provider::Ollama => (
+                    "Ollama API key (optional)",
+                    "Optional bearer token for an Ollama endpoint behind \
+                     an authenticating proxy. Leave blank for a local install.",
+                ),
+                Provider::Fireworks => (
+                    "Fireworks AI Firepass API key",
+                    "Used by Generate / Modify / Animate / Ask. Default \
+                     model is the Fire Pass `kimi-k2p6` router (zero \
+                     per-token cost on Kimi K2 for personal agentic-coding \
+                     use). Stored in your user config directory.",
+                ),
+                Provider::Zai => (
+                    "Z.ai API key",
+                    "Used by Generate / Modify / Animate / Ask. Default \
+                     model is `glm-5.1` (Z.ai's GLM family via the \
+                     OpenAI-compatible chat API). The same key drives \
+                     the `glm-image` texture path when you set Image \
+                     provider → Z.ai.",
+                ),
+                Provider::ClaudeCode => unreachable!(),
+            };
+            style::framed_section(ui, heading, Some(hint), |ui| {
+                let key_id = egui::Id::new(("opts_api_key", active_provider.key()));
+                let key_buf: &mut String = match active_provider {
+                    Provider::Gemini => &mut self.options_api_key_draft,
+                    Provider::OpenAI => &mut self.settings.openai_api_key,
+                    Provider::Anthropic => &mut self.settings.anthropic_api_key,
+                    Provider::Ollama => &mut self.settings.ollama_api_key,
+                    Provider::Fireworks => &mut self.settings.fireworks_api_key,
+                    Provider::Zai => &mut self.settings.zai_api_key,
+                    Provider::ClaudeCode => unreachable!(),
+                };
+                crate::app::text_menu::text_edit_with_menu(
+                    ui,
+                    key_id,
+                    key_buf,
+                    |ui, text| {
                         ui.add(
-                            egui::TextEdit::singleline(&mut self.settings.ollama_base_url)
-                                .hint_text("http://localhost:11434")
-                                .desired_width(f32::INFINITY),
-                        );
-                    }
+                            egui::TextEdit::singleline(text)
+                                .password(true)
+                                .hint_text(style::placeholder(
+                                    "paste key (leave blank to clear)",
+                                ))
+                                .desired_width(f32::INFINITY)
+                                .id(key_id),
+                        )
+                    },
+                );
 
-                    let env_var = active_provider.env_var();
-                    if !env_var.is_empty()
-                        && std::env::var(env_var)
-                            .map(|v| !v.trim().is_empty())
-                            .unwrap_or(false)
-                    {
-                        ui.add_space(4.0);
-                        ui.colored_label(
-                            egui::Color32::from_rgb(150, 180, 230),
-                            format!(
-                                "{env_var} is also set in your environment — \
-                                 the saved key here takes precedence when non-empty.",
-                            ),
-                        );
-                    }
-
-                    if matches!(active_provider, Provider::Zai) {
-                        // GLM Coding Plan endpoint toggle. Default-on so users
-                        // on the coding plan land on the supported surface
-                        // (`/api/coding/paas/v4`) — the general PaaS endpoint
-                        // throws `os error 10054` (peer reset) on coding-plan
-                        // keys carrying the heavy MoGen DSL system instruction.
-                        ui.add_space(8.0);
-                        let mut on = self.settings.zai_use_coding_plan();
-                        let resp = ui.checkbox(&mut on, "Use GLM Coding Plan endpoint");
-                        resp.on_hover_text(
-                            "Routes Z.ai chat calls through `/api/coding/paas/v4` (the \
-                             dedicated endpoint Z.ai documents for tools like \
-                             Claude Code, Cline, Crush, MoGen Studio) instead of \
-                             the general `/api/paas/v4` surface. Default on. \
-                             Disable if you don't have a GLM Coding Plan \
-                             subscription on this key.",
-                        );
-                        if on != self.settings.zai_use_coding_plan() {
-                            self.settings.set_zai_use_coding_plan(on);
-                        }
-                    }
-
+                if matches!(active_provider, Provider::Ollama) {
+                    ui.add_space(6.0);
+                    ui.label("Ollama base URL (optional)").on_hover_text(
+                        "Override for self-hosted Ollama. Leave blank for the \
+                         library default (http://localhost:11434).",
+                    );
+                    ui.add(
+                        egui::TextEdit::singleline(&mut self.settings.ollama_base_url)
+                            .hint_text(style::placeholder("http://localhost:11434"))
+                            .desired_width(f32::INFINITY),
+                    );
                 }
 
-                // --- Models (provider-aware: presets and target fields swap
-                // when the LLM provider above changes) ---
-                if self
-                    .settings
-                    .thinking_model_field_mut(active_provider)
-                    .is_some()
+                let env_var = active_provider.env_var();
+                if !env_var.is_empty()
+                    && std::env::var(env_var)
+                        .map(|v| !v.trim().is_empty())
+                        .unwrap_or(false)
                 {
-                    ui.add_space(12.0);
-                    ui.heading("Models");
-                    ui.label(format!(
-                        "Thinking model runs the heavy DSL paths (generate / modify / \
-                         animate). Fast model runs cheap rewrites like the Prompt \
-                         Enhancer. Showing presets for {}.",
-                        active_slot.label(),
-                    ));
-                    ui.add_space(6.0);
-
-                    // Preview / bleeding-edge toggle. Off by default — preview
-                    // model ids can be deprecated or rate-limited without notice.
-                    // OAuth slot already pins to preview tags so the toggle is
-                    // redundant there; hide it to avoid confusion.
-                    if !active_slot.is_gemini_oauth()
-                        && preview_thinking_model(active_provider).is_some()
-                    {
-                        let mut on = self.settings.use_preview_models;
-                        if ui
-                            .checkbox(&mut on, "Use preview / bleeding-edge models")
-                            .on_hover_text(
-                                "When enabled (and no explicit override is set), \
-                                 default to the latest Gemini preview Pro / Flash \
-                                 IDs instead of the stable `*-latest` aliases. \
-                                 Preview models can be deprecated without notice.",
-                            )
-                            .changed()
-                        {
-                            self.settings.use_preview_models = on;
-                        }
-                        ui.add_space(6.0);
-                    }
-
-                    let (thinking_default, fast_default) = if active_slot.is_gemini_oauth() {
-                        (DEFAULT_OAUTH_GEMINI_MODEL, DEFAULT_OAUTH_GEMINI_FAST_MODEL)
-                    } else if self.settings.use_preview_models {
-                        (
-                            preview_thinking_model(active_provider)
-                                .unwrap_or_else(|| active_provider.default_model()),
-                            preview_fast_model(active_provider)
-                                .unwrap_or_else(|| active_provider.default_fast_model()),
-                        )
-                    } else {
-                        (active_provider.default_model(), active_provider.default_fast_model())
-                    };
-                    let presets = model_presets(active_slot);
-
-                    // --- thinking model picker ---
-                    ui.label("Thinking model").on_hover_text(
-                        "Used for generate / modify / animate and their repair loops. \
-                         Pick a preset or type a custom model id.",
+                    ui.add_space(4.0);
+                    style::info_row(
+                        ui,
+                        &format!(
+                            "{env_var} is set in your environment; the saved \
+                             key above takes precedence when non-empty.",
+                        ),
                     );
-                    let mut thinking_draft = self
-                        .settings
-                        .thinking_model_field(active_provider)
-                        .to_string();
-                    let thinking_selected = if thinking_draft.is_empty() {
-                        format!("(library default: {thinking_default})")
-                    } else {
-                        thinking_draft.clone()
-                    };
+                }
+
+                if matches!(active_provider, Provider::Zai) {
+                    // GLM Coding Plan endpoint toggle (default-on).
+                    ui.add_space(8.0);
+                    let mut on = self.settings.zai_use_coding_plan();
+                    let resp = ui.checkbox(&mut on, "Use GLM Coding Plan endpoint");
+                    resp.on_hover_text(
+                        "Routes Z.ai chat calls through `/api/coding/paas/v4` (the \
+                         dedicated endpoint Z.ai documents for tools like Claude \
+                         Code, Cline, Crush, MoGen Studio) instead of the general \
+                         `/api/paas/v4` surface. Default on. Disable if you don't \
+                         have a GLM Coding Plan subscription on this key.",
+                    );
+                    if on != self.settings.zai_use_coding_plan() {
+                        self.settings.set_zai_use_coding_plan(on);
+                    }
+                }
+            });
+        }
+
+        // ── Section 4: Models (provider-aware) ──
+        if self
+            .settings
+            .thinking_model_field_mut(active_provider)
+            .is_some()
+        {
+            let models_hint = format!(
+                "Thinking model runs the heavy DSL paths (generate / modify / \
+                 animate). Fast model runs cheap rewrites like the Prompt \
+                 Enhancer. Showing presets for {}.",
+                active_slot.label(),
+            );
+            style::framed_section(ui, "Models", Some(&models_hint), |ui| {
+                // Preview / bleeding-edge toggle. Off by default; OAuth
+                // slot pins to preview tags so the toggle is hidden there.
+                if !active_slot.is_gemini_oauth()
+                    && preview_thinking_model(active_provider).is_some()
+                {
+                    let mut on = self.settings.use_preview_models;
+                    if ui
+                        .checkbox(&mut on, "Use preview / bleeding-edge models")
+                        .on_hover_text(
+                            "When enabled (and no explicit override is set), \
+                             default to the latest Gemini preview Pro / Flash \
+                             IDs instead of the stable `*-latest` aliases. \
+                             Preview models can be deprecated without notice.",
+                        )
+                        .changed()
+                    {
+                        self.settings.use_preview_models = on;
+                    }
+                    ui.add_space(6.0);
+                }
+
+                let (thinking_default, fast_default) = if active_slot.is_gemini_oauth() {
+                    (DEFAULT_OAUTH_GEMINI_MODEL, DEFAULT_OAUTH_GEMINI_FAST_MODEL)
+                } else if self.settings.use_preview_models {
+                    (
+                        preview_thinking_model(active_provider)
+                            .unwrap_or_else(|| active_provider.default_model()),
+                        preview_fast_model(active_provider)
+                            .unwrap_or_else(|| active_provider.default_fast_model()),
+                    )
+                } else {
+                    (active_provider.default_model(), active_provider.default_fast_model())
+                };
+                let presets = model_presets(active_slot);
+
+                // --- thinking model: text field + presets dropdown in one row ---
+                ui.label("Thinking model").on_hover_text(
+                    "Used for generate / modify / animate and their repair loops. \
+                     Pick a preset from the menu or type a custom model id.",
+                );
+                let mut thinking_draft = self
+                    .settings
+                    .thinking_model_field(active_provider)
+                    .to_string();
+                ui.horizontal(|ui| {
+                    let preset_w = 96.0;
+                    let avail = ui.available_width().max(preset_w + 60.0);
+                    ui.add(
+                        egui::TextEdit::singleline(&mut thinking_draft)
+                            .hint_text(style::placeholder(thinking_default))
+                            .desired_width(avail - preset_w - 6.0),
+                    );
                     egui::ComboBox::from_id_salt((
-                        "opts_model_thinking",
+                        "opts_model_thinking_presets",
                         active_provider.key(),
                     ))
-                    .selected_text(thinking_selected)
+                    .selected_text("Presets ▾")
+                    .width(preset_w)
                     .show_ui(ui, |ui| {
                         for m in presets {
                             if ui
@@ -581,35 +655,35 @@ impl MogenStudioApp {
                             }
                         }
                     });
+                });
+                if let Some(buf) = self.settings.thinking_model_field_mut(active_provider) {
+                    *buf = thinking_draft;
+                }
+
+                ui.add_space(6.0);
+
+                // --- fast model: same row pattern ---
+                ui.label("Fast model").on_hover_text(
+                    "Used for low-stakes text rewrites like the Prompt Enhancer.",
+                );
+                let mut fast_draft = self
+                    .settings
+                    .fast_model_field(active_provider)
+                    .to_string();
+                ui.horizontal(|ui| {
+                    let preset_w = 96.0;
+                    let avail = ui.available_width().max(preset_w + 60.0);
                     ui.add(
-                        egui::TextEdit::singleline(&mut thinking_draft)
-                            .hint_text(thinking_default)
-                            .desired_width(f32::INFINITY),
+                        egui::TextEdit::singleline(&mut fast_draft)
+                            .hint_text(style::placeholder(fast_default))
+                            .desired_width(avail - preset_w - 6.0),
                     );
-                    if let Some(buf) = self.settings.thinking_model_field_mut(active_provider) {
-                        *buf = thinking_draft;
-                    }
-
-                    ui.add_space(6.0);
-
-                    // --- fast model picker ---
-                    ui.label("Fast model").on_hover_text(
-                        "Used for low-stakes text rewrites like the Prompt Enhancer.",
-                    );
-                    let mut fast_draft = self
-                        .settings
-                        .fast_model_field(active_provider)
-                        .to_string();
-                    let fast_selected = if fast_draft.is_empty() {
-                        format!("(library default: {fast_default})")
-                    } else {
-                        fast_draft.clone()
-                    };
                     egui::ComboBox::from_id_salt((
-                        "opts_model_fast",
+                        "opts_model_fast_presets",
                         active_provider.key(),
                     ))
-                    .selected_text(fast_selected)
+                    .selected_text("Presets ▾")
+                    .width(preset_w)
                     .show_ui(ui, |ui| {
                         for m in presets {
                             if ui.selectable_label(fast_draft == *m, *m).clicked() {
@@ -617,101 +691,136 @@ impl MogenStudioApp {
                             }
                         }
                     });
-                    ui.add(
-                        egui::TextEdit::singleline(&mut fast_draft)
-                            .hint_text(fast_default)
-                            .desired_width(f32::INFINITY),
-                    );
-                    if let Some(buf) = self.settings.fast_model_field_mut(active_provider) {
-                        *buf = fast_draft;
-                    }
-
-                    // --- pricing summary ---
-                    // Resolve currently-active model ids (override > preview >
-                    // default) and read their rates straight from the same
-                    // table the session meter uses. Gemini-only for now —
-                    // other providers fall through to a zero-rate row.
-                    let thinking_model = self.settings.provider_model();
-                    let fast_model = self.settings.provider_fast_model();
-                    let thinking_price = text_pricing(&thinking_model);
-                    let fast_price = text_pricing(&fast_model);
-                    let has_pricing = thinking_price.input_per_million_usd > 0.0
-                        || fast_price.input_per_million_usd > 0.0;
-
-                    if has_pricing {
-                        ui.add_space(10.0);
-                        ui.label(
-                            egui::RichText::new("Pricing (approx, USD)")
-                                .strong(),
-                        );
-                        ui.label(
-                            egui::RichText::new(
-                                "List rates from ai.google.dev/gemini-api/docs/pricing. \
-                                 The session meter shows actual cost based on token usage.",
-                            )
-                            .weak(),
-                        );
-                        ui.add_space(4.0);
-
-                        price_row(
-                            ui,
-                            "Thinking",
-                            &thinking_model,
-                            thinking_price,
-                        );
-                        if fast_price.input_per_million_usd > 0.0 {
-                            price_row(ui, "Fast", &fast_model, fast_price);
-                        }
-
-                        // Image rate (textures pipeline). Only show when the
-                        // pricing table actually knows the model — Z.ai's
-                        // `glm-image` rate isn't surfaced here.
-                        let img_model = match self.settings.image_provider() {
-                            ImageProvider::Auto
-                            | ImageProvider::ApiKey
-                            | ImageProvider::Antigravity => "gemini-2.5-flash-image",
-                            ImageProvider::ZAI => "",
-                        };
-                        let img_price = image_pricing(img_model);
-                        if img_price.per_image_usd > 0.0 {
-                            ui.add_space(2.0);
-                            ui.label(egui::RichText::new(format!(
-                                "Texture image  {img_model}  ${:.3}/image",
-                                img_price.per_image_usd,
-                            )));
-                        }
-
-                        // Typical-call envelope so users have a feel for what
-                        // a single generate / modify costs without doing the
-                        // arithmetic. ~5k input + ~3k output is what a small
-                        // example.mog round-trips at; real prompts vary.
-                        let typical_in = 5_000.0_f64;
-                        let typical_out = 3_000.0_f64;
-                        let typical_cost = typical_in
-                            * thinking_price.input_per_million_usd
-                            / 1_000_000.0
-                            + typical_out
-                                * thinking_price.output_per_million_usd
-                                / 1_000_000.0;
-                        ui.add_space(2.0);
-                        ui.label(
-                            egui::RichText::new(format!(
-                                "Typical generate (~5k in / ~3k out): ~${:.3}",
-                                typical_cost,
-                            ))
-                            .weak(),
-                        );
-                    }
+                });
+                if let Some(buf) = self.settings.fast_model_field_mut(active_provider) {
+                    *buf = fast_draft;
                 }
 
-                ui.add_space(12.0);
-                ui.heading("Thinking budget");
-                ui.label(
-                    "Cap on the model's hidden reasoning tokens per call. Higher = \
-                     better DSL on hard prompts but slower and more expensive. \
-                     Ignored by providers / models that don't expose a budget.",
-                );
-                ui.add_space(6.0);
+                // --- pricing block ---
+                // Resolve currently-active model ids (override > preview >
+                // default) and read their rates straight from the same
+                // table the session meter uses.
+                let thinking_model = self.settings.provider_model();
+                let fast_model = self.settings.provider_fast_model();
+                let thinking_price = text_pricing(&thinking_model);
+                let fast_price = text_pricing(&fast_model);
+                let has_pricing = thinking_price.input_per_million_usd > 0.0
+                    || fast_price.input_per_million_usd > 0.0;
+
+                if has_pricing {
+                    // Always-visible typical cost so users see the headline
+                    // figure without expanding the breakdown.
+                    let typical_in = 5_000.0_f64;
+                    let typical_out = 3_000.0_f64;
+                    let typical_cost = typical_in
+                        * thinking_price.input_per_million_usd
+                        / 1_000_000.0
+                        + typical_out
+                            * thinking_price.output_per_million_usd
+                            / 1_000_000.0;
+                    ui.add_space(8.0);
+                    ui.label(
+                        egui::RichText::new(format!(
+                            "Typical generate (~5k in / ~3k out): ~${:.3}",
+                            typical_cost,
+                        ))
+                        .weak(),
+                    );
+
+                    let img_model = match self.settings.image_provider() {
+                        ImageProvider::Auto
+                        | ImageProvider::ApiKey
+                        | ImageProvider::Antigravity => "gemini-2.5-flash-image",
+                        ImageProvider::ZAI => "",
+                    };
+                    let img_price = image_pricing(img_model);
+
+                    egui::CollapsingHeader::new(egui::RichText::new("Pricing breakdown").weak())
+                        .id_salt("opts_pricing_details")
+                        .default_open(false)
+                        .show(ui, |ui| {
+                            ui.label(
+                                egui::RichText::new(
+                                    "List rates from ai.google.dev/gemini-api/docs/pricing. \
+                                     The session meter shows actual cost based on token usage.",
+                                )
+                                .weak(),
+                            );
+                            ui.add_space(4.0);
+                            egui::Grid::new("opts_pricing_grid")
+                                .num_columns(5)
+                                .spacing([12.0, 4.0])
+                                .striped(true)
+                                .show(ui, |ui| {
+                                    ui.label(egui::RichText::new("Tier").strong());
+                                    ui.label(egui::RichText::new("Model").strong());
+                                    ui.label(egui::RichText::new("In").strong());
+                                    ui.label(egui::RichText::new("Out").strong());
+                                    ui.label(egui::RichText::new("Cached").strong());
+                                    ui.end_row();
+
+                                    price_grid_row(
+                                        ui,
+                                        "Thinking",
+                                        &thinking_model,
+                                        thinking_price,
+                                        false,
+                                    );
+                                    if thinking_price.is_tiered() {
+                                        price_grid_row(
+                                            ui,
+                                            "  >200k",
+                                            &thinking_model,
+                                            thinking_price,
+                                            true,
+                                        );
+                                    }
+                                    if fast_price.input_per_million_usd > 0.0 {
+                                        price_grid_row(
+                                            ui,
+                                            "Fast",
+                                            &fast_model,
+                                            fast_price,
+                                            false,
+                                        );
+                                        if fast_price.is_tiered() {
+                                            price_grid_row(
+                                                ui,
+                                                "  >200k",
+                                                &fast_model,
+                                                fast_price,
+                                                true,
+                                            );
+                                        }
+                                    }
+                                    if img_price.per_image_usd > 0.0 {
+                                        ui.label("Image");
+                                        ui.label(img_model);
+                                        ui.label(format!(
+                                            "${:.3}/image",
+                                            img_price.per_image_usd,
+                                        ));
+                                        ui.label("");
+                                        ui.label("");
+                                        ui.end_row();
+                                    }
+                                });
+                        });
+                }
+            });
+        }
+
+        // ── Section 5: Thinking budget ──
+        style::framed_section(
+            ui,
+            "Thinking budget",
+            Some(
+                "Cap on the model's hidden reasoning tokens per call. \
+                 Higher = better DSL on hard prompts but slower and more \
+                 expensive. Ignored by providers / models that don't \
+                 expose a budget.",
+            ),
+            |ui| {
                 let current = self.settings.thinking_level();
                 egui::ComboBox::from_id_salt("opts_thinking_level")
                     .selected_text(thinking_level_label(current))
@@ -728,108 +837,127 @@ impl MogenStudioApp {
                             }
                         }
                     });
+            },
+        );
 
-                ui.add_space(12.0);
-                egui::CollapsingHeader::new("Advanced (sampling, repair, seed)")
-                    .id_salt("opts_advanced")
-                    .default_open(false)
-                    .show(ui, |ui| {
+        // ── Section 6: Advanced (sampling, repair, seed) ──
+        ui.add_space(6.0);
+        egui::CollapsingHeader::new(
+            egui::RichText::new("Advanced (sampling, repair, seed)").strong(),
+        )
+        .id_salt("opts_advanced")
+        .default_open(false)
+        .show(ui, |ui| {
+            // --- temperature ---
+            ui.label("Temperature").on_hover_text(
+                "Sampling temperature (0 = deterministic, 2 = chaotic). \
+                 The DSL generator is happier at low values; raise it only \
+                 if you want stylistic variation.",
+            );
+            let mut temp = self
+                .settings
+                .gemini_temperature
+                .unwrap_or(mogen_llm::gemini::DEFAULT_TEMPERATURE);
+            ui.horizontal(|ui| {
+                let resp = ui.add(
+                    egui::Slider::new(&mut temp, 0.0..=2.0)
+                        .max_decimals(2)
+                        .text("°"),
+                )
+                .on_hover_text(
+                    "0 = deterministic, 2 = chaotic. Default 0.3.",
+                );
+                if resp.changed() {
+                    self.settings.gemini_temperature = Some(temp);
+                }
+                if ui
+                    .small_button("Reset")
+                    .on_hover_text("Restore the library default (0.3)")
+                    .clicked()
+                {
+                    self.settings.gemini_temperature = None;
+                }
+            });
 
-                        // --- temperature ---
-                        ui.label("Temperature")
-                            .on_hover_text(
-                                "Sampling temperature (0 = deterministic, 2 = chaotic). \
-                                 The DSL generator is happier at low values; raise it only \
-                                 if you want stylistic variation.",
-                            );
-                        let mut temp =
-                            self.settings.gemini_temperature.unwrap_or(
-                                mogen_llm::gemini::DEFAULT_TEMPERATURE,
-                            );
-                        if ui
-                            .add(
-                                egui::Slider::new(&mut temp, 0.0..=2.0)
-                                    .fixed_decimals(2)
-                                    .text("°"),
-                            )
-                            .changed()
-                        {
-                            self.settings.gemini_temperature = Some(temp);
-                        }
-                        if ui
-                            .small_button("Reset")
-                            .on_hover_text("Restore the library default (0.3)")
-                            .clicked()
-                        {
-                            self.settings.gemini_temperature = None;
-                        }
+            ui.add_space(6.0);
 
-                        ui.add_space(6.0);
+            // --- max repair iters ---
+            ui.label("Max repair iterations").on_hover_text(
+                "How many times to re-call the active provider when the \
+                 generated DSL fails validation. Higher = more API cost \
+                 but fewer invalid outputs. Range 0–5.",
+            );
+            let mut iters = self
+                .settings
+                .max_repair_iters
+                .unwrap_or(DEFAULT_MAX_REPAIR_ITERS);
+            if ui
+                .add(
+                    egui::DragValue::new(&mut iters)
+                        .range(0..=5)
+                        .speed(0.1),
+                )
+                .on_hover_text("Range 0–5.")
+                .changed()
+            {
+                self.settings.max_repair_iters = Some(iters);
+            }
 
-                        // --- max repair iters ---
-                        ui.label("Max repair iterations")
-                            .on_hover_text(
-                                "How many times to re-call the active provider when the \
-                                 generated DSL fails validation. Higher = more API cost but \
-                                 fewer invalid outputs.",
-                            );
-                        let mut iters =
-                            self.settings.max_repair_iters.unwrap_or(DEFAULT_MAX_REPAIR_ITERS);
-                        if ui
-                            .add(
-                                egui::DragValue::new(&mut iters)
-                                    .range(0..=5)
-                                    .speed(0.1),
-                            )
-                            .changed()
-                        {
-                            self.settings.max_repair_iters = Some(iters);
-                        }
+            ui.add_space(6.0);
 
-                        ui.add_space(6.0);
-
-                        // --- seed override ---
-                        ui.label("Seed")
-                            .on_hover_text(
-                                "Deterministic seed stamped on every generated .mog header. \
-                                 Set to reproduce a prior run; clear for a fresh seed each call.",
-                            );
-                        ui.horizontal(|ui| {
-                            let mut seed_str = self
-                                .settings
-                                .seed_override
-                                .map(|s| s.to_string())
-                                .unwrap_or_default();
-                            let resp = ui.add(
-                                egui::TextEdit::singleline(&mut seed_str)
-                                    .hint_text("(random each call)")
-                                    .desired_width(160.0),
-                            );
-                            if resp.changed() {
-                                let trimmed = seed_str.trim();
-                                self.settings.seed_override = if trimmed.is_empty() {
-                                    None
-                                } else {
-                                    trimmed.parse::<u64>().ok()
-                                };
-                            }
-                            if ui
-                                .small_button("🎲")
-                                .on_hover_text("Pick a random seed now")
-                                .clicked()
-                            {
-                                self.settings.seed_override =
-                                    Some(crate::app::util::pick_default_seed());
-                            }
-                            if ui
-                                .small_button("Clear")
-                                .on_hover_text("Use a fresh random seed on every call")
-                                .clicked()
-                            {
-                                self.settings.seed_override = None;
-                            }
-                        });
-                    });
+            // --- seed override ---
+            ui.label("Seed").on_hover_text(
+                "Deterministic seed stamped on every generated .mog header. \
+                 Set to reproduce a prior run; clear for a fresh seed each \
+                 call. Must be a non-negative integer.",
+            );
+            ui.horizontal(|ui| {
+                let mut seed_str = self
+                    .settings
+                    .seed_override
+                    .map(|s| s.to_string())
+                    .unwrap_or_default();
+                let resp = ui.add(
+                    egui::TextEdit::singleline(&mut seed_str)
+                        .hint_text(style::placeholder("(random each call)"))
+                        .desired_width(160.0),
+                );
+                let trimmed = seed_str.trim().to_string();
+                let parse_result =
+                    if trimmed.is_empty() { Ok(None) } else {
+                        trimmed.parse::<u64>().map(Some)
+                    };
+                if resp.changed() {
+                    self.settings.seed_override = match &parse_result {
+                        Ok(v) => *v,
+                        Err(_) => self.settings.seed_override,
+                    };
+                }
+                if ui
+                    .small_button("🎲")
+                    .on_hover_text("Pick a random seed now")
+                    .clicked()
+                {
+                    self.settings.seed_override =
+                        Some(crate::app::util::pick_default_seed());
+                }
+                if ui
+                    .small_button("Clear")
+                    .on_hover_text("Use a fresh random seed on every call")
+                    .clicked()
+                {
+                    self.settings.seed_override = None;
+                }
+                // Inline validation feedback so users know why a typo
+                // didn't take effect — matches the new_prompt dialog.
+                if !trimmed.is_empty() && parse_result.is_err() {
+                    ui.label(
+                        egui::RichText::new("not a valid u64")
+                            .color(ui.visuals().warn_fg_color),
+                    );
+                }
+            });
+        });
     }
 
     /// Gemini OAuth section. Shown when the active slot is `GeminiOAuth`.

--- a/crates/mogen-studio/src/app/ui_llm/enhance.rs
+++ b/crates/mogen-studio/src/app/ui_llm/enhance.rs
@@ -30,11 +30,12 @@ impl MogenStudioApp {
         };
 
         ui.horizontal(|ui| {
-            if ui
-                .add_enabled(can_run, egui::Button::new("✨ Enhance"))
-                .on_hover_text(hover)
-                .clicked()
-            {
+            // Icon-only secondary affordance — Enhance shouldn't compete
+            // visually with the canonical primary action (Modify / Animate /
+            // Generate Textures) it sits next to. Tooltip carries the
+            // intent.
+            let btn = egui::Button::new(egui::RichText::new("✨"));
+            if ui.add_enabled(can_run, btn).on_hover_text(hover).clicked() {
                 let ctx = ui.ctx().clone();
                 self.start_prompt_enhance(ctx, target);
             }
@@ -49,7 +50,7 @@ impl MogenStudioApp {
             } else if !has_key {
                 ui.label(
                     egui::RichText::new("no API key")
-                        .color(egui::Color32::from_rgb(230, 200, 100)),
+                        .color(ui.visuals().warn_fg_color),
                 );
             }
         });

--- a/crates/mogen-studio/src/app/ui_llm/main.rs
+++ b/crates/mogen-studio/src/app/ui_llm/main.rs
@@ -1,5 +1,6 @@
 use eframe::egui;
 
+use crate::app::style;
 use crate::app::types::EnhanceTarget;
 use crate::app::MogenStudioApp;
 
@@ -31,7 +32,7 @@ impl MogenStudioApp {
             // (paste / env var) gets its own line.
             let provider = self.settings.provider().display_name();
             ui.colored_label(
-                egui::Color32::from_rgb(230, 200, 100),
+                ui.visuals().warn_fg_color,
                 format!("{provider}: no API key — every LLM action below is disabled."),
             );
             ui.label(
@@ -79,7 +80,7 @@ impl MogenStudioApp {
 
         // Generate lives in the File → New from Prompt modal now; the
         // inspector only exposes transformations of the current MOG file.
-        ui.label("Modify current:");
+        ui.label("Modify this file");
         let mod_id = egui::Id::new(("mog_llm_mod_prompt", self.active));
         crate::app::text_menu::text_edit_with_menu(
             ui,
@@ -88,7 +89,7 @@ impl MogenStudioApp {
             |ui, text| {
                 ui.add(
                     egui::TextEdit::multiline(text)
-                        .hint_text("e.g. make the legs taller")
+                        .hint_text(style::placeholder("e.g. make the legs taller"))
                         .desired_rows(4)
                         .desired_width(f32::INFINITY)
                         .id(mod_id),
@@ -103,7 +104,7 @@ impl MogenStudioApp {
         ]);
         ui.horizontal(|ui| {
             let resp = ui
-                .add_enabled(mod_enabled, egui::Button::new("Modify"))
+                .add_enabled(mod_enabled, style::primary_button(ui, "Modify"))
                 .on_hover_text(
                     mod_reason
                         .as_deref()
@@ -116,12 +117,13 @@ impl MogenStudioApp {
             self.ui_enhance_button(
                 ui,
                 EnhanceTarget::Modify,
-                "Rewrite the Modify prompt with the fast model",
+                "Rewrite the Modify prompt with the fast model — \
+                 the model expands and clarifies your prompt before sending.",
             );
         });
 
         ui.add_space(8.0);
-        ui.label("Animate current:");
+        ui.label("Animate this file");
         let anim_id = egui::Id::new(("mog_llm_anim_prompt", self.active));
         crate::app::text_menu::text_edit_with_menu(
             ui,
@@ -130,7 +132,7 @@ impl MogenStudioApp {
             |ui, text| {
                 ui.add(
                     egui::TextEdit::multiline(text)
-                        .hint_text("e.g. spin the rotor at 120 rpm")
+                        .hint_text(style::placeholder("e.g. spin the rotor at 120 rpm"))
                         .desired_rows(4)
                         .desired_width(f32::INFINITY)
                         .id(anim_id),
@@ -145,7 +147,7 @@ impl MogenStudioApp {
         ]);
         ui.horizontal(|ui| {
             let resp = ui
-                .add_enabled(anim_enabled, egui::Button::new("Animate"))
+                .add_enabled(anim_enabled, style::primary_button(ui, "Animate"))
                 .on_hover_text(
                     anim_reason
                         .as_deref()
@@ -158,7 +160,8 @@ impl MogenStudioApp {
             self.ui_enhance_button(
                 ui,
                 EnhanceTarget::Animate,
-                "Rewrite the Animate prompt with the fast model",
+                "Rewrite the Animate prompt with the fast model — \
+                 the model expands and clarifies your prompt before sending.",
             );
         });
 
@@ -178,7 +181,7 @@ impl MogenStudioApp {
             })
             .unwrap_or(0);
         let provider_name = self.settings.provider().display_name();
-        ui.label("Repair current:");
+        ui.label("Repair this file");
         ui.label(
             egui::RichText::new(format!(
                 "hand the current file's validation errors back to {provider_name} — \
@@ -208,7 +211,7 @@ impl MogenStudioApp {
             "Feed the diagnostics (with spans and fix hints) back to {provider_name}"
         );
         if ui
-            .add_enabled(repair_enabled, egui::Button::new(repair_label))
+            .add_enabled(repair_enabled, style::primary_button(ui, &repair_label))
             .on_hover_text(repair_reason.as_deref().unwrap_or(&repair_default_tip))
             .clicked()
         {
@@ -230,7 +233,7 @@ impl MogenStudioApp {
             .as_ref()
             .map(|r| r.scene.is_some() && !mogen_core::has_errors(&r.diagnostics))
             .unwrap_or(false);
-        ui.label("Refine current:");
+        ui.label("Refine this file");
         ui.label(
             egui::RichText::new(format!(
                 "render the current scene, hand it back to {provider_name} with the \
@@ -293,7 +296,7 @@ impl MogenStudioApp {
                 format!("Refine {iters}×")
             };
             if ui
-                .add_enabled(refine_enabled, egui::Button::new(refine_label))
+                .add_enabled(refine_enabled, style::primary_button(ui, &refine_label))
                 .on_hover_text(refine_tip)
                 .clicked()
             {
@@ -325,7 +328,7 @@ impl MogenStudioApp {
 
         if !provider_supports_images {
             ui.colored_label(
-                egui::Color32::from_rgb(230, 200, 100),
+                ui.visuals().warn_fg_color,
                 format!(
                     "{provider_name} has no vision input — switch to Gemini or Z.ai to enable Refine",
                 ),
@@ -333,7 +336,7 @@ impl MogenStudioApp {
         }
 
         ui.add_space(8.0);
-        ui.label("Textures:");
+        ui.label("Textures");
         ui.label(
             egui::RichText::new(
                 "generates a base_color PNG per material, writes to ./textures/ \
@@ -371,7 +374,7 @@ impl MogenStudioApp {
                             |ui, text| {
                                 ui.add(
                                     egui::TextEdit::singleline(text)
-                                        .hint_text("photorealistic")
+                                        .hint_text(style::placeholder("photorealistic"))
                                         .desired_width(f32::INFINITY)
                                         .id(style_id),
                                 )
@@ -440,7 +443,10 @@ impl MogenStudioApp {
             );
         }
         if ui
-            .add_enabled(tex_enabled, egui::Button::new("Generate Textures"))
+            .add_enabled(
+                tex_enabled,
+                style::primary_button(ui, "Generate Textures"),
+            )
             .on_hover_text(tex_reason.as_deref().unwrap_or(
                 "Run the textures pipeline with the options above. \
                  Writes PNGs to ./textures/ next to the .mog.",
@@ -452,7 +458,7 @@ impl MogenStudioApp {
         }
         if !has_path && !src_empty {
             ui.colored_label(
-                egui::Color32::from_rgb(230, 200, 100),
+                ui.visuals().warn_fg_color,
                 "save the file first — textures writes PNGs next to it",
             );
         }

--- a/crates/mogen-studio/src/app/ui_llm/thinking.rs
+++ b/crates/mogen-studio/src/app/ui_llm/thinking.rs
@@ -19,8 +19,9 @@ impl MogenStudioApp {
                 .on_hover_text(
                     "Per-file cap on the model's reasoning budget (applies to \
                      providers / models that support a thinking budget). \
-                     Saved into the .mog header so it applies to CLI runs too. \
-                     Leave as \"Use global default\" to defer to Options.",
+                     Saved into the .mog header (meta thinking=…) so it \
+                     applies to CLI runs too. Leave as \"Use global default\" \
+                     to defer to Options.",
                 );
             egui::ComboBox::from_id_salt(("mog_thinking_override", self.active))
                 .selected_text(preview)
@@ -42,14 +43,12 @@ impl MogenStudioApp {
                             self.active_mut().thinking_override = Some(level);
                         }
                     }
-                });
-            // Tiny hint about how the override is persisted. Quiet so it
-            // doesn't shout at users who never touched the dropdown.
-            if current.is_some() {
-                ui.label(
-                    egui::RichText::new("(saved in file header)").weak(),
+                })
+                .response
+                .on_hover_text(
+                    "Saved into the .mog header so the same budget applies \
+                     to CLI runs of this file.",
                 );
-            }
         });
     }
 }

--- a/crates/mogen-studio/src/app/ui_panels/animation.rs
+++ b/crates/mogen-studio/src/app/ui_panels/animation.rs
@@ -2,6 +2,7 @@ use std::time::Instant;
 
 use eframe::egui;
 
+use crate::app::style;
 use crate::app::types::UndoKey;
 use crate::app::util::{find_clip_source_span, origin_in_visible_set, visible_origins};
 use crate::app::MogenStudioApp;
@@ -88,16 +89,21 @@ impl MogenStudioApp {
             {
                 self.viewer.reset_anim_times();
             }
+            // Visual divider between transport controls (Pause / Reset) and
+            // the bulk-selection controls (All / None) so the two button
+            // clusters don't read as one undifferentiated row.
+            ui.separator();
+            ui.label(egui::RichText::new("Enable:").weak());
             if ui
                 .button("All")
-                .on_hover_text("Activate every clip")
+                .on_hover_text("Enable every clip")
                 .clicked()
             {
                 self.viewer.set_all_clips_active(true);
             }
             if ui
                 .button("None")
-                .on_hover_text("Deactivate every clip")
+                .on_hover_text("Disable every clip")
                 .clicked()
             {
                 self.viewer.set_all_clips_active(false);
@@ -113,17 +119,21 @@ impl MogenStudioApp {
             let resp = ui.add(
                 egui::Slider::new(&mut speed, -2.0..=4.0)
                     .suffix("×")
-                    .fixed_decimals(2)
+                    .max_decimals(2)
                     .clamping(egui::SliderClamping::Always),
             );
             if resp.changed() {
                 self.viewer.set_playback_speed(speed);
             }
-            if ui
-                .button("1×")
-                .on_hover_text("Reset playback speed to real time")
-                .clicked()
-                && (speed - 1.0).abs() > f32::EPSILON
+            // Reset button only appears when the slider is off-default; at
+            // 1× the readout already says so and a "1×" button next to a
+            // "1.00×" readout is just visual redundancy.
+            let at_default = (speed - 1.0).abs() < f32::EPSILON;
+            if !at_default
+                && ui
+                    .button("Reset to 1×")
+                    .on_hover_text("Reset playback speed to real time")
+                    .clicked()
             {
                 self.viewer.set_playback_speed(1.0);
             }
@@ -133,7 +143,7 @@ impl MogenStudioApp {
                 "paused"
             } else if speed < 0.0 {
                 "reverse"
-            } else if (speed - 1.0).abs() < 0.005 {
+            } else if at_default {
                 "real time"
             } else if speed > 1.0 {
                 "fast"
@@ -143,12 +153,16 @@ impl MogenStudioApp {
             ui.label(egui::RichText::new(format!("({tag})")).weak());
         });
 
-        ui.add_space(4.0);
+        // Bigger gap separates the toolbar above from the clip list below;
+        // inside the loop, a smaller add_space splits cards from each other.
+        ui.add_space(8.0);
         let file_i = self.active;
         let mut pending_delete: Option<String> = None;
+        let warn_color = style::accent_warn(&ui.style().visuals);
         for i in visible_clip_indices {
             let c = &clips[i];
             ui.group(|ui| {
+                // Row 1: enable + name + (right-aligned) delete affordance.
                 ui.horizontal(|ui| {
                     let mut on = active[i];
                     if ui
@@ -158,10 +172,64 @@ impl MogenStudioApp {
                     {
                         self.viewer.set_clip_active(i, on);
                     }
-                    ui.label(&c.name);
+                    ui.label(egui::RichText::new(&c.name).strong());
+                    let span = find_clip_source_span(&self.files[file_i].source, &c.name);
+                    let pending_for_this =
+                        self.clip_delete_pending.as_deref() == Some(c.name.as_str());
+                    ui.with_layout(
+                        egui::Layout::right_to_left(egui::Align::Center),
+                        |ui| {
+                            // Two-step confirm: first click latches a pending
+                            // state and turns the trash icon into a tinted
+                            // "Delete?" chip; second click commits. Any other
+                            // click in the panel clears the latch (handled
+                            // below by resetting on the catch-all).
+                            let (label, fill, tip) = if pending_for_this {
+                                (
+                                    egui::RichText::new("Delete?").strong(),
+                                    Some(warn_color),
+                                    "Click again to delete this clip",
+                                )
+                            } else if span.is_some() {
+                                (
+                                    egui::RichText::new("🗑"),
+                                    None,
+                                    "Delete this clip from the DSL source",
+                                )
+                            } else {
+                                (
+                                    egui::RichText::new("🗑"),
+                                    None,
+                                    "This clip has no authored source to delete\n\
+                                     (procedural template with multiple targets)",
+                                )
+                            };
+                            let mut btn = egui::Button::new(label).small();
+                            if let Some(c) = fill {
+                                btn = btn.fill(c);
+                            }
+                            let resp = ui
+                                .add_enabled(span.is_some(), btn)
+                                .on_hover_text(tip);
+                            if resp.clicked() {
+                                if pending_for_this {
+                                    pending_delete = Some(c.name.clone());
+                                    self.clip_delete_pending = None;
+                                } else {
+                                    self.clip_delete_pending = Some(c.name.clone());
+                                }
+                            }
+                        },
+                    );
+                });
+
+                // Row 2: meta line — duration and (optional) import origin
+                // tag. Indented past the checkbox column so the eye reads
+                // them as belonging to the clip name above.
+                ui.horizontal(|ui| {
+                    ui.add_space(20.0);
                     ui.label(
-                        egui::RichText::new(format!("{:.2}s", c.duration))
-                            .weak(),
+                        egui::RichText::new(style::format_seconds(c.duration)).weak(),
                     );
                     if let Some(p) = &c.origin {
                         let stem = p
@@ -169,44 +237,32 @@ impl MogenStudioApp {
                             .and_then(|s| s.to_str())
                             .unwrap_or("import");
                         ui.label(
-                            egui::RichText::new(format!("⤴ {stem}"))
-                                .weak(),
+                            egui::RichText::new(format!("⤴ {stem}")).weak(),
                         )
                         .on_hover_text(p.to_string_lossy());
                     }
-                    // Delete: splice the authored clip (or procedural-template
-                    // node that produced it) out of the source. Disabled when
-                    // no matching AST node is found — multi-target templates
-                    // produce `name_0`/`name_1`/… clips whose names don't map
-                    // back to a single authored node.
-                    let span = find_clip_source_span(&self.files[file_i].source, &c.name);
-                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        let btn = egui::Button::new("🗑").small();
-                        let resp = ui.add_enabled(span.is_some(), btn).on_hover_text(
-                            if span.is_some() {
-                                "Delete this clip from the DSL source"
-                            } else {
-                                "This clip has no authored source to delete\n\
-                                 (procedural template with multiple targets)"
-                            },
-                        );
-                        if resp.clicked() {
-                            pending_delete = Some(c.name.clone());
-                        }
-                    });
                 });
+
+                // Row 3: scrub slider. Outside-label pattern matches LOD
+                // scale and Speed for visual consistency; suffix " s" so the
+                // numeric readout is self-describing.
+                ui.add_space(2.0);
                 let dur = c.duration.max(0.001);
                 let mut t = times[i].clamp(0.0, dur);
-                let resp = ui.add(
-                    egui::Slider::new(&mut t, 0.0..=dur)
-                        .text("t")
-                        .clamping(egui::SliderClamping::Always)
-                        .fixed_decimals(2),
-                );
-                if resp.changed() {
-                    self.viewer.seek_clip(i, t);
-                }
+                ui.horizontal(|ui| {
+                    ui.label("Time");
+                    let resp = ui.add(
+                        egui::Slider::new(&mut t, 0.0..=dur)
+                            .suffix(" s")
+                            .clamping(egui::SliderClamping::Always)
+                            .max_decimals(2),
+                    );
+                    if resp.changed() {
+                        self.viewer.seek_clip(i, t);
+                    }
+                });
             });
+            ui.add_space(4.0);
         }
         if let Some(name) = pending_delete {
             use crate::edit;

--- a/crates/mogen-studio/src/app/ui_panels/summary.rs
+++ b/crates/mogen-studio/src/app/ui_panels/summary.rs
@@ -150,17 +150,21 @@ impl MogenStudioApp {
         let current = edit::get_lod_scale(&self.files[i].source).unwrap_or(1.0);
         let mut draft = current;
         ui.add_space(6.0);
+        let lod_hint =
+            "Multiplies primitive default segment/ring counts.\n\
+             Per-primitive `segments=`/`rings=` overrides still win.";
         let resp = ui
-            .add(
-                egui::Slider::new(&mut draft, 0.25..=4.0)
-                    .text("LOD scale")
-                    .logarithmic(true)
-                    .fixed_decimals(2),
-            )
-            .on_hover_text(
-                "Multiplies primitive default segment/ring counts.\n\
-                 Per-primitive `segments=`/`rings=` overrides still win.",
-            );
+            .horizontal(|ui| {
+                ui.label("LOD scale").on_hover_text(lod_hint);
+                ui.add(
+                    egui::Slider::new(&mut draft, 0.25..=4.0)
+                        .suffix("×")
+                        .logarithmic(true)
+                        .max_decimals(2),
+                )
+                .on_hover_text(lod_hint)
+            })
+            .inner;
         if resp.drag_stopped() || (resp.changed() && !resp.dragged()) {
             let snapped = (draft * 100.0).round() / 100.0;
             if (snapped - current).abs() > 1e-3 {


### PR DESCRIPTION
## Summary
This PR significantly redesigns the Preferences dialog with improved layout, visual hierarchy, and responsive behavior. It also introduces a new `style` module that centralizes UI styling helpers used across dialogs and panels, replacing ad-hoc color and formatting choices with theme-aware utilities.

## Key Changes

### Preferences Dialog Redesign
- **Responsive layout**: Dialog now resizes based on available screen space (360–720px width, capped height with scrolling body)
- **Backdrop scrim**: Added semi-transparent background overlay to visually separate the modal from side panels
- **Tab styling**: Active tab now has an underline accent bar instead of relying on selection state alone; tab labels are bolded when active
- **Scrollable body**: Content area scrolls independently while tab strip and footer remain pinned
- **Right-aligned footer**: Save/Cancel buttons now use right-to-left layout with Save styled as a primary button
- **Framed sections**: LLM provider, image generation, auth, and models sections now use a consistent framed block style with optional ⓘ tooltips for long-form hints
- **Refactored pricing display**: `price_row()` renamed to `price_grid_row()` and restructured to render individual grid cells instead of multi-line labels, supporting both headline and >200k tier rates

### New Style Module (`crate::app::style`)
- `accent_primary()`: Theme-derived primary action color (mirrors selection fill)
- `accent_info()`: Hyperlink-based informational accent for ⓘ glyphs
- `accent_warn()`: Warning accent for two-step confirm states
- `primary_button()`: Factory for filled accent buttons (canonical actions)
- `placeholder()`: Dim italic hint text for TextEdit fields
- `section()`: Collapsible section header for inspector panels
- `framed_section()`: Framed block with title, optional tooltip, and body content
- `info_row()`: Inline ⓘ + weak-text hint row (replaces colored_label for non-alert info)

### Animation Panel Improvements
- Added visual divider (separator) between transport controls and bulk-selection controls
- "All/None" buttons now labeled with "Enable:" prefix for clarity
- Playback speed slider changed from `fixed_decimals(2)` to `max_decimals(2)` for cleaner display
- Reset button only appears when speed is off-default (1×), reducing visual redundancy
- Clip cards now show clip name in bold; delete affordance uses two-step confirm with pending state latch
- Improved spacing: 8px gap between toolbar and clip list, 4px between cards

### Other UI Refinements
- LLM panel: Changed "Modify current:" to "Modify this file" for clarity; warning color now uses `visuals.warn_fg_color` instead of hardcoded RGB
- Hint text throughout now uses `style::placeholder()` for consistent italic + weak styling
- Environment variable precedence notes now use `style::info_row()` instead of `colored_label()`
- Ollama base URL field now uses placeholder helper
- Z.ai environment variable note refactored to use info_row
- Summary panel LOD scale slider tooltip improved with line breaks

### Type System
- `PrefsTab` enum now derives `Hash` in addition to existing derives, enabling use as a salt in egui IDs

### State Management
- Added `clip_delete_pending: Option<String>` field to `MogenStudioApp` to track two-step confirm state for clip deletion

## Implementation Details
- All color choices now derive from the active theme's `Visuals` rather than hardcoded RGB values, ensuring consistency across Dark/Nord/Sunset/Light/High-Contrast themes
- The pricing grid refactor enables future table-like layouts for pricing breakdowns
- ScrollArea uses `id_salt` with the active tab to maintain independent scroll positions per tab
- Dialog sizing uses `clamp()` to adapt gracefully from 360px (minimum usable) to 720px (comfortable reading width) based on available screen space

https://claude.ai/code/session_01PD9S3epqDwThCSD5DeGXqX