### PR TITLE
feat(llm): line-edit mode for `modify` so the model patches instead of rewriting

### DIFF
--- a/crates/mogen-llm/src/lib.rs
+++ b/crates/mogen-llm/src/lib.rs
@@ -65,7 +65,8 @@ pub use prompt::{
 pub use provider::{GoogleCredential, LlmClient, Provider, ProviderError};
 pub use refine::{build_reviewer_message, visual_refine};
 pub use repair::{
-    generate_with_repair, repair_message, validate_text, GenerateOutcome, RepairConfig,
+    generate_edits_with_repair, generate_with_repair, repair_message, validate_text,
+    GenerateOutcome, RepairConfig, EDIT_BLOCK_INSTRUCTIONS,
 };
 pub use settings_store::{
     load_api_keys, read_api_key, settings_path as settings_store_path, zai_base_url, ApiKeys,

--- a/crates/mogen-llm/src/repair.rs
+++ b/crates/mogen-llm/src/repair.rs
@@ -95,6 +95,36 @@ pub fn generate_with_repair(
     cfg: GenerateConfig,
     repair: &RepairConfig,
 ) -> Result<GenerateOutcome, ProviderError> {
+    run_repair_loop(client, cfg, repair, false, None)
+}
+
+/// Variant of [`generate_with_repair`] that starts in edit mode: the first
+/// model response is parsed as SEARCH/REPLACE blocks against `baseline` and,
+/// only if that fails (no blocks, malformed, missing/ambiguous match), is it
+/// retried as a full rewrite. Used by `mogen modify` so a small change to a
+/// large file doesn't require the model to re-emit the entire DSL.
+///
+/// The caller is responsible for crafting a `cfg.user_prompt` that asks the
+/// model for SEARCH/REPLACE blocks (see [`EDIT_BLOCK_INSTRUCTIONS`]). After
+/// the first call, the loop's per-iteration mode logic ([`is_local_only`])
+/// takes over for any subsequent repair passes — exactly as in
+/// [`generate_with_repair`].
+pub fn generate_edits_with_repair(
+    client: &LlmClient,
+    cfg: GenerateConfig,
+    repair: &RepairConfig,
+    baseline: &str,
+) -> Result<GenerateOutcome, ProviderError> {
+    run_repair_loop(client, cfg, repair, true, Some(baseline.to_string()))
+}
+
+fn run_repair_loop(
+    client: &LlmClient,
+    cfg: GenerateConfig,
+    repair: &RepairConfig,
+    asked_for_edits_init: bool,
+    prev_dsl_init: Option<String>,
+) -> Result<GenerateOutcome, ProviderError> {
     let mut cfg = cfg;
     let mut total_usage = Usage::default();
     let mut calls = 0u32;
@@ -115,8 +145,11 @@ pub fn generate_with_repair(
     // them against. `asked_for_edits` mirrors what we requested, not what we
     // got — the model may ignore the format and return a full file anyway,
     // which we detect by parse failure and treat as a rewrite.
-    let mut asked_for_edits = false;
-    let mut prev_dsl: Option<String> = None;
+    //
+    // The init values let `generate_edits_with_repair` start the very first
+    // call in edit mode against a caller-supplied baseline.
+    let mut asked_for_edits = asked_for_edits_init;
+    let mut prev_dsl: Option<String> = prev_dsl_init;
 
     for iter in 0..=repair.max_iters {
         let resp = client.generate(&cfg)?;
@@ -314,24 +347,37 @@ pub fn repair_message(
             "Produce a corrected DSL file that addresses every error while preserving the \
              original intent. Reply with ONLY the corrected DSL — no commentary, no markdown fences.",
         ),
-        RepairMode::Edits => s.push_str(
-            "Reply with one or more SEARCH/REPLACE blocks that fix every error. Use this exact format:\n\
-             \n\
-             <<<<<<< SEARCH\n\
-             <text copied byte-for-byte from your previous attempt, including indentation>\n\
-             =======\n\
-             <replacement text>\n\
-             >>>>>>> REPLACE\n\
-             \n\
-             Rules:\n\
-             - Each SEARCH must appear EXACTLY ONCE in the previous attempt. If a fragment is ambiguous, expand it with surrounding context until it is unique.\n\
-             - SEARCH must be non-empty.\n\
-             - Emit one block per fix; multiple blocks are applied in order.\n\
-             - Do not include any commentary, explanations, or markdown fences — only the blocks.",
-        ),
+        RepairMode::Edits => {
+            s.push_str("Reply with one or more SEARCH/REPLACE blocks that fix every error. ");
+            s.push_str(EDIT_BLOCK_INSTRUCTIONS);
+        }
     }
     s
 }
+
+/// Format spec appended to a model prompt when we want it to reply with
+/// SEARCH/REPLACE edit blocks instead of a full rewrite. Shared between the
+/// repair loop's recovery turn and the `modify` command's first call so both
+/// paths produce blocks that [`parse_edit_blocks`] can decode the same way.
+///
+/// Callers prepend a one-line lead-in describing what the edits should
+/// achieve (e.g. "fix every error" / "apply your edit") and then drop this
+/// spec straight in.
+pub const EDIT_BLOCK_INSTRUCTIONS: &str =
+    "Use this exact format:\n\
+     \n\
+     <<<<<<< SEARCH\n\
+     <text copied byte-for-byte from the source above, including indentation>\n\
+     =======\n\
+     <replacement text>\n\
+     >>>>>>> REPLACE\n\
+     \n\
+     Rules:\n\
+     - Each SEARCH must appear EXACTLY ONCE in the source. If a fragment is ambiguous, expand it with surrounding context until it is unique.\n\
+     - SEARCH must be non-empty. To insert without removing anything, anchor SEARCH on a unique nearby line and include that line at the start of REPLACE followed by the new content.\n\
+     - To delete, leave REPLACE empty.\n\
+     - Emit one block per logical change; multiple blocks are applied in order.\n\
+     - Do not include any commentary, explanations, or markdown fences — only the blocks.";
 
 /// One SEARCH/REPLACE block parsed from a model response. `search` and
 /// `replace` are the raw strings between the markers, with the leading and

--- a/crates/mogen-llm/tests/mock_server.rs
+++ b/crates/mogen-llm/tests/mock_server.rs
@@ -8,7 +8,8 @@ use std::thread;
 
 use mogen_llm::gemini::GeminiClient;
 use mogen_llm::{
-    generate_with_repair, GenerateConfig, ImageInput, LlmClient, Provider, RepairConfig,
+    generate_edits_with_repair, generate_with_repair, GenerateConfig, ImageInput, LlmClient,
+    Provider, RepairConfig,
 };
 
 struct MockServer {
@@ -427,4 +428,71 @@ fn fireworks_vision_uses_image_url_content() {
     assert_eq!(parts[0]["text"], "describe");
     assert_eq!(parts[1]["type"], "image_url");
     assert_eq!(parts[1]["image_url"]["url"], "data:image/png;base64,AQID");
+}
+
+#[test]
+fn edit_mode_first_call_applies_search_replace_against_baseline() {
+    // The model returns a single SEARCH/REPLACE block. The repair loop
+    // should apply it against the supplied baseline and treat the result as
+    // the candidate DSL — no full rewrite required, dramatically smaller
+    // response payload than re-emitting the entire file.
+    let baseline = "scene { box \"b\" (size=[1,1,1]) }\n";
+    let edit_block = "<<<<<<< SEARCH\nsize=[1,1,1]\n=======\nsize=[2,2,2]\n>>>>>>> REPLACE\n";
+    let server = MockServer::start(vec![&candidate_body(edit_block)]);
+    let client = LlmClient::with_base_url(Provider::Gemini, "test-key", server.base_url());
+
+    let outcome = generate_edits_with_repair(
+        &client,
+        GenerateConfig::new("make it bigger"),
+        &RepairConfig::default(),
+        baseline,
+    )
+    .expect("request ok");
+
+    assert!(outcome.is_ok(), "diagnostics: {:?}", outcome.diagnostics);
+    assert_eq!(outcome.call_count, 1, "edit mode should resolve in one call");
+    assert!(
+        outcome.dsl.contains("size=[2,2,2]"),
+        "edit block should mutate the baseline: {}",
+        outcome.dsl
+    );
+    assert!(
+        !outcome.dsl.contains("size=[1,1,1]"),
+        "old size should be replaced: {}",
+        outcome.dsl
+    );
+}
+
+#[test]
+fn edit_mode_falls_back_to_rewrite_when_model_returns_full_dsl() {
+    // Some models ignore the SEARCH/REPLACE format and emit a full file
+    // anyway (especially when the requested edit is structural). The loop
+    // must transparently treat a parseable DSL response as a rewrite,
+    // otherwise edit-mode would regress the legacy modify happy path.
+    let baseline = "scene { box \"b\" (size=[1,1,1]) }\n";
+    let full_rewrite = "scene { sphere \"s\" (radius=2) }";
+    let server = MockServer::start(vec![&candidate_body(full_rewrite)]);
+    let client = LlmClient::with_base_url(Provider::Gemini, "test-key", server.base_url());
+
+    let outcome = generate_edits_with_repair(
+        &client,
+        GenerateConfig::new("turn it into a sphere"),
+        &RepairConfig::default(),
+        baseline,
+    )
+    .expect("request ok");
+
+    assert!(outcome.is_ok(), "diagnostics: {:?}", outcome.diagnostics);
+    assert_eq!(outcome.call_count, 1);
+    // The model's whole-file rewrite wins, not the baseline.
+    assert!(
+        outcome.dsl.contains("sphere"),
+        "full-file rewrite should pass through: {}",
+        outcome.dsl
+    );
+    assert!(
+        !outcome.dsl.contains("box"),
+        "baseline should not leak into the response: {}",
+        outcome.dsl
+    );
 }

--- a/crates/mogen-studio/src/app/util/llm.rs
+++ b/crates/mogen-studio/src/app/util/llm.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 
 use mogen_llm::{
     apply_style_to_prompt, cacheable_block, default_cache_path, embed_seed_header,
-    format_imports_preserve_block, generate_with_repair, inline_block, parse_prompt_header,
-    parse_seed_header, parse_style_header, repair_message, resolve_or_create_cache,
-    stamp_style_header, summarize_imports, validate_text, visual_refine, GenerateConfig,
-    GoogleCredential, ImageInput, LlmClient, OAuthBundle, Provider, RepairConfig, StdlibIndex,
-    Style, ThinkingLevel, Usage, DEFAULT_TTL_SECONDS,
+    format_imports_preserve_block, generate_edits_with_repair, generate_with_repair, inline_block,
+    parse_prompt_header, parse_seed_header, parse_style_header, repair_message,
+    resolve_or_create_cache, stamp_style_header, summarize_imports, validate_text, visual_refine,
+    GenerateConfig, GoogleCredential, ImageInput, LlmClient, OAuthBundle, Provider, RepairConfig,
+    StdlibIndex, Style, ThinkingLevel, Usage, DEFAULT_TTL_SECONDS, EDIT_BLOCK_INSTRUCTIONS,
 };
 
 use crate::app::error_class::classify;
@@ -278,18 +278,43 @@ pub(in crate::app) fn run_llm(
                 })
                 .map(|s| format!("{s}\n"))
                 .unwrap_or_default();
-            format!(
-                "You are editing an existing mogen DSL file. Apply this modification:\n\n\
-                {mod_prompt}\n\n\
-                {imports_block}\
-                Make the smallest edit that satisfies the request. Do not rename, reorder, \
-                reformat, or restyle parts the modification does not touch.\n\n\
-                Reply with ONLY the full modified DSL — no commentary, no markdown fences. \
-                Do not write a `meta(...)` block; the caller stamps it after generation.\n\n\
-                Existing file:\n\n{existing}",
-                mod_prompt = prompt.trim(),
-                existing = existing.as_deref().unwrap_or("").trim_end(),
-            )
+            // Edit mode (the default): the existing file becomes the
+            // baseline and the model returns SEARCH/REPLACE blocks instead
+            // of re-emitting the full DSL. The repair loop transparently
+            // falls back to a full rewrite when the model ignores the
+            // format, so this is safe even when the response isn't blocks.
+            // Skipped only when there's no existing buffer to edit (an
+            // unsaved Modify call shouldn't really happen, but the spawn
+            // path allows `existing = None`).
+            if existing.as_deref().map(|s| !s.is_empty()).unwrap_or(false) {
+                format!(
+                    "You are editing an existing mogen DSL file. Apply this modification:\n\n\
+                    {mod_prompt}\n\n\
+                    {imports_block}\
+                    Make the smallest edit that satisfies the request. Do not rename, reorder, \
+                    reformat, or restyle parts the modification does not touch.\n\n\
+                    Reply with one or more SEARCH/REPLACE blocks that apply your edit to the \
+                    existing file below. Do not write a `meta(...)` block; the caller stamps \
+                    it after generation. {edit_spec}\n\n\
+                    Existing file:\n\n{existing}",
+                    mod_prompt = prompt.trim(),
+                    existing = existing.as_deref().unwrap_or("").trim_end(),
+                    edit_spec = EDIT_BLOCK_INSTRUCTIONS,
+                )
+            } else {
+                format!(
+                    "You are editing an existing mogen DSL file. Apply this modification:\n\n\
+                    {mod_prompt}\n\n\
+                    {imports_block}\
+                    Make the smallest edit that satisfies the request. Do not rename, reorder, \
+                    reformat, or restyle parts the modification does not touch.\n\n\
+                    Reply with ONLY the full modified DSL — no commentary, no markdown fences. \
+                    Do not write a `meta(...)` block; the caller stamps it after generation.\n\n\
+                    Existing file:\n\n{existing}",
+                    mod_prompt = prompt.trim(),
+                    existing = existing.as_deref().unwrap_or("").trim_end(),
+                )
+            }
         }
         LlmKind::Animate => {
             let imports_block = existing
@@ -482,7 +507,22 @@ pub(in crate::app) fn run_llm(
         allow_edit_mode: true,
     };
 
-    match generate_with_repair(&client, cfg, &repair) {
+    // For Modify with a non-empty existing buffer, run in edit-block mode
+    // so the model can return SEARCH/REPLACE patches against the file
+    // instead of re-emitting the whole DSL. The repair loop's transparent
+    // rewrite fallback handles any model that ignores the format.
+    let modify_baseline = match kind {
+        LlmKind::Modify => existing
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+        _ => None,
+    };
+    let result = match modify_baseline {
+        Some(baseline) => generate_edits_with_repair(&client, cfg, &repair, &baseline),
+        None => generate_with_repair(&client, cfg, &repair),
+    };
+    match result {
         Ok(outcome) => {
             // Roll planner usage/calls into the final summary so the
             // status line reflects the full cost of the run, not just

--- a/crates/mogen/src/cli/cmd.rs
+++ b/crates/mogen/src/cli/cmd.rs
@@ -227,6 +227,14 @@ pub(crate) enum Cmd {
         /// `generate --auto-refine`.
         #[arg(long, default_value_t = 0, value_parser = clap::value_parser!(u32).range(0..=10))]
         auto_refine: u32,
+        /// Force the model to re-emit the entire DSL instead of returning
+        /// SEARCH/REPLACE edit blocks against the existing file. The
+        /// edit-block mode is the default and falls back to a full rewrite
+        /// transparently when blocks don't apply, so this flag is only
+        /// useful when the requested change is broad enough that surgical
+        /// edits would be more fragile than a clean restatement.
+        #[arg(long)]
+        rewrite: bool,
     },
     /// Add or edit animations on an existing DSL file via the configured LLM
     /// provider, then validate and recompile the GLB. The LLM is restricted

--- a/crates/mogen/src/commands/modify.rs
+++ b/crates/mogen/src/commands/modify.rs
@@ -4,9 +4,10 @@ use std::path::PathBuf;
 use anyhow::{anyhow, bail, Context, Result};
 use mogen_llm::{
     apply_style_to_prompt, compose_coder_prompt, embed_seed_header, format_imports_preserve_block,
-    generate_plan, generate_with_repair, parse_prompt_header, parse_seed_header,
-    parse_style_header, parse_thinking_header, stamp_style_header, summarize_imports,
-    visual_refine, GenerateConfig, ImageInput, Provider, RepairConfig, Style, ThinkingLevel, Usage,
+    generate_edits_with_repair, generate_plan, generate_with_repair, parse_prompt_header,
+    parse_seed_header, parse_style_header, parse_thinking_header, stamp_style_header,
+    summarize_imports, visual_refine, GenerateConfig, ImageInput, Provider, RepairConfig, Style,
+    ThinkingLevel, Usage, EDIT_BLOCK_INSTRUCTIONS,
 };
 use crate::refine_render::render_dsl_to_png;
 
@@ -44,6 +45,11 @@ pub(crate) struct ModifyArgs {
     pub plan: bool,
     /// Visual auto-refinement iteration count. `0` skips refinement.
     pub auto_refine: u32,
+    /// Force a full file rewrite instead of asking the model for
+    /// SEARCH/REPLACE edit blocks against the existing file. Useful when the
+    /// requested change is broad enough that surgical edits would be more
+    /// fragile than a clean restatement.
+    pub rewrite: bool,
     /// Gemini credential-resolution mode derived from `--provider`.
     pub auth: GeminiAuthMode,
 }
@@ -152,11 +158,15 @@ pub(crate) fn modify(args: ModifyArgs) -> Result<()> {
         args.prompt.clone()
     };
 
-    let user_prompt = format!(
-        "You are editing an existing mogen DSL file. Apply this modification:\n\n\
-    {mod_prompt}\n\n\
-{imports_block}\
-Make the smallest edit that satisfies the request. Do not rename, reorder, \
+    // Edit mode is the default for `modify`: the existing file is the
+    // baseline and the model returns SEARCH/REPLACE blocks instead of
+    // re-emitting the whole DSL. The repair loop transparently falls back
+    // to a full rewrite if the response can't be parsed/applied as edit
+    // blocks, so this is safe even when the model ignores the format.
+    // `--rewrite` opts back into the legacy full-file path.
+    let edit_mode = !args.rewrite;
+    let trimmed_existing = existing.trim_end();
+    let shared_constraints = "Make the smallest edit that satisfies the request. Do not rename, reorder, \
 reformat, or restyle parts the modification does not touch — preserve their \
 names, materials, transforms, connectors, attaches, joints, clips, and \
 tracks verbatim. Do not \"improve\" unrelated geometry.\n\n\
@@ -166,15 +176,39 @@ the scene or `tags=\"floating\"` on itself or an ancestor — otherwise the \
 geometric connectivity validator (E1101) will reject it. When the edit \
 removes or renames a node, update every reference to that name: `attach \
 parent=`/`child=`, `joint pivot=`, animation `target=`, and any `socket`/\
-`plug` that pointed at a removed connector.\n\n\
+`plug` that pointed at a removed connector.";
+    let user_prompt = if edit_mode {
+        format!(
+            "You are editing an existing mogen DSL file. Apply this modification:\n\n\
+{mod_prompt}\n\n\
+{imports_block}\
+{shared_constraints}\n\n\
+Reply with one or more SEARCH/REPLACE blocks that apply your edit to the \
+existing file below. Do not write a `meta(...)` block; the caller stamps it \
+after generation. {edit_spec}\n\n\
+Existing file:\n\n{existing}",
+            existing = trimmed_existing,
+            mod_prompt = coder_request_prompt.trim(),
+            imports_block = imports_block,
+            shared_constraints = shared_constraints,
+            edit_spec = EDIT_BLOCK_INSTRUCTIONS,
+        )
+    } else {
+        format!(
+            "You are editing an existing mogen DSL file. Apply this modification:\n\n\
+{mod_prompt}\n\n\
+{imports_block}\
+{shared_constraints}\n\n\
 Reply with ONLY the full modified DSL — no commentary, no markdown fences, \
 no diff markers. Emit the entire file, not just the changed region. Do not \
 write a `meta(...)` block; the caller stamps it after generation.\n\n\
 Existing file:\n\n{existing}",
-        existing = existing.trim_end(),
-        mod_prompt = coder_request_prompt.trim(),
-        imports_block = imports_block,
-    );
+            existing = trimmed_existing,
+            mod_prompt = coder_request_prompt.trim(),
+            imports_block = imports_block,
+            shared_constraints = shared_constraints,
+        )
+    };
 
     // Prepend the style block to the assembled scaffold prompt. `None` is
     // a passthrough so the existing prompt stays byte-for-byte identical.
@@ -208,11 +242,21 @@ Existing file:\n\n{existing}",
         allow_edit_mode: true,
     };
 
-    let mut outcome = match generate_with_repair(&client, cfg.clone(), &repair) {
-        Ok(o) => o,
-        Err(e) => {
-            pb.abandon_with_message(format!("modify: {provider_label} error — {e}"));
-            return Err(anyhow!("{}: {e}", provider_label.to_lowercase()));
+    let mut outcome = if edit_mode {
+        match generate_edits_with_repair(&client, cfg.clone(), &repair, &existing) {
+            Ok(o) => o,
+            Err(e) => {
+                pb.abandon_with_message(format!("modify: {provider_label} error — {e}"));
+                return Err(anyhow!("{}: {e}", provider_label.to_lowercase()));
+            }
+        }
+    } else {
+        match generate_with_repair(&client, cfg.clone(), &repair) {
+            Ok(o) => o,
+            Err(e) => {
+                pb.abandon_with_message(format!("modify: {provider_label} error — {e}"));
+                return Err(anyhow!("{}: {e}", provider_label.to_lowercase()));
+            }
         }
     };
     total_usage.add(&outcome.usage);

--- a/crates/mogen/src/main.rs
+++ b/crates/mogen/src/main.rs
@@ -123,6 +123,7 @@ fn main() -> ExitCode {
             style,
             plan,
             auto_refine,
+            rewrite,
         } => modify(ModifyArgs {
             input,
             prompt,
@@ -142,6 +143,7 @@ fn main() -> ExitCode {
             style: style.map(Into::into),
             plan,
             auto_refine,
+            rewrite,
             auth: provider.into(),
         }),
         Cmd::Animate {


### PR DESCRIPTION
## Summary

- `mogen modify` (and Studio's Modify) now ask the model for SEARCH/REPLACE blocks against the existing file instead of re-emitting the whole DSL. Smaller responses, cheaper output tokens, less reasoning budget burned on prose the file already contains.
- New `generate_edits_with_repair(client, cfg, repair, baseline)` initialises the existing repair loop in edit mode on the very first call. Reuses the SEARCH/REPLACE machinery the loop already had for local validator fixes.
- Shared `EDIT_BLOCK_INSTRUCTIONS` constant so the modify prompt and the repair loop's recovery turn emit identically-shaped blocks.
- New `--rewrite` flag on `mogen modify` restores the legacy full-file path when surgical edits would be too fragile.

## Why

Re-emitting a 200-line DSL to flip one number is expensive in output tokens. Edit mode keeps small modifications small. The repair loop already supported SEARCH/REPLACE blocks (it switches to them when all validator errors are local) — this just exposes the same primitive on the first Coder call.

## Safety / fallback

If the model ignores the format and returns a complete DSL file, `parse_edit_blocks` reports `NoBlocks` and the loop transparently falls back to treating the response as a rewrite. Subsequent repair iterations continue with the loop's existing diagnostic-locality-driven mode logic.

## Test plan

- [x] `cargo test -p mogen-llm` — all 12 mock-server tests pass, including two new ones:
  - `edit_mode_first_call_applies_search_replace_against_baseline` — model returns one block, baseline gets mutated, no rewrite.
  - `edit_mode_falls_back_to_rewrite_when_model_returns_full_dsl` — model ignores the format, full file passes through cleanly.
- [x] `cargo check -p mogen -p mogen-llm -p mogen-studio` clean.
- [ ] Real-provider smoke test on `mogen modify examples/chair.mog "make legs taller"` to confirm payload sizes shrink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)