### PR TITLE
fix(studio): truncate LLM progress headline + Shift+Tab in autocomplete

### DIFF
--- a/crates/mogen-studio/src/app/autocomplete.rs
+++ b/crates/mogen-studio/src/app/autocomplete.rs
@@ -39,6 +39,14 @@ impl MogenStudioApp {
                 action = AutocompleteKey::MoveUp;
                 return;
             }
+            // Shift+Tab is the conventional reverse-navigation key in
+            // completion popups (Tab moves to the next match, Shift+Tab to
+            // the previous). Consumed before indent.rs sees it so the popup
+            // stays in front of the dedent shortcut while it's open.
+            if i.consume_key(egui::Modifiers::SHIFT, egui::Key::Tab) {
+                action = AutocompleteKey::MoveUp;
+                return;
+            }
             if i.consume_key(egui::Modifiers::NONE, egui::Key::Tab)
                 || i.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
             {

--- a/crates/mogen-studio/src/app/ui_llm/progress.rs
+++ b/crates/mogen-studio/src/app/ui_llm/progress.rs
@@ -33,11 +33,12 @@ impl MogenStudioApp {
             .inner_margin(egui::Margin::symmetric(10.0, 8.0))
             .show(ui, |ui| {
                 // ── header row: pill · stage caption · elapsed time ─────
+                // Reserve the right-side elapsed slot first via a
+                // right-to-left layout so a long headline truncates instead of
+                // sliding under the timer.
                 ui.horizontal(|ui| {
                     draw_kind_pill(ui, kind, accent);
                     ui.add_space(6.0);
-                    ui.spinner();
-                    ui.label(egui::RichText::new(stage_headline(&progress, kind, provider)));
                     ui.with_layout(
                         egui::Layout::right_to_left(egui::Align::Center),
                         |ui| {
@@ -47,7 +48,20 @@ impl MogenStudioApp {
                                         .monospace()
                                         .weak(),
                                 );
+                                ui.add_space(8.0);
                             }
+                            ui.with_layout(
+                                egui::Layout::left_to_right(egui::Align::Center),
+                                |ui| {
+                                    ui.spinner();
+                                    ui.add(
+                                        egui::Label::new(egui::RichText::new(
+                                            stage_headline(&progress, kind, provider),
+                                        ))
+                                        .truncate(),
+                                    );
+                                },
+                            );
                         },
                     );
                 });


### PR DESCRIPTION
## Summary

- **LLM progress card header now truncates** the stage caption instead of letting long strings (e.g. `repair 2/2 — 1 error → re-calling Gemini`) slide under the right-aligned elapsed-time label. The fix reserves the timer slot first via a right-to-left layout, then renders the spinner + headline in the remaining width with a truncating `Label`.
- **Autocomplete popup now responds to Shift+Tab** as `MoveUp`, the conventional reverse of `Tab` = accept/next match. Previously it only consumed plain `Tab`, so Shift+Tab fell through to `indent.rs` (which early-returns while the popup is open) and either did nothing or risked focus escape. Plain Shift+Tab dedent in the source editor is unchanged.

## Test plan

- [ ] Trigger a `modify` run that hits the repair loop and confirm the elapsed time on the right (`56s`, `1m 02s`, …) stays fully visible — long captions ellipsize.
- [ ] Open the autocomplete popup in the editor and verify Tab → next, Shift+Tab → previous, ArrowDown/ArrowUp still work, and Enter still accepts.
- [ ] With the popup closed, Shift+Tab still dedents the current line / multi-line selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)