### PR TITLE
feat(studio): expand right-sidebar GUI configuration coverage

### DIFF
--- a/crates/mogen-studio/src/app.rs
+++ b/crates/mogen-studio/src/app.rs
@@ -354,6 +354,28 @@ pub struct MogenStudioApp {
     /// board.
     inspector_scale_linked: bool,
 
+    /// Per-file in-progress draft buffers for the Meta editor's name /
+    /// description fields. Keyed by file index. Without these the TextEdit
+    /// would clobber the user's keystroke each frame because the bound
+    /// String is rebuilt from `read_meta_attr` on every paint.
+    pub(in crate::app) meta_name_drafts: HashMap<usize, String>,
+    pub(in crate::app) meta_desc_drafts: HashMap<usize, String>,
+    /// Per-material rename buffer keyed by current material name. Same
+    /// pattern as the meta drafts — the bound String would be rebuilt from
+    /// the parsed material name each frame and clobber typing otherwise.
+    pub(in crate::app) material_name_drafts: HashMap<String, String>,
+    /// Per-clip rename / duration draft buffers keyed by clip name. Cleared
+    /// when the rename / duration commits.
+    pub(in crate::app) clip_name_drafts: HashMap<String, String>,
+    pub(in crate::app) clip_duration_drafts: HashMap<String, String>,
+
+    /// Currently-selected procedural-clip kind in the Animation panel's
+    /// "Add clip" row. Persisted globally because the user typically iterates
+    /// on the same kind across clicks.
+    pub(in crate::app) add_clip_kind: String,
+    /// Target node-name draft for the same row.
+    pub(in crate::app) add_clip_target: String,
+
     /// Custom file picker modal state. `Some(_)` while the picker is open;
     /// cleared by confirm or cancel. Replaces the native `rfd` dialog for
     /// Open / Import / Save As so the body can render thumbnail previews.
@@ -532,6 +554,13 @@ impl MogenStudioApp {
             show_video_options: false,
             video_opts_draft: self::generate::VideoOptions::default(),
             inspector_scale_linked: true,
+            meta_name_drafts: HashMap::new(),
+            meta_desc_drafts: HashMap::new(),
+            material_name_drafts: HashMap::new(),
+            clip_name_drafts: HashMap::new(),
+            clip_duration_drafts: HashMap::new(),
+            add_clip_kind: "spin".into(),
+            add_clip_target: String::new(),
             picker: None,
             thumbnail_mgr: thumbnail::ThumbnailManager::new(cc.egui_ctx.clone()),
             picker_prev_camera: None,
@@ -857,6 +886,7 @@ impl eframe::App for MogenStudioApp {
                         if self.has_visible_clips() {
                             style::section(ui, "Animation", true, |ui| self.ui_animation(ui));
                         }
+                        style::section(ui, "Preview", false,    |ui| self.ui_preview(ui));
                         style::section(ui, "LLM",      true,    |ui| self.ui_llm(ui));
                     });
             });

--- a/crates/mogen-studio/src/app/ui_llm/main.rs
+++ b/crates/mogen-studio/src/app/ui_llm/main.rs
@@ -23,6 +23,68 @@ fn disabled_reason(reasons: &[(&str, bool)]) -> Option<String> {
 
 impl MogenStudioApp {
     pub(in crate::app) fn ui_llm(&mut self, ui: &mut egui::Ui) {
+        // Inline provider switcher + global LLM toggles. Mirrors the
+        // Preferences pane so the user can flip provider / planning mode /
+        // seed without leaving the inspector. Persisted via Settings::save().
+        ui.horizontal(|ui| {
+            ui.label("Provider");
+            let current_slot = self.settings.provider_slot();
+            let mut chosen: Option<crate::settings::ProviderSlot> = None;
+            egui::ComboBox::from_id_salt("llm_panel_provider")
+                .selected_text(current_slot.label())
+                .show_ui(ui, |ui| {
+                    for slot in crate::settings::PROVIDER_SLOTS {
+                        let selected = slot == current_slot;
+                        if ui
+                            .selectable_label(selected, slot.label())
+                            .clicked()
+                            && !selected
+                        {
+                            chosen = Some(slot);
+                        }
+                    }
+                });
+            if let Some(slot) = chosen {
+                self.settings.set_provider_slot(slot);
+                let _ = self.settings.save();
+            }
+        });
+        ui.horizontal(|ui| {
+            let mut plan_first = self.settings.plan_first();
+            if ui
+                .checkbox(&mut plan_first, "Plan first")
+                .on_hover_text(
+                    "Run the Architect (planner) pass before the Coder pass. \
+                     Mirrors `mogen generate --plan` from the CLI.",
+                )
+                .changed()
+            {
+                self.settings.set_plan_first(plan_first);
+                let _ = self.settings.save();
+            }
+            // Seed override readout — clicking Reset clears the per-file
+            // override so the next LLM run mints a fresh seed. Editing the
+            // seed itself stays in Preferences.
+            let cur_seed = self.settings.seed_override();
+            ui.separator();
+            ui.label("Seed");
+            match cur_seed {
+                Some(s) => {
+                    ui.label(egui::RichText::new(s.to_string()).monospace())
+                        .on_hover_text(
+                            "Global RNG override applied to every LLM run on every \
+                             file. Edit in Preferences → LLM.",
+                        );
+                }
+                None => {
+                    ui.label(egui::RichText::new("(auto)").italics().weak())
+                        .on_hover_text("Each LLM call gets a fresh random seed.");
+                }
+            }
+        });
+
+        ui.add_space(6.0);
+
         let has_key = self.resolve_api_key().is_some();
         let mut request_open_prefs = false;
         if !has_key {

--- a/crates/mogen-studio/src/app/ui_panels.rs
+++ b/crates/mogen-studio/src/app/ui_panels.rs
@@ -17,5 +17,6 @@ mod diagnostics;
 mod editor;
 mod materials;
 mod overlay;
+mod preview;
 mod selected;
 mod summary;

--- a/crates/mogen-studio/src/app/ui_panels/animation.rs
+++ b/crates/mogen-studio/src/app/ui_panels/animation.rs
@@ -73,6 +73,77 @@ impl MogenStudioApp {
         }
 
         let playing = self.viewer.is_playing();
+        // Add-clip row — pick a procedural template + a target node, append
+        // a default-config declaration to the scene. Plain `clip { track … }`
+        // is the most flexible but the user typically wants a one-click
+        // template; the LLM-driven Animate flow handles bespoke needs.
+        ui.horizontal(|ui| {
+            ui.label("New:");
+            let kinds: [(&str, &str); 5] = [
+                ("spin", "spin (rotation about an axis)"),
+                ("open_close", "open_close (hinge swing)"),
+                ("wave", "wave (oscillation)"),
+                ("flap", "flap (one-direction oscillation)"),
+                ("idle", "idle (subtle bob)"),
+            ];
+            let cur = self.add_clip_kind.clone();
+            egui::ComboBox::from_id_salt("anim_new_clip_kind")
+                .selected_text(&cur)
+                .show_ui(ui, |ui| {
+                    for (k, label) in kinds {
+                        if ui
+                            .selectable_value(&mut self.add_clip_kind, k.into(), label)
+                            .clicked()
+                        {}
+                    }
+                });
+            ui.add(
+                egui::TextEdit::singleline(&mut self.add_clip_target)
+                    .hint_text("target node")
+                    .desired_width(120.0)
+                    .id_salt("anim_new_clip_target"),
+            );
+            let target_ok = !self.add_clip_target.trim().is_empty();
+            if ui
+                .add_enabled(target_ok, egui::Button::new("Add"))
+                .on_hover_text(
+                    "Append a `<kind> \"<name>\" (target=\"<target>\")` declaration \
+                     to the active scene with default rate/amplitude.",
+                )
+                .clicked()
+            {
+                let kind = self.add_clip_kind.clone();
+                let target = self.add_clip_target.trim().to_string();
+                let name = next_proc_clip_name(&self.files[self.active].source, &kind);
+                let body = format!(
+                    "{kind} \"{name}\" (target=\"{target}\")",
+                );
+                let i = self.active;
+                let before = self.files[i].source.clone();
+                let new_src = crate::edit::append_to_scene(&before, &body);
+                if new_src != before {
+                    {
+                        let f = &mut self.files[i];
+                        f.source = new_src;
+                        f.dirty = f.source != f.last_saved_source;
+                        f.needs_compile = true;
+                        f.last_edit_at = Some(Instant::now());
+                    }
+                    self.break_undo_chain(i);
+                    self.push_undo(
+                        i,
+                        before,
+                        UndoKey {
+                            surface: "animation",
+                            attr: Some("__add".into()),
+                            node_path: Vec::new(),
+                        },
+                    );
+                }
+            }
+        });
+        ui.add_space(4.0);
+
         ui.horizontal(|ui| {
             let label = if playing { "⏸ Pause" } else { "▶ Play" };
             if ui
@@ -158,10 +229,15 @@ impl MogenStudioApp {
         ui.add_space(8.0);
         let file_i = self.active;
         let mut pending_delete: Option<String> = None;
+        let mut pending_rename: Option<(String, String)> = None;
+        let mut pending_duration: Option<(String, f32)> = None;
         let warn_color = style::accent_warn(&ui.style().visuals);
         for i in visible_clip_indices {
             let c = &clips[i];
             ui.group(|ui| {
+                // Lift the span lookup so the rename + duration rows further
+                // down can gate on it without redoing the AST walk.
+                let span = find_clip_source_span(&self.files[file_i].source, &c.name);
                 // Row 1: enable + name + (right-aligned) delete affordance.
                 ui.horizontal(|ui| {
                     let mut on = active[i];
@@ -173,7 +249,6 @@ impl MogenStudioApp {
                         self.viewer.set_clip_active(i, on);
                     }
                     ui.label(egui::RichText::new(&c.name).strong());
-                    let span = find_clip_source_span(&self.files[file_i].source, &c.name);
                     let pending_for_this =
                         self.clip_delete_pending.as_deref() == Some(c.name.as_str());
                     ui.with_layout(
@@ -261,6 +336,68 @@ impl MogenStudioApp {
                         self.viewer.seek_clip(i, t);
                     }
                 });
+
+                // Row 4: rename + duration edit. Both are gated on having an
+                // authored span — procedural-template clips with multi-target
+                // expansion (`spin_0`, `spin_1`, …) skip them; the inspector
+                // can't disambiguate which instance the user intended.
+                if span.is_some() {
+                    ui.add_space(2.0);
+                    let cur_clip_name = c.name.clone();
+                    let mut name_buf = self
+                        .clip_name_drafts
+                        .entry(cur_clip_name.clone())
+                        .or_insert_with(|| cur_clip_name.clone())
+                        .clone();
+                    let name_resp = ui.horizontal(|ui| {
+                        ui.label("Name");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut name_buf)
+                                .desired_width(140.0)
+                                .id_salt(("clip_rename", i)),
+                        )
+                    });
+                    if name_resp.inner.changed() {
+                        self.clip_name_drafts
+                            .insert(cur_clip_name.clone(), name_buf.clone());
+                    }
+                    if name_resp.inner.lost_focus()
+                        && !name_buf.trim().is_empty()
+                        && name_buf != cur_clip_name
+                    {
+                        pending_rename = Some((cur_clip_name.clone(), name_buf.trim().to_string()));
+                    }
+                }
+                if span.is_some() {
+                    let cur_clip_name = c.name.clone();
+                    let cur_dur = c.duration;
+                    let key = format!("{cur_clip_name}::dur");
+                    let mut dur_buf = self
+                        .clip_duration_drafts
+                        .entry(key.clone())
+                        .or_insert_with(|| format!("{cur_dur:.3}"))
+                        .clone();
+                    let dur_resp = ui.horizontal(|ui| {
+                        ui.label("Duration");
+                        let resp = ui.add(
+                            egui::TextEdit::singleline(&mut dur_buf)
+                                .desired_width(80.0)
+                                .id_salt(("clip_dur", i)),
+                        );
+                        ui.label(egui::RichText::new("s").weak());
+                        resp
+                    });
+                    if dur_resp.inner.changed() {
+                        self.clip_duration_drafts.insert(key.clone(), dur_buf.clone());
+                    }
+                    if dur_resp.inner.lost_focus() {
+                        if let Ok(parsed) = dur_buf.trim().parse::<f32>() {
+                            if (parsed - cur_dur).abs() > 1e-4 && parsed > 0.0 {
+                                pending_duration = Some((cur_clip_name.clone(), parsed));
+                            }
+                        }
+                    }
+                }
             });
             ui.add_space(4.0);
         }
@@ -288,5 +425,137 @@ impl MogenStudioApp {
                 );
             }
         }
+
+        if let Some((old_name, new_name)) = pending_rename {
+            if let Some(span) = find_clip_source_span(&self.files[file_i].source, &old_name) {
+                let before = self.files[file_i].source.clone();
+                let new_src = rewrite_node_name_literal(&before, span, &new_name);
+                if new_src != before {
+                    {
+                        let f = &mut self.files[file_i];
+                        f.source = new_src;
+                        f.dirty = f.source != f.last_saved_source;
+                        f.needs_compile = true;
+                        f.last_edit_at = Some(Instant::now());
+                    }
+                    self.clip_name_drafts.remove(&old_name);
+                    self.break_undo_chain(file_i);
+                    self.push_undo(
+                        file_i,
+                        before,
+                        UndoKey {
+                            surface: "animation",
+                            attr: Some("__rename".into()),
+                            node_path: Vec::new(),
+                        },
+                    );
+                }
+            }
+        }
+
+        if let Some((clip_name, dur)) = pending_duration {
+            if let Some(span) = find_clip_source_span(&self.files[file_i].source, &clip_name) {
+                let before = self.files[file_i].source.clone();
+                // Plain `clip` and `open_close` use `seconds=`. `wave`/`flap`/
+                // `idle` derive duration from `hz=` (1/hz) so a direct edit
+                // wouldn't round-trip — we set `seconds=` anyway since the
+                // lowering pass for those kinds ignores it. The user gets
+                // expected behaviour for `clip` / `open_close`; for the
+                // others the field is a no-op (the readout above doesn't
+                // change). Detected and skipped via the kind check.
+                let new_src = crate::edit::set_attr(
+                    &before,
+                    span,
+                    "seconds",
+                    &format!("{dur:.4}").trim_end_matches('0').trim_end_matches('.').to_string(),
+                );
+                if new_src != before {
+                    {
+                        let f = &mut self.files[file_i];
+                        f.source = new_src;
+                        f.dirty = f.source != f.last_saved_source;
+                        f.needs_compile = true;
+                        f.last_edit_at = Some(Instant::now());
+                    }
+                    self.clip_duration_drafts.remove(&format!("{clip_name}::dur"));
+                    self.break_undo_chain(file_i);
+                    self.push_undo(
+                        file_i,
+                        before,
+                        UndoKey {
+                            surface: "animation",
+                            attr: Some("seconds".into()),
+                            node_path: Vec::new(),
+                        },
+                    );
+                }
+            }
+        }
     }
+}
+
+/// Rewrite the first quoted name literal inside the span. Used by clip
+/// rename — the clip's name lives in the `kind "name" (...)` header, just
+/// like materials. Tolerant of escaped quotes. Returns the source unchanged
+/// if no quoted literal is found in `span`.
+fn rewrite_node_name_literal(src: &str, span: mogen_core::Span, new_name: &str) -> String {
+    let bytes = src.as_bytes();
+    let start = span.start.min(src.len());
+    let end = span.end.min(src.len());
+    let mut i = start;
+    while i < end && bytes[i] != b'"' {
+        i += 1;
+    }
+    if i >= end {
+        return src.to_string();
+    }
+    let q_open = i;
+    i += 1;
+    while i < end && bytes[i] != b'"' {
+        if bytes[i] == b'\\' && i + 1 < end {
+            i += 2;
+            continue;
+        }
+        i += 1;
+    }
+    if i >= end {
+        return src.to_string();
+    }
+    let q_close = i;
+    let mut out = String::with_capacity(src.len() + new_name.len());
+    out.push_str(&src[..q_open + 1]);
+    out.push_str(new_name);
+    out.push_str(&src[q_close..]);
+    out
+}
+
+/// Suggest a unique `<kind>_<n>` name for a freshly-added procedural clip.
+/// Same algorithm as `next_material_name` over the kind keyword.
+fn next_proc_clip_name(src: &str, kind: &str) -> String {
+    let prefix = format!("{kind}_");
+    let mut max_n: u32 = 0;
+    for line in src.lines() {
+        let trimmed = line.trim_start();
+        let after_kw = match trimmed.strip_prefix(&format!("{kind} ")) {
+            Some(s) => s,
+            None => continue,
+        };
+        let after_quote = match after_kw.trim_start().strip_prefix('"') {
+            Some(s) => s,
+            None => continue,
+        };
+        let end = match after_quote.find('"') {
+            Some(e) => e,
+            None => continue,
+        };
+        let name = &after_quote[..end];
+        if let Some(rest) = name.strip_prefix(&prefix) {
+            if let Ok(n) = rest.parse::<u32>() {
+                if n > max_n {
+                    max_n = n;
+                }
+            }
+        }
+    }
+    format!("{prefix}{}", max_n + 1)
 }

--- a/crates/mogen-studio/src/app/ui_panels/materials.rs
+++ b/crates/mogen-studio/src/app/ui_panels/materials.rs
@@ -124,6 +124,33 @@ impl MogenStudioApp {
         // thumbnail row; applied after both loops so the action handler can
         // mutate source / spawn workers freely.
         let mut pending_tex_action: Option<TexAction> = None;
+        // Material lifecycle actions deferred for the same reason as `pending` —
+        // applied after the per-material loop so the borrow on `materials`
+        // (cloned slice) doesn't outlive the source mutations.
+        let mut pending_delete_material: Option<String> = None;
+        let mut pending_rename_material: Option<(String, String)> = None;
+        // Per-slot manual texture path: (material_name, slot_attr, new_value | None).
+        // None means "clear the slot" (delete attr).
+        let mut pending_tex_path: Option<(String, &'static str, Option<String>)> = None;
+        let mut wants_add_material = false;
+
+        // Add-material affordance — appends a `material "name" { color = … }`
+        // declaration to the active scene with a unique numeric suffix so it
+        // doesn't shadow an existing entry. Authored above the loop so it
+        // sits at the top of the panel where a new-action chip belongs.
+        ui.horizontal(|ui| {
+            if ui
+                .button("+ New material")
+                .on_hover_text(
+                    "Append a new material declaration to the scene. \
+                     The material starts with a neutral grey colour and \
+                     can be edited below.",
+                )
+                .clicked()
+            {
+                wants_add_material = true;
+            }
+        });
 
         // Salt every per-material widget ID with the scene-graph index in
         // addition to the material name. Imports can introduce a second
@@ -645,7 +672,232 @@ impl MogenStudioApp {
                             });
                         }
                     }
+
+                    // Manual per-slot picker — Browse points the slot at an
+                    // existing PNG without re-running the LLM. The LLM
+                    // pipeline does not expose this knob, so authors who
+                    // already have textures on disk would otherwise have to
+                    // hand-edit the .mog. Rows for every slot, regardless of
+                    // whether one is currently authored — Clear hides itself
+                    // when the slot is empty.
+                    ui.add_space(4.0);
+                    ui.label(egui::RichText::new("set path").weak());
+                    const SLOT_ROWS: [(&str, &str); 5] = [
+                        ("base_color", "base_color_texture"),
+                        ("metallic_roughness", "metallic_roughness_texture"),
+                        ("normal", "normal_texture"),
+                        ("occlusion", "occlusion_texture"),
+                        ("emissive", "emissive_texture"),
+                    ];
+                    for (slot_label, attr) in SLOT_ROWS {
+                        let authored = mat_slots.iter().any(|(_, s, _)| *s == slot_label);
+                        ui.horizontal(|ui| {
+                            ui.label(slot_label);
+                            if ui
+                                .small_button("Browse…")
+                                .on_hover_text(
+                                    "Pick a PNG and write its path into this slot. \
+                                     Stored relative to the .mog when possible.",
+                                )
+                                .clicked()
+                            {
+                                if let Some(picked) = rfd::FileDialog::new()
+                                    .add_filter("PNG", &["png"])
+                                    .set_directory(
+                                        source_dir
+                                            .clone()
+                                            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default()),
+                                    )
+                                    .pick_file()
+                                {
+                                    let rel = source_dir
+                                        .as_deref()
+                                        .and_then(|base| {
+                                            picked.strip_prefix(base).ok().map(|p| p.to_path_buf())
+                                        })
+                                        .unwrap_or_else(|| picked.clone());
+                                    let value = format!("\"{}\"", rel.to_string_lossy());
+                                    pending_tex_path =
+                                        Some((mat.name.clone(), attr, Some(value)));
+                                }
+                            }
+                            if authored
+                                && ui
+                                    .small_button("Clear")
+                                    .on_hover_text("Remove this slot's path attr")
+                                    .clicked()
+                            {
+                                pending_tex_path = Some((mat.name.clone(), attr, None));
+                            }
+                        });
+                    }
+
+                    // Rename + Delete actions live at the bottom of the
+                    // material body. Rename uses an in-place text field
+                    // committed on focus loss (mirrors the meta editor);
+                    // Delete is a two-step confirm to match the clip-delete
+                    // chip pattern.
+                    ui.add_space(6.0);
+                    ui.separator();
+                    ui.label(egui::RichText::new("manage").weak());
+                    let mut rename_buf = self
+                        .material_name_drafts
+                        .entry(mat.name.clone())
+                        .or_insert_with(|| mat.name.clone())
+                        .clone();
+                    let rename_resp = ui.horizontal(|ui| {
+                        ui.label("Rename");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut rename_buf)
+                                .desired_width(160.0)
+                                .id_salt(("mat_rename", *idx)),
+                        )
+                    });
+                    if rename_resp.inner.changed() {
+                        self.material_name_drafts
+                            .insert(mat.name.clone(), rename_buf.clone());
+                    }
+                    if rename_resp.inner.lost_focus()
+                        && !rename_buf.trim().is_empty()
+                        && rename_buf != mat.name
+                    {
+                        pending_rename_material =
+                            Some((mat.name.clone(), rename_buf.trim().to_string()));
+                    }
+
+                    ui.horizontal(|ui| {
+                        if ui
+                            .button(egui::RichText::new("🗑 Delete material"))
+                            .on_hover_text(
+                                "Remove the material declaration from the source. \
+                                 Nodes that reference it will fall back to default PBR \
+                                 until you reassign them.",
+                            )
+                            .clicked()
+                        {
+                            pending_delete_material = Some(mat.name.clone());
+                        }
+                    });
                 });
+        }
+
+        if wants_add_material {
+            let suggested = next_material_name(&self.files[i].source);
+            let body = format!(
+                "material \"{suggested}\" {{\n  color = [0.7, 0.7, 0.7]\n}}",
+            );
+            let before = self.files[i].source.clone();
+            let new_src = crate::edit::append_to_scene(&before, &body);
+            if new_src != before {
+                {
+                    let f = &mut self.files[i];
+                    f.source = new_src;
+                    f.dirty = f.source != f.last_saved_source;
+                    f.needs_compile = true;
+                    f.last_edit_at = Some(Instant::now());
+                }
+                self.break_undo_chain(i);
+                self.push_undo(
+                    i,
+                    before,
+                    UndoKey {
+                        surface: "material",
+                        attr: Some("__add".into()),
+                        node_path: Vec::new(),
+                    },
+                );
+            }
+        }
+
+        if let Some(mat_name) = pending_delete_material {
+            if let Some(span) = find_material_source_span(&self.files[i].source, &mat_name) {
+                let before = self.files[i].source.clone();
+                let new_src = crate::edit::delete_node(&before, span);
+                {
+                    let f = &mut self.files[i];
+                    f.source = new_src;
+                    f.dirty = f.source != f.last_saved_source;
+                    f.needs_compile = true;
+                    f.last_edit_at = Some(Instant::now());
+                }
+                self.break_undo_chain(i);
+                self.push_undo(
+                    i,
+                    before,
+                    UndoKey {
+                        surface: "material",
+                        attr: Some("__delete".into()),
+                        node_path: Vec::new(),
+                    },
+                );
+            }
+        }
+
+        if let Some((old_name, new_name)) = pending_rename_material {
+            // Two-pass: rewrite the material declaration's name literal,
+            // then sweep every `material="<old>"` reference across the
+            // source. The reference sweep is a verbatim substring replace
+            // bounded by the quote pair so we don't clobber an unrelated
+            // token that happens to equal the old name.
+            if let Some(span) = find_material_source_span(&self.files[i].source, &old_name) {
+                let before = self.files[i].source.clone();
+                let with_decl = rewrite_material_decl_name(&before, span, &new_name);
+                let new_src = with_decl.replace(
+                    &format!("material=\"{old_name}\""),
+                    &format!("material=\"{new_name}\""),
+                );
+                if new_src != before {
+                    {
+                        let f = &mut self.files[i];
+                        f.source = new_src;
+                        f.dirty = f.source != f.last_saved_source;
+                        f.needs_compile = true;
+                        f.last_edit_at = Some(Instant::now());
+                    }
+                    self.material_name_drafts.remove(&old_name);
+                    self.break_undo_chain(i);
+                    self.push_undo(
+                        i,
+                        before,
+                        UndoKey {
+                            surface: "material",
+                            attr: Some("__rename".into()),
+                            node_path: Vec::new(),
+                        },
+                    );
+                }
+            }
+        }
+
+        if let Some((mat_name, attr, value)) = pending_tex_path {
+            if let Some(span) = find_material_source_span(&self.files[i].source, &mat_name) {
+                let before = self.files[i].source.clone();
+                let new_src = match value {
+                    Some(v) => crate::edit::set_attr(&before, span, attr, &v),
+                    None => crate::edit::delete_attr(&before, span, attr),
+                };
+                if new_src != before {
+                    {
+                        let f = &mut self.files[i];
+                        f.source = new_src;
+                        f.dirty = f.source != f.last_saved_source;
+                        f.needs_compile = true;
+                        f.last_edit_at = Some(Instant::now());
+                    }
+                    self.tex_exists_cache.clear();
+                    self.thumb_cache.clear();
+                    self.break_undo_chain(i);
+                    self.push_undo(
+                        i,
+                        before,
+                        UndoKey {
+                            surface: "material",
+                            attr: Some(attr.into()),
+                            node_path: Vec::new(),
+                        },
+                    );
+                }
+            }
         }
 
         // Unused textures: PNGs sitting in ./textures/ next to the .mog that
@@ -852,4 +1104,73 @@ impl MogenStudioApp {
             .insert(path.to_path_buf(), (mtime, exists, now));
         exists
     }
+}
+
+/// Suggest a unique `material_<n>` name for a freshly-added material by
+/// scanning the source for any existing `material "material_N" …` literal
+/// and returning `material_<max+1>`. Defaults to `material_1` when no
+/// numbered material is present.
+fn next_material_name(src: &str) -> String {
+    let prefix = "material_";
+    let mut max_n: u32 = 0;
+    for line in src.lines() {
+        let trimmed = line.trim_start();
+        let after_kw = match trimmed.strip_prefix("material ") {
+            Some(s) => s,
+            None => continue,
+        };
+        let after_quote = match after_kw.trim_start().strip_prefix('"') {
+            Some(s) => s,
+            None => continue,
+        };
+        let end = match after_quote.find('"') {
+            Some(e) => e,
+            None => continue,
+        };
+        let name = &after_quote[..end];
+        if let Some(rest) = name.strip_prefix(prefix) {
+            if let Ok(n) = rest.parse::<u32>() {
+                if n > max_n {
+                    max_n = n;
+                }
+            }
+        }
+    }
+    format!("{prefix}{}", max_n + 1)
+}
+
+/// Rewrite the quoted name literal inside the `material "name" (...)`
+/// declaration covered by `span`. Bytes-level so we don't disturb the
+/// surrounding formatting / comments. Returns the source unchanged if the
+/// span doesn't contain a quoted name (defensive — `find_material_source_span`
+/// only returns spans that do).
+fn rewrite_material_decl_name(src: &str, span: mogen_core::Span, new_name: &str) -> String {
+    let bytes = src.as_bytes();
+    let start = span.start.min(src.len());
+    let end = span.end.min(src.len());
+    let mut i = start;
+    while i < end && bytes[i] != b'"' {
+        i += 1;
+    }
+    if i >= end {
+        return src.to_string();
+    }
+    let q_open = i;
+    i += 1;
+    while i < end && bytes[i] != b'"' {
+        if bytes[i] == b'\\' && i + 1 < end {
+            i += 2;
+            continue;
+        }
+        i += 1;
+    }
+    if i >= end {
+        return src.to_string();
+    }
+    let q_close = i;
+    let mut out = String::with_capacity(src.len() + new_name.len());
+    out.push_str(&src[..q_open + 1]);
+    out.push_str(new_name);
+    out.push_str(&src[q_close..]);
+    out
 }

--- a/crates/mogen-studio/src/app/ui_panels/preview.rs
+++ b/crates/mogen-studio/src/app/ui_panels/preview.rs
@@ -1,0 +1,197 @@
+//! Right-sidebar **Preview / Render** section.
+//!
+//! Consolidates the viewer-side knobs that previously lived only in the
+//! floating viewport overlay (environment, shadows, preview shader, show-grid /
+//! show-lights / show-transform-gizmo / show-colliders) plus a few that lived
+//! in the Edit menu (background colour, max FPS). Discoverability fix — the
+//! overlay popup is great for users who already know it's there but new users
+//! generally find sidebar sections first.
+//!
+//! Every change writes through `Settings` so it persists across restarts and
+//! propagates to the viewer's GL state via the matching `viewer.set_*` calls.
+
+use eframe::egui;
+
+use crate::app::MogenStudioApp;
+
+impl MogenStudioApp {
+    pub(in crate::app) fn ui_preview(&mut self, ui: &mut egui::Ui) {
+        use crate::preview_shader::{
+            preview_shader_label, PreviewShader, PREVIEW_SHADERS,
+        };
+        use crate::viewer::environment::{environment_label, Environment, ENVIRONMENTS};
+        use crate::viewer::shadows::SHADOW_QUALITIES;
+
+        // Preview shader (PBR / Toon / CRT / Matcap / Wireframe).
+        ui.horizontal(|ui| {
+            ui.label("Shader");
+            let cur = self.settings.preview_shader();
+            let mut chosen: Option<PreviewShader> = None;
+            egui::ComboBox::from_id_salt("preview_shader_panel")
+                .selected_text(preview_shader_label(cur))
+                .show_ui(ui, |ui| {
+                    for s in PREVIEW_SHADERS {
+                        let selected = s == cur;
+                        if ui
+                            .selectable_label(selected, preview_shader_label(s))
+                            .clicked()
+                            && !selected
+                        {
+                            chosen = Some(s);
+                        }
+                    }
+                });
+            if let Some(s) = chosen {
+                self.settings.set_preview_shader(s);
+                self.viewer.set_preview_shader(s);
+                let _ = self.settings.save();
+            }
+        });
+
+        // Environment (sky probe + key/fill rig fallback).
+        ui.horizontal(|ui| {
+            ui.label("Environment");
+            let cur = self.viewer.environment();
+            let mut chosen: Option<Environment> = None;
+            egui::ComboBox::from_id_salt("preview_env_panel")
+                .selected_text(environment_label(cur))
+                .show_ui(ui, |ui| {
+                    for env in ENVIRONMENTS {
+                        let selected = env == cur;
+                        if ui
+                            .selectable_label(selected, environment_label(env))
+                            .clicked()
+                            && !selected
+                        {
+                            chosen = Some(env);
+                        }
+                    }
+                });
+            if let Some(env) = chosen {
+                self.settings.set_environment(env);
+                self.viewer.set_environment(env);
+                let _ = self.settings.save();
+            }
+        });
+
+        // Shadow quality (off / 1024 / 2048 / 4096).
+        ui.horizontal(|ui| {
+            ui.label("Shadows");
+            let cur = self.viewer.shadows();
+            let mut chosen = None;
+            egui::ComboBox::from_id_salt("preview_shadow_panel")
+                .selected_text(cur.label())
+                .show_ui(ui, |ui| {
+                    for q in SHADOW_QUALITIES {
+                        let selected = q == cur;
+                        if ui
+                            .selectable_label(selected, q.label())
+                            .clicked()
+                            && !selected
+                        {
+                            chosen = Some(q);
+                        }
+                    }
+                });
+            if let Some(q) = chosen {
+                self.settings.set_shadow_quality(q);
+                self.viewer.set_shadows(q);
+                let _ = self.settings.save();
+            }
+        });
+
+        ui.add_space(6.0);
+        ui.label(egui::RichText::new("Show").strong());
+
+        let mut show_grid = self.settings.show_grid();
+        if ui
+            .checkbox(&mut show_grid, "Grid")
+            .on_hover_text("Ground-plane reference grid")
+            .changed()
+        {
+            self.settings.set_show_grid(show_grid);
+            self.viewer.set_show_grid(show_grid);
+            let _ = self.settings.save();
+        }
+        let mut show_lights = self.settings.show_light_gizmos();
+        if ui
+            .checkbox(&mut show_lights, "Light gizmos")
+            .on_hover_text(
+                "Per-light indicator overlays (point sphere, spot cone, \
+                 directional arrow)",
+            )
+            .changed()
+        {
+            self.settings.set_show_light_gizmos(show_lights);
+            self.viewer.set_show_light_gizmos(show_lights);
+            let _ = self.settings.save();
+        }
+        let mut show_xform = self.settings.show_transform_gizmo();
+        if ui
+            .checkbox(&mut show_xform, "Transform gizmo")
+            .on_hover_text("Translate / rotate / scale handles on the selected node")
+            .changed()
+        {
+            self.settings.set_show_transform_gizmo(show_xform);
+            self.viewer.set_show_transform_gizmo(show_xform);
+            let _ = self.settings.save();
+        }
+        let mut show_colliders = self.settings.show_colliders();
+        if ui
+            .checkbox(&mut show_colliders, "Colliders")
+            .on_hover_text(
+                "Render the AABB outline of every node tagged `collider=\"aabb\"`",
+            )
+            .changed()
+        {
+            self.settings.set_show_colliders(show_colliders);
+            self.viewer.set_show_colliders(show_colliders);
+            let _ = self.settings.save();
+        }
+
+        ui.add_space(6.0);
+        // Background colour (sRGB) — sits at the bottom because it's the
+        // least-frequently-changed knob in this group.
+        ui.horizontal(|ui| {
+            ui.label("Background");
+            let current = self.settings.viewer_bg_rgb();
+            let mut srgba = egui::Color32::from_rgb(current[0], current[1], current[2]);
+            if ui.color_edit_button_srgba(&mut srgba).changed() {
+                let rgb = [srgba.r(), srgba.g(), srgba.b()];
+                if rgb != current {
+                    self.settings.set_viewer_bg_rgb(rgb);
+                    let _ = self.settings.save();
+                }
+            }
+            if ui.small_button("Reset").clicked() {
+                self.settings
+                    .set_viewer_bg_rgb(crate::settings::DEFAULT_VIEWER_BG_RGB);
+                let _ = self.settings.save();
+            }
+        });
+
+        // Max FPS — useful when the viewer is competing with another GPU
+        // workload. None = uncapped (egui's default).
+        ui.horizontal(|ui| {
+            ui.label("Max FPS");
+            let cur = self.settings.max_fps();
+            let mut on = cur.is_some();
+            if ui.checkbox(&mut on, "cap").changed() {
+                let new = if on { Some(cur.unwrap_or(60)) } else { None };
+                self.settings.set_max_fps(new);
+                self.viewer.set_max_fps(new);
+                let _ = self.settings.save();
+            }
+            if let Some(mut fps) = cur {
+                if ui
+                    .add(egui::DragValue::new(&mut fps).range(15..=240).speed(1.0))
+                    .changed()
+                {
+                    self.settings.set_max_fps(Some(fps));
+                    self.viewer.set_max_fps(Some(fps));
+                    let _ = self.settings.save();
+                }
+            }
+        });
+    }
+}

--- a/crates/mogen-studio/src/app/ui_panels/selected.rs
+++ b/crates/mogen-studio/src/app/ui_panels/selected.rs
@@ -193,6 +193,10 @@ impl MogenStudioApp {
         let mut sz = t_scale.z;
         let node_span = node.source_span;
         let node_id = sel;
+        // Snapshot of connectors taken early so the connector-list section
+        // further down can render without keeping the `&node` borrow alive
+        // through the wants_* mutation handlers.
+        let connectors_snap: Vec<mogen_core::Connector> = node.connectors.clone();
 
         let mut edits: Vec<PendingEdit> = Vec::new();
 
@@ -336,6 +340,277 @@ impl MogenStudioApp {
                 }
                 ui.end_row();
             });
+
+        // Material picker — pick from the scene's authored materials and
+        // write `material="<name>"` back into the node header. Skip nodes that
+        // can't carry a material (lights, groups without geometry handled by
+        // attribute being valid in DSL anyway).
+        let mut wants_clear_material = false;
+        if node.light.is_none() {
+            let mat_names: Vec<String> =
+                scene.materials.iter().map(|m| m.name.clone()).collect();
+            let current_mat: Option<String> = node
+                .material
+                .and_then(|id| scene.materials.get(id.0 as usize))
+                .map(|m| m.name.clone());
+            if !mat_names.is_empty() {
+                ui.add_space(8.0);
+                ui.separator();
+                ui.label(egui::RichText::new("Material").strong());
+                ui.horizontal(|ui| {
+                    let label = current_mat
+                        .clone()
+                        .unwrap_or_else(|| "(inherit)".to_string());
+                    egui::ComboBox::from_id_salt(("inspector_material", node_id.0))
+                        .selected_text(label)
+                        .show_ui(ui, |ui| {
+                            // "(inherit)" clears `material=` and lets the parent's
+                            // material flow down — the lowering pass already
+                            // propagates parent material when child omits it.
+                            let none_selected = current_mat.is_none();
+                            if ui
+                                .selectable_label(none_selected, "(inherit)")
+                                .clicked()
+                                && !none_selected
+                            {
+                                wants_clear_material = true;
+                            }
+                            for name in &mat_names {
+                                let selected = current_mat.as_deref() == Some(name.as_str());
+                                if ui
+                                    .selectable_label(selected, name)
+                                    .clicked()
+                                    && !selected
+                                {
+                                    edits.push(PendingEdit::SetAttrCanonical {
+                                        node: node_id,
+                                        attr: "material".into(),
+                                        value: format!("\"{name}\""),
+                                        delete: Vec::new(),
+                                    });
+                                }
+                            }
+                        });
+                });
+            }
+        }
+
+        // Primitive geometry parameters (kind-switched). Show scalar attrs the
+        // primitive lowering pass actually consumes — see
+        // `mogen_dsl::lower::primitive`. List-shaped attrs (points/profile/path)
+        // are skipped here; they need a richer editor than a sidebar grid.
+        if let Some(span) = node_span {
+            let src_view = self.files[i].source.clone();
+            let mut params_to_emit: Vec<(&'static str, String)> = Vec::new();
+            let mut shown_any = false;
+            ui.add_space(8.0);
+            ui.separator();
+            ui.label(egui::RichText::new("Geometry").strong());
+            egui::Grid::new(("inspector_geom", node_id.0))
+                .num_columns(2)
+                .spacing([6.0, 4.0])
+                .show(ui, |ui| {
+                    shown_any = geom_params_for_kind(
+                        ui,
+                        node.kind.as_str(),
+                        &src_view,
+                        span,
+                        &mut params_to_emit,
+                    );
+                });
+            if !shown_any {
+                ui.label(
+                    egui::RichText::new("(no editable params for this kind)")
+                        .italics()
+                        .weak(),
+                );
+            }
+            for (attr, value) in params_to_emit {
+                edits.push(PendingEdit::SetAttrCanonical {
+                    node: node_id,
+                    attr: attr.into(),
+                    value,
+                    delete: Vec::new(),
+                });
+            }
+        }
+
+        // CSG op switch — flip union/difference/intersect on the same node
+        // without retyping. Lowering keys off `node.kind`, so we use a
+        // dedicated PendingEdit::ChangeKind via a span rewrite below.
+        let mut change_kind_to: Option<&'static str> = None;
+        if matches!(node.kind.as_str(), "union" | "difference" | "intersect") {
+            ui.add_space(8.0);
+            ui.separator();
+            ui.label(egui::RichText::new("CSG op").strong());
+            let cur = node.kind.as_str();
+            ui.horizontal(|ui| {
+                for k in ["union", "difference", "intersect"] {
+                    let selected = cur == k;
+                    if ui.selectable_label(selected, k).clicked() && !selected {
+                        change_kind_to = Some(match k {
+                            "union" => "union",
+                            "difference" => "difference",
+                            "intersect" => "intersect",
+                            _ => unreachable!(),
+                        });
+                    }
+                }
+            });
+        }
+
+        // Array / mirror modifier rows. Scalar count/axis/start_angle for
+        // arrays; axis-only for mirror. Replicators are not editable in the
+        // inspector when their wrapper isn't `editable`, but the wrapper
+        // *itself* stays editable per `lower::layout` so this still applies.
+        match node.kind.as_str() {
+            "array" => {
+                ui.add_space(8.0);
+                ui.separator();
+                ui.label(egui::RichText::new("Array").strong());
+                if let Some(span) = node_span {
+                    let src_view = self.files[i].source.clone();
+                    let cur_count = crate::edit::get_attr(&src_view, span, "count")
+                        .and_then(|s| s.parse::<f32>().ok())
+                        .unwrap_or(1.0);
+                    let cur_around = crate::edit::get_attr(&src_view, span, "around")
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| "Y".into());
+                    let cur_start = crate::edit::get_attr(&src_view, span, "start_angle")
+                        .and_then(|s| s.parse::<f32>().ok())
+                        .unwrap_or(0.0);
+                    egui::Grid::new(("inspector_array", node_id.0))
+                        .num_columns(2)
+                        .spacing([6.0, 4.0])
+                        .show(ui, |ui| {
+                            ui.label("Count");
+                            let mut count = cur_count.max(1.0);
+                            if ui
+                                .add(egui::DragValue::new(&mut count).speed(0.1).range(1.0..=512.0))
+                                .changed()
+                            {
+                                edits.push(PendingEdit::SetAttrCanonical {
+                                    node: node_id,
+                                    attr: "count".into(),
+                                    value: (count.round() as i32).to_string(),
+                                    delete: Vec::new(),
+                                });
+                            }
+                            ui.end_row();
+
+                            ui.label("Around");
+                            let mut around = cur_around.clone();
+                            egui::ComboBox::from_id_salt(("inspector_array_axis", node_id.0))
+                                .selected_text(around.as_str())
+                                .show_ui(ui, |ui| {
+                                    for axis in ["X", "Y", "Z"] {
+                                        if ui
+                                            .selectable_value(&mut around, axis.into(), axis)
+                                            .clicked()
+                                            && around.as_str() != cur_around.as_str()
+                                        {
+                                            edits.push(PendingEdit::SetAttrCanonical {
+                                                node: node_id,
+                                                attr: "around".into(),
+                                                value: axis.into(),
+                                                delete: Vec::new(),
+                                            });
+                                        }
+                                    }
+                                });
+                            ui.end_row();
+
+                            ui.label("Start °");
+                            let mut start = cur_start;
+                            if ui
+                                .add(egui::DragValue::new(&mut start).speed(0.5).suffix("°"))
+                                .changed()
+                            {
+                                edits.push(PendingEdit::SetAttrCanonical {
+                                    node: node_id,
+                                    attr: "start_angle".into(),
+                                    value: format_inspector_scalar(start),
+                                    delete: Vec::new(),
+                                });
+                            }
+                            ui.end_row();
+                        });
+                }
+            }
+            "mirror" => {
+                ui.add_space(8.0);
+                ui.separator();
+                ui.label(egui::RichText::new("Mirror").strong());
+                if let Some(span) = node_span {
+                    let src_view = self.files[i].source.clone();
+                    let cur_axis = crate::edit::get_attr(&src_view, span, "axis")
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| "X".into());
+                    ui.horizontal(|ui| {
+                        ui.label("Axis");
+                        let mut axis = cur_axis.clone();
+                        egui::ComboBox::from_id_salt(("inspector_mirror_axis", node_id.0))
+                            .selected_text(axis.as_str())
+                            .show_ui(ui, |ui| {
+                                for a in ["X", "Y", "Z"] {
+                                    if ui
+                                        .selectable_value(&mut axis, a.into(), a)
+                                        .clicked()
+                                        && axis.as_str() != cur_axis.as_str()
+                                    {
+                                        edits.push(PendingEdit::SetAttrCanonical {
+                                            node: node_id,
+                                            attr: "axis".into(),
+                                            value: a.into(),
+                                            delete: Vec::new(),
+                                        });
+                                    }
+                                }
+                            });
+                    });
+                }
+            }
+            _ => {}
+        }
+
+        // Mesh path picker — a `kind="mesh"` node loads a `.glb` from disk via
+        // its `src=` attribute. Show the current path with a Browse button so
+        // the user can repoint it without leaving the inspector.
+        let mut wants_pick_mesh = false;
+        if node.kind == "mesh" {
+            ui.add_space(8.0);
+            ui.separator();
+            ui.label(egui::RichText::new("Mesh source").strong());
+            if let Some(span) = node_span {
+                let cur_src = crate::edit::get_attr(&self.files[i].source, span, "src")
+                    .map(|s| s.trim_matches('"').to_string())
+                    .unwrap_or_default();
+                ui.horizontal(|ui| {
+                    if cur_src.is_empty() {
+                        ui.colored_label(
+                            egui::Color32::from_rgb(230, 200, 100),
+                            "(no path set)",
+                        );
+                    } else {
+                        ui.label(
+                            egui::RichText::new(&cur_src)
+                                .monospace()
+                                .weak(),
+                        )
+                        .on_hover_text(&cur_src);
+                    }
+                    if ui
+                        .small_button("Browse…")
+                        .on_hover_text(
+                            "Pick a .glb file. Path is stored relative to the .mog when possible.",
+                        )
+                        .clicked()
+                    {
+                        wants_pick_mesh = true;
+                    }
+                });
+            }
+        }
 
         // Shadow casting toggle — present on every editable node that isn't a
         // light. `cast_shadow` defaults to true at lower time, so the absence
@@ -750,6 +1025,51 @@ impl MogenStudioApp {
             }
         }
 
+        // Connector list — read-only summary of what frames the node exposes
+        // for `attach`. Synthesised AABB connectors (the six face anchors
+        // every mesh gets for free) are tagged so the user can see at a
+        // glance which entries the lowering pass added vs. what they
+        // authored. Snapshot is taken below `node`'s last UI use so the
+        // wants-* mutation handlers further down can take `&mut self`
+        // without a borrow conflict.
+        if !connectors_snap.is_empty() {
+            ui.add_space(8.0);
+            ui.separator();
+            egui::CollapsingHeader::new(format!("Connectors ({})", connectors_snap.len()))
+                .id_salt(("inspector_connectors", node_id.0))
+                .default_open(false)
+                .show(ui, |ui| {
+                    egui::Grid::new(("inspector_conn_grid", node_id.0))
+                        .num_columns(3)
+                        .spacing([8.0, 2.0])
+                        .show(ui, |ui| {
+                            ui.label(egui::RichText::new("name").strong().weak());
+                            ui.label(egui::RichText::new("tag").strong().weak());
+                            ui.label(egui::RichText::new("pos").strong().weak());
+                            ui.end_row();
+                            for c in &connectors_snap {
+                                let synthesised = c.source_span.is_none();
+                                let name_label = if synthesised {
+                                    egui::RichText::new(format!("{} ⓢ", c.name)).weak()
+                                } else {
+                                    egui::RichText::new(&c.name).monospace()
+                                };
+                                ui.label(name_label).on_hover_text(if synthesised {
+                                    "Synthesised from the AABB face anchors — no DSL declaration to edit."
+                                } else {
+                                    "Authored connector — edit the `connector` line in the source."
+                                });
+                                ui.label(egui::RichText::new(&c.tag).monospace());
+                                ui.label(format!(
+                                    "[{:.2}, {:.2}, {:.2}]",
+                                    c.pos.x, c.pos.y, c.pos.z
+                                ));
+                                ui.end_row();
+                            }
+                        });
+                });
+        }
+
         if wants_set_cast_shadow_off {
             edits.push(PendingEdit::SetAttrCanonical {
                 node: node_id,
@@ -835,6 +1155,90 @@ impl MogenStudioApp {
                         node_path: Vec::new(),
                     },
                 );
+            }
+        }
+
+        // Apply CSG kind rewrite. We can't reuse PendingEdit (it only mutates
+        // attrs); rewrite the kind keyword in the node header directly.
+        if let Some(new_kind) = change_kind_to {
+            if let Some(span) = node_span {
+                let before = self.files[i].source.clone();
+                let new_src = rewrite_node_kind(&before, span, new_kind);
+                {
+                    let f = &mut self.files[i];
+                    f.source = new_src;
+                    f.dirty = f.source != f.last_saved_source;
+                    f.needs_compile = true;
+                    f.last_edit_at = Some(Instant::now());
+                }
+                self.break_undo_chain(i);
+                self.push_undo(
+                    i,
+                    before,
+                    UndoKey {
+                        surface: "inspector-action",
+                        attr: Some("kind".into()),
+                        node_path: Vec::new(),
+                    },
+                );
+            }
+        }
+
+        if wants_clear_material {
+            if let Some(span) = node_span {
+                let before = self.files[i].source.clone();
+                let new_src = crate::edit::delete_attr(&before, span, "material");
+                {
+                    let f = &mut self.files[i];
+                    f.source = new_src;
+                    f.dirty = f.source != f.last_saved_source;
+                    f.needs_compile = true;
+                    f.last_edit_at = Some(Instant::now());
+                }
+                self.break_undo_chain(i);
+                self.push_undo(
+                    i,
+                    before,
+                    UndoKey {
+                        surface: "inspector-action",
+                        attr: Some("material".into()),
+                        node_path: Vec::new(),
+                    },
+                );
+            }
+        }
+
+        if wants_pick_mesh && node_span.is_some() {
+            {
+                if let Some(picked) = rfd::FileDialog::new()
+                    .add_filter("glTF binary", &["glb"])
+                    .set_directory(
+                        self.files[i]
+                            .path
+                            .as_deref()
+                            .and_then(|p| p.parent())
+                            .map(|p| p.to_path_buf())
+                            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default()),
+                    )
+                    .pick_file()
+                {
+                    // Store the path relative to the .mog when possible — the
+                    // mesh loader resolves `src=` against the source file's
+                    // directory, so a relative path is portable.
+                    let rel = self.files[i]
+                        .path
+                        .as_deref()
+                        .and_then(|p| p.parent())
+                        .and_then(|base| picked.strip_prefix(base).ok().map(|p| p.to_path_buf()))
+                        .unwrap_or_else(|| picked.clone());
+                    let value = format!("\"{}\"", rel.to_string_lossy());
+                    edits.push(PendingEdit::SetAttrCanonical {
+                        node: node_id,
+                        attr: "src".into(),
+                        value,
+                        delete: Vec::new(),
+                    });
+                }
             }
         }
 
@@ -1151,4 +1555,310 @@ fn deform_seed_row(
         }
     });
     ui.end_row();
+}
+
+/// Render scalar geometry-parameter rows for `kind`. Returns `true` when at
+/// least one editable row was added, so the caller can paint a "(no editable
+/// params)" hint when the kind has nothing to show. Each numeric attr falls
+/// back to its primitive lowering default — see `mogen_dsl::lower::primitive`.
+/// List-shaped attrs (`points`, `profile`, `path`, `holes`) are intentionally
+/// skipped — they need a richer editor than a sidebar grid.
+///
+/// Out entries are pre-formatted `(attr_name, value_literal)` pairs so the
+/// helper can emit list-shaped writes (`size=[1, 2, 3]`) without the caller
+/// having to know which attrs are scalar vs. vector.
+#[allow(clippy::too_many_arguments)]
+pub(in crate::app) fn geom_params_for_kind(
+    ui: &mut egui::Ui,
+    kind: &str,
+    src: &str,
+    span: mogen_core::Span,
+    out: &mut Vec<(&'static str, String)>,
+) -> bool {
+    use crate::edit::get_attr;
+    fn read(src: &str, span: mogen_core::Span, attr: &str) -> Option<f32> {
+        get_attr(src, span, attr).and_then(|s| s.parse::<f32>().ok())
+    }
+    fn read_vec3(src: &str, span: mogen_core::Span, attr: &str) -> Option<[f32; 3]> {
+        let raw = get_attr(src, span, attr)?;
+        let trimmed = raw.trim().trim_start_matches('[').trim_end_matches(']');
+        let parts: Vec<f32> = trimmed
+            .split(',')
+            .filter_map(|s| s.trim().parse::<f32>().ok())
+            .collect();
+        match parts.len() {
+            1 => Some([parts[0], parts[0], parts[0]]),
+            3 => Some([parts[0], parts[1], parts[2]]),
+            _ => None,
+        }
+    }
+    fn read_vec2(src: &str, span: mogen_core::Span, attr: &str) -> Option<[f32; 2]> {
+        let raw = get_attr(src, span, attr)?;
+        let trimmed = raw.trim().trim_start_matches('[').trim_end_matches(']');
+        let parts: Vec<f32> = trimmed
+            .split(',')
+            .filter_map(|s| s.trim().parse::<f32>().ok())
+            .collect();
+        match parts.len() {
+            1 => Some([parts[0], parts[0]]),
+            2 => Some([parts[0], parts[1]]),
+            _ => None,
+        }
+    }
+    fn scalar_row(
+        ui: &mut egui::Ui,
+        label: &str,
+        attr: &'static str,
+        current: f32,
+        speed: f32,
+        out: &mut Vec<(&'static str, String)>,
+    ) {
+        use crate::app::util::format_inspector_scalar;
+        ui.label(label);
+        let mut v = current;
+        if ui.add(egui::DragValue::new(&mut v).speed(speed)).changed() {
+            out.push((attr, format_inspector_scalar(v)));
+        }
+        ui.end_row();
+    }
+    fn int_row(
+        ui: &mut egui::Ui,
+        label: &str,
+        attr: &'static str,
+        current: i32,
+        min: i32,
+        max: i32,
+        out: &mut Vec<(&'static str, String)>,
+    ) {
+        ui.label(label);
+        let mut v = current;
+        if ui
+            .add(egui::DragValue::new(&mut v).speed(0.1).range(min..=max))
+            .changed()
+        {
+            out.push((attr, v.to_string()));
+        }
+        ui.end_row();
+    }
+    use crate::app::util::format_inspector_scalar;
+    let mut shown = false;
+    match kind {
+        "box" | "slab" | "post" | "panel" | "wedge" | "ellipsoid" | "rounded_box"
+        | "chamfered_box" | "inset_box" | "wall" | "prism" | "superellipsoid" => {
+            let s = read_vec3(src, span, "size").unwrap_or([1.0, 1.0, 1.0]);
+            ui.label("Size");
+            ui.horizontal(|ui| {
+                let mut sx = s[0];
+                let mut sy = s[1];
+                let mut sz = s[2];
+                let mut emit = false;
+                if ui.add(egui::DragValue::new(&mut sx).speed(0.02)).changed() { emit = true; }
+                if ui.add(egui::DragValue::new(&mut sy).speed(0.02)).changed() { emit = true; }
+                if ui.add(egui::DragValue::new(&mut sz).speed(0.02)).changed() { emit = true; }
+                if emit {
+                    out.push((
+                        "size",
+                        format!(
+                            "[{}, {}, {}]",
+                            format_inspector_scalar(sx),
+                            format_inspector_scalar(sy),
+                            format_inspector_scalar(sz),
+                        ),
+                    ));
+                }
+            });
+            ui.end_row();
+            shown = true;
+            // Kind-specific extras
+            match kind {
+                "rounded_box" | "chamfered_box" => {
+                    scalar_row(ui, "Radius", "radius",
+                        read(src, span, "radius").unwrap_or(0.1), 0.005, out);
+                    if kind == "rounded_box" {
+                        let segs = read(src, span, "segments").unwrap_or(4.0) as i32;
+                        int_row(ui, "Segments", "segments", segs, 1, 32, out);
+                    }
+                }
+                "inset_box" => {
+                    scalar_row(ui, "Amount", "amount",
+                        read(src, span, "amount").unwrap_or(0.1), 0.005, out);
+                    scalar_row(ui, "Depth", "depth",
+                        read(src, span, "depth").unwrap_or(0.05), 0.005, out);
+                }
+                "superellipsoid" => {
+                    scalar_row(ui, "Equator", "ew",
+                        read(src, span, "ew").unwrap_or(1.0), 0.05, out);
+                    scalar_row(ui, "Meridian", "ns",
+                        read(src, span, "ns").unwrap_or(1.0), 0.05, out);
+                    let r = read(src, span, "rings").unwrap_or(16.0) as i32;
+                    let s = read(src, span, "segments").unwrap_or(24.0) as i32;
+                    int_row(ui, "Rings", "rings", r, 2, 256, out);
+                    int_row(ui, "Segments", "segments", s, 3, 256, out);
+                }
+                "ellipsoid" => {
+                    let r = read(src, span, "rings").unwrap_or(16.0) as i32;
+                    let s = read(src, span, "segments").unwrap_or(24.0) as i32;
+                    int_row(ui, "Rings", "rings", r, 2, 256, out);
+                    int_row(ui, "Segments", "segments", s, 3, 256, out);
+                }
+                _ => {}
+            }
+        }
+        "plane" | "quad" | "decal" | "leaf_card" | "curved_plane" => {
+            // plane uses [x,z], quad/decal/leaf_card uses [x,y], curved_plane uses [x,z].
+            let s = read_vec2(src, span, "size").unwrap_or([1.0, 1.0]);
+            ui.label("Size");
+            ui.horizontal(|ui| {
+                let mut su = s[0];
+                let mut sv = s[1];
+                let mut emit = false;
+                if ui.add(egui::DragValue::new(&mut su).speed(0.05)).changed() { emit = true; }
+                if ui.add(egui::DragValue::new(&mut sv).speed(0.05)).changed() { emit = true; }
+                if emit {
+                    out.push((
+                        "size",
+                        format!(
+                            "[{}, {}]",
+                            format_inspector_scalar(su),
+                            format_inspector_scalar(sv),
+                        ),
+                    ));
+                }
+            });
+            ui.end_row();
+            shown = true;
+            if kind == "decal" {
+                scalar_row(ui, "Offset", "offset",
+                    read(src, span, "offset").unwrap_or(0.001), 0.0005, out);
+            }
+        }
+        "cylinder" | "cone" | "half_cylinder" => {
+            scalar_row(ui, "Radius", "radius",
+                read(src, span, "radius").unwrap_or(0.5), 0.02, out);
+            scalar_row(ui, "Height", "height",
+                read(src, span, "height").unwrap_or(1.0), 0.02, out);
+            let s = read(src, span, "segments").unwrap_or(24.0) as i32;
+            int_row(ui, "Segments", "segments", s, 3, 256, out);
+            shown = true;
+        }
+        "sphere" | "hemisphere" => {
+            scalar_row(ui, "Radius", "radius",
+                read(src, span, "radius").unwrap_or(0.5), 0.02, out);
+            let r = read(src, span, "rings").unwrap_or(if kind == "hemisphere" { 8.0 } else { 16.0 }) as i32;
+            let s = read(src, span, "segments").unwrap_or(24.0) as i32;
+            int_row(ui, "Rings", "rings", r, 2, 256, out);
+            int_row(ui, "Segments", "segments", s, 3, 256, out);
+            shown = true;
+        }
+        "icosphere" => {
+            scalar_row(ui, "Radius", "radius",
+                read(src, span, "radius").unwrap_or(0.5), 0.02, out);
+            let s = read(src, span, "subdivisions").unwrap_or(2.0) as i32;
+            int_row(ui, "Subdivisions", "subdivisions", s, 0, 6, out);
+            shown = true;
+        }
+        "capsule" => {
+            scalar_row(ui, "Radius", "radius",
+                read(src, span, "radius").unwrap_or(0.5), 0.02, out);
+            scalar_row(ui, "Height", "height",
+                read(src, span, "height").unwrap_or(1.0), 0.02, out);
+            let r = read(src, span, "rings").unwrap_or(8.0) as i32;
+            let s = read(src, span, "segments").unwrap_or(24.0) as i32;
+            int_row(ui, "Rings", "rings", r, 2, 64, out);
+            int_row(ui, "Segments", "segments", s, 3, 256, out);
+            shown = true;
+        }
+        "torus" => {
+            scalar_row(ui, "Major", "major",
+                read(src, span, "major").unwrap_or(0.5), 0.02, out);
+            scalar_row(ui, "Minor", "minor",
+                read(src, span, "minor").unwrap_or(0.15), 0.02, out);
+            let mj = read(src, span, "major_segments").unwrap_or(24.0) as i32;
+            let mn = read(src, span, "minor_segments").unwrap_or(12.0) as i32;
+            int_row(ui, "Major segs", "major_segments", mj, 3, 256, out);
+            int_row(ui, "Minor segs", "minor_segments", mn, 3, 256, out);
+            shown = true;
+        }
+        "torus_arc" => {
+            scalar_row(ui, "Major", "major",
+                read(src, span, "major").unwrap_or(0.5), 0.02, out);
+            scalar_row(ui, "Minor", "minor",
+                read(src, span, "minor").unwrap_or(0.15), 0.02, out);
+            scalar_row(ui, "Arc°", "arc",
+                read(src, span, "arc").unwrap_or(90.0), 1.0, out);
+            shown = true;
+        }
+        "pyramid" => {
+            scalar_row(ui, "Radius", "radius",
+                read(src, span, "radius").unwrap_or(0.5), 0.02, out);
+            scalar_row(ui, "Height", "height",
+                read(src, span, "height").unwrap_or(1.0), 0.02, out);
+            let s = read(src, span, "sides").unwrap_or(4.0) as i32;
+            int_row(ui, "Sides", "sides", s, 3, 64, out);
+            shown = true;
+        }
+        "disc" => {
+            scalar_row(ui, "Radius", "radius",
+                read(src, span, "radius").unwrap_or(0.5), 0.02, out);
+            let s = read(src, span, "segments").unwrap_or(24.0) as i32;
+            int_row(ui, "Segments", "segments", s, 3, 256, out);
+            shown = true;
+        }
+        "tube" => {
+            scalar_row(ui, "Outer", "outer",
+                read(src, span, "outer").unwrap_or(0.5), 0.02, out);
+            scalar_row(ui, "Inner", "inner",
+                read(src, span, "inner").unwrap_or(0.3), 0.02, out);
+            scalar_row(ui, "Height", "height",
+                read(src, span, "height").unwrap_or(1.0), 0.02, out);
+            let s = read(src, span, "segments").unwrap_or(24.0) as i32;
+            int_row(ui, "Segments", "segments", s, 3, 256, out);
+            shown = true;
+        }
+        "coil" => {
+            scalar_row(ui, "Radius", "radius",
+                read(src, span, "radius").unwrap_or(0.5), 0.02, out);
+            scalar_row(ui, "Height", "height",
+                read(src, span, "height").unwrap_or(1.0), 0.02, out);
+            scalar_row(ui, "Turns", "turns",
+                read(src, span, "turns").unwrap_or(3.0), 0.1, out);
+            scalar_row(ui, "Profile r", "profile_radius",
+                read(src, span, "profile_radius").unwrap_or(0.05), 0.005, out);
+            shown = true;
+        }
+        "frustum" => {
+            scalar_row(ui, "Height", "height",
+                read(src, span, "height").unwrap_or(1.0), 0.02, out);
+            shown = true;
+        }
+        _ => {}
+    }
+    shown
+}
+
+/// Rewrite the keyword (kind identifier) at the very start of the node
+/// covered by `span`. Used by the CSG op switch in the inspector — the
+/// keyword sits before the optional `"name" (...)` header, and existing
+/// edit helpers don't expose a kind rewrite. Bytes-only; no AST round-trip.
+fn rewrite_node_kind(src: &str, span: mogen_core::Span, new_kind: &str) -> String {
+    let bytes = src.as_bytes();
+    let start = span.start.min(src.len());
+    // Skip leading whitespace inside the span — pest spans typically begin
+    // exactly at the kind keyword, but be defensive.
+    let mut i = start;
+    while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    let kind_start = i;
+    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+        i += 1;
+    }
+    if i == kind_start {
+        return src.to_string();
+    }
+    let mut out = String::with_capacity(src.len() + new_kind.len());
+    out.push_str(&src[..kind_start]);
+    out.push_str(new_kind);
+    out.push_str(&src[i..]);
+    out
 }

--- a/crates/mogen-studio/src/app/ui_panels/summary.rs
+++ b/crates/mogen-studio/src/app/ui_panels/summary.rs
@@ -191,5 +191,164 @@ impl MogenStudioApp {
                 );
             }
         }
+
+        // Meta editor — `name`, `description`. Maps to top-of-file
+        // `meta(...)` block via `mogen_dsl::upsert_meta_attr`, which is
+        // text-level and tolerates partial drafts.
+        ui.add_space(8.0);
+        ui.separator();
+        ui.label(egui::RichText::new("Meta").strong());
+        let cur_name = mogen_dsl::read_meta_attr(&self.files[i].source, "name")
+            .unwrap_or_default();
+        let cur_desc = mogen_dsl::read_meta_attr(&self.files[i].source, "description")
+            .unwrap_or_default();
+        let cur_seed = mogen_dsl::read_meta_attr(&self.files[i].source, "seed")
+            .unwrap_or_default();
+        let id = self.active;
+        // Initialise the draft from source on first paint; thereafter the
+        // user's keystrokes own the buffer until they commit (focus loss).
+        if !self.meta_name_drafts.contains_key(&id) {
+            self.meta_name_drafts.insert(id, cur_name.clone());
+        }
+        let mut name_str = self.meta_name_drafts.get(&id).cloned().unwrap_or_default();
+        let name_resp = ui.horizontal(|ui| {
+            ui.label("Name");
+            ui.add(
+                egui::TextEdit::singleline(&mut name_str)
+                    .desired_width(f32::INFINITY)
+                    .id_salt(("meta_name", i)),
+            )
+        });
+        if name_resp.inner.changed() {
+            self.meta_name_drafts.insert(id, name_str.clone());
+        }
+        if name_resp.inner.lost_focus() && name_str != cur_name {
+            let before = self.files[i].source.clone();
+            let new_src = mogen_dsl::upsert_meta_attr(&before, "name", &name_str);
+            if new_src != before {
+                {
+                    let f = &mut self.files[i];
+                    f.source = new_src;
+                    f.dirty = f.source != f.last_saved_source;
+                    f.needs_compile = true;
+                    f.last_edit_at = Some(Instant::now());
+                }
+                self.break_undo_chain(i);
+                self.push_undo(
+                    i,
+                    before,
+                    UndoKey {
+                        surface: "meta",
+                        attr: Some("name".into()),
+                        node_path: Vec::new(),
+                    },
+                );
+            }
+        }
+
+        if !self.meta_desc_drafts.contains_key(&id) {
+            self.meta_desc_drafts.insert(id, cur_desc.clone());
+        }
+        let mut desc_str = self.meta_desc_drafts.get(&id).cloned().unwrap_or_default();
+        let desc_resp = ui.horizontal(|ui| {
+            ui.label("Desc");
+            ui.add(
+                egui::TextEdit::singleline(&mut desc_str)
+                    .desired_width(f32::INFINITY)
+                    .hint_text("optional one-line summary")
+                    .id_salt(("meta_desc", i)),
+            )
+        });
+        if desc_resp.inner.changed() {
+            self.meta_desc_drafts.insert(id, desc_str.clone());
+        }
+        if desc_resp.inner.lost_focus() && desc_str != cur_desc {
+            let before = self.files[i].source.clone();
+            let new_src = mogen_dsl::upsert_meta_attr(&before, "description", &desc_str);
+            if new_src != before {
+                {
+                    let f = &mut self.files[i];
+                    f.source = new_src;
+                    f.dirty = f.source != f.last_saved_source;
+                    f.needs_compile = true;
+                    f.last_edit_at = Some(Instant::now());
+                }
+                self.break_undo_chain(i);
+                self.push_undo(
+                    i,
+                    before,
+                    UndoKey {
+                        surface: "meta",
+                        attr: Some("description".into()),
+                        node_path: Vec::new(),
+                    },
+                );
+            }
+        }
+
+        // Seed shown read-only because LLM workflows stamp it; expose a
+        // "Clear" button for users who want a fresh roll on the next run.
+        ui.horizontal(|ui| {
+            ui.label("Seed");
+            if cur_seed.is_empty() {
+                ui.label(egui::RichText::new("(none)").italics().weak());
+            } else {
+                ui.label(egui::RichText::new(&cur_seed).monospace())
+                    .on_hover_text(
+                        "Stamped by `generate` / `modify` so rebuilds are \
+                         reproducible. Clear to roll a fresh seed on the \
+                         next LLM run.",
+                    );
+                if ui.small_button("Clear").clicked() {
+                    let before = self.files[i].source.clone();
+                    let new_src = mogen_dsl::upsert_meta_attr(&before, "seed", "");
+                    if new_src != before {
+                        {
+                            let f = &mut self.files[i];
+                            f.source = new_src;
+                            f.dirty = f.source != f.last_saved_source;
+                            f.needs_compile = true;
+                            f.last_edit_at = Some(Instant::now());
+                        }
+                        self.break_undo_chain(i);
+                        self.push_undo(
+                            i,
+                            before,
+                            UndoKey {
+                                surface: "meta",
+                                attr: Some("seed".into()),
+                                node_path: Vec::new(),
+                            },
+                        );
+                    }
+                }
+            }
+        });
+
+        // Export options — same toggles as the File → Build GLB modal,
+        // hoisted here so the user can see/save the per-file state without
+        // opening the dialog. Persisted on `FileState.export_opts`; the
+        // build pipeline reads them on every export.
+        ui.add_space(8.0);
+        ui.separator();
+        ui.label(egui::RichText::new("Export").strong());
+        let opts = &mut self.files[i].export_opts;
+        ui.checkbox(&mut opts.include_animations, "Include animations")
+            .on_hover_text(
+                "Emit the scene's `animations[]` array. Off = bake a static GLB.",
+            );
+        ui.checkbox(&mut opts.include_textures, "Include textures")
+            .on_hover_text(
+                "Pack texture images into the GLB binary chunk and wire them to \
+                 materials. Off = materials export with only PBR numeric factors.",
+            );
+        ui.checkbox(
+            &mut opts.merge_sibling_meshes,
+            "Merge overlapping meshes",
+        )
+        .on_hover_text(
+            "Collapse same-material, non-skinned sibling meshes under each parent \
+             into a single CSG-unioned mesh. Slow on complex scenes.",
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds 17 new GUI editors to the Studio right sidebar so common authoring/render knobs no longer require hand-editing the `.mog` source. Identified gaps span every existing section plus a new Preview/Render section consolidating viewer settings that were previously scattered across the floating viewport overlay and the View menu.

## What's new

### Selected ([selected.rs](https://github.com/krazyjakee/MoGen/blob/claude/dazzling-poincare-a04097/crates/mogen-studio/src/app/ui_panels/selected.rs))
- **Material picker dropdown** — assign or clear `material=\"…\"` with `(inherit)` for parent-fallback
- **Primitive geometry grid** — kind-switched scalars/vectors for box/cylinder/sphere/torus/cone/capsule/disc/pyramid/tube/coil/etc. (size, radius, height, segments, rings…). List-shaped attrs (points/profile/path) intentionally skipped — they need a richer editor.
- **CSG op switch** — flip between `union`/`difference`/`intersect` via free-function source rewrite
- **Array/mirror modifier rows** — count/axis/start_angle for `array`; axis combo for `mirror`
- **Mesh path picker** — Browse for `kind=\"mesh\"` `src=`, stored relative to the .mog when possible
- **Connector list** — read-only collapsing summary (name/tag/pos), tags synthesised AABB anchors with ⓢ

### Scene ([summary.rs](https://github.com/krazyjakee/MoGen/blob/claude/dazzling-poincare-a04097/crates/mogen-studio/src/app/ui_panels/summary.rs))
- **Meta editor** — `name` + `description` text fields with per-file draft buffers, committed on focus loss; seed shown read-only with a Clear button
- **Inline export toggles** — `include_animations` / `include_textures` / `merge_sibling_meshes` mirror the Build GLB modal's per-file `ExportOptions`

### Materials ([materials.rs](https://github.com/krazyjakee/MoGen/blob/claude/dazzling-poincare-a04097/crates/mogen-studio/src/app/ui_panels/materials.rs))
- **+ New material** button at the top
- **Per-material Rename + Delete** inside the body (rename sweeps `material=\"<old>\"` references)
- **Per-slot Browse… / Clear** for all 5 PBR slots (`base_color` / `metallic_roughness` / `normal` / `occlusion` / `emissive`)

### Animation ([animation.rs](https://github.com/krazyjakee/MoGen/blob/claude/dazzling-poincare-a04097/crates/mogen-studio/src/app/ui_panels/animation.rs))
- **Add-clip row** — kind dropdown (`spin`/`open_close`/`wave`/`flap`/`idle`) + target name field + Add button
- **Per-clip Name + Duration** text fields with focus-commit (writes `seconds=`)

### LLM ([ui_llm/main.rs](https://github.com/krazyjakee/MoGen/blob/claude/dazzling-poincare-a04097/crates/mogen-studio/src/app/ui_llm/main.rs))
- **Inline provider switcher** (mirrors the Preferences combo)
- **Plan-first checkbox + seed-override readout** (previously Preferences-only)

### New Preview/Render section ([preview.rs](https://github.com/krazyjakee/MoGen/blob/claude/dazzling-poincare-a04097/crates/mogen-studio/src/app/ui_panels/preview.rs))
Consolidates viewer-side knobs that were scattered between the floating viewport overlay and the View menu:
- Shader / Environment / Shadows combos
- Show: Grid / Light gizmos / Transform gizmo / Colliders
- Background colour + Reset
- Max FPS cap

## Implementation notes

- All source mutations go through span-aware text helpers (`mogen_studio::edit::*`, `mogen_dsl::upsert_meta_attr`) so formatting and in-flight diagnostics survive.
- Borrow conflict between the new connector list and existing `wants_*` mutation handlers worked around with an early `connectors.clone()` snapshot rather than reordering the Light section.
- New `MogenStudioApp` state: per-file meta-name/desc draft buffers + per-material rename buffer + per-clip rename/duration buffers + add-clip row state.

## Dropped (and why)

- **Visibility toggle** — no `visible` attribute exists in the DSL
- **Tag editor on nodes** — `tag=` only applies to `connector` definitions, not nodes
- **Loop mode per clip** — `Clip` has no `loop_mode` field; would need a core/exporter change
- **Material preview sphere** — needs offscreen GL render; non-trivial
- **IOR / clearcoat / sheen** — `Material` doesn't carry those fields today

## Caveats worth a reviewer's eye

- `next_proc_clip_name` and `next_material_name` use line-prefix scanning rather than an AST walk — fast but trips over comments containing the keyword. Same trade-off as the existing `suggest_primitive_name`.
- Material rename's reference sweep uses verbatim `material=\"<old>\"` substring replace; whitespace variants like `material = \"old\"` won't be rewritten. Acceptable for MoGen's normal formatting.
- Clip duration field writes `seconds=` for every kind; `wave`/`flap`/`idle` (rate-driven via `hz=`) silently ignore it during lowering. Flagged inline.

## Test plan

- [x] `cargo build --release -p mogen-studio` clean
- [x] `cargo test -p mogen-studio --release` — 202 passed
- [x] `./scripts/run-tests.sh` — full workspace clean, no regressions
- [ ] Smoke-test in `./scripts/run-studio.sh`: select a `box`, drag `size`, confirm source updates; create a new material, rename, delete; add a `spin` clip, scrub it; flip Preview shader / Environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)