### PR TITLE
Add streaming LLM response support with real-time status updates

### DIFF
--- a/crates/mogen-llm/src/gemini.rs
+++ b/crates/mogen-llm/src/gemini.rs
@@ -845,6 +845,16 @@ struct RawGenerateEnvelope {
 
 #[derive(Debug, Deserialize)]
 struct RawCandidate {
+    // Gemini streams emit several candidate shapes during one response:
+    // text-bearing frames (`content.parts[0].text`), `finishReason`-only
+    // tail frames, and the occasional safety-ratings-only frame. Only
+    // the first carries a `content` block, so this field has to be
+    // tolerated as absent — without `#[serde(default)]` the SSE
+    // accumulator's `from_str` fails on the first non-text frame, sets
+    // `sse_err`, aborts the stream, and the caller sees a half-finished
+    // response. Found in production: a single `finishReason` frame from
+    // gemini-2.5-flash was cutting `modify` off after one token.
+    #[serde(default)]
     content: RawContent,
 }
 

--- a/crates/mogen-llm/src/gemini.rs
+++ b/crates/mogen-llm/src/gemini.rs
@@ -523,7 +523,11 @@ impl GeminiClient {
         if let Some(e) = sse_err {
             return Err(e);
         }
-        if cumulative.is_empty() {
+        // Mirror the OpenAI streaming path: a whitespace-only response
+        // is just as useless as an empty one (no parser anchors land,
+        // the repair loop has nothing to feed back), so treat them the
+        // same.
+        if cumulative.trim().is_empty() {
             return Err(GeminiError::EmptyResponse);
         }
 

--- a/crates/mogen-llm/src/gemini.rs
+++ b/crates/mogen-llm/src/gemini.rs
@@ -444,6 +444,113 @@ impl GeminiClient {
         Ok(bytes.to_vec())
     }
 
+    /// Streaming variant of [`Self::generate`]. Hits
+    /// `:streamGenerateContent?alt=sse` and invokes `on_chunk(delta,
+    /// cumulative)` once per SSE frame, where `delta` is the new text
+    /// just received and `cumulative` is the full response text so far.
+    /// Returns the same [`GenerateResponse`] shape as `generate` at the
+    /// end of the stream so callers can treat the two interchangeably.
+    ///
+    /// OAuth (cloudcode) clients transparently fall back to the
+    /// non-streaming [`Self::generate`] path — `v1internal` exposes a
+    /// `:streamGenerateContent` endpoint but the response envelope
+    /// differs and we don't have a tested mock for it yet. The
+    /// callback simply never fires in that case; the headline status
+    /// remains the coarse "calling Gemini…" the worker already emits.
+    pub fn stream_generate(
+        &self,
+        cfg: &GenerateConfig,
+        on_chunk: &mut dyn FnMut(&str, &str),
+    ) -> Result<GenerateResponse, GeminiError> {
+        let key = match &self.auth {
+            GeminiAuth::ApiKey(k) => k.clone(),
+            GeminiAuth::OAuth(_) | GeminiAuth::AntigravityOAuth(_) => {
+                return self.generate(cfg);
+            }
+        };
+
+        let model = if cfg.model.is_empty() {
+            DEFAULT_MODEL
+        } else {
+            cfg.model.as_str()
+        };
+        let inner = build_request(cfg);
+
+        let url = format!(
+            "{}/models/{}:streamGenerateContent?alt=sse&key={}",
+            self.base_url, model, key,
+        );
+        let resp = self.http.post(&url).json(&inner).send()?;
+        let status = resp.status();
+        if !status.is_success() {
+            let bytes = resp.bytes()?;
+            return Err(GeminiError::Api {
+                status: status.as_u16(),
+                message: parse_error_message(&bytes),
+            });
+        }
+
+        let mut cumulative = String::new();
+        let mut last_usage: Option<RawUsageMetadata> = None;
+        let mut sse_err: Option<GeminiError> = None;
+
+        crate::stream_sse::for_each_sse_data(resp, |payload: &str| {
+            let parsed: RawGenerateResponse = match serde_json::from_str(payload) {
+                Ok(v) => v,
+                Err(e) => {
+                    sse_err = Some(GeminiError::InvalidResponse(e.to_string()));
+                    return false;
+                }
+            };
+            if let Some(delta_text) = parsed
+                .candidates
+                .first()
+                .and_then(|c| c.content.parts.first())
+                .map(|p| p.text.as_str())
+            {
+                if !delta_text.is_empty() {
+                    cumulative.push_str(delta_text);
+                    on_chunk(delta_text, cumulative.as_str());
+                }
+            }
+            if let Some(u) = parsed.usage_metadata {
+                last_usage = Some(u);
+            }
+            true
+        })
+        .map_err(|e| GeminiError::InvalidResponse(format!("SSE read error: {e}")))?;
+
+        if let Some(e) = sse_err {
+            return Err(e);
+        }
+        if cumulative.is_empty() {
+            return Err(GeminiError::EmptyResponse);
+        }
+
+        let usage = last_usage
+            .map(|u| Usage {
+                prompt_tokens: u.prompt_token_count,
+                response_tokens: u.candidates_token_count,
+                total_tokens: u.total_token_count,
+                cached_tokens: u.cached_content_token_count,
+            })
+            .unwrap_or_default();
+
+        if let Some(budget) = cfg.budget_tokens {
+            if usage.total_tokens > budget {
+                return Err(GeminiError::BudgetExceeded {
+                    used: usage.total_tokens,
+                    budget,
+                });
+            }
+        }
+
+        Ok(GenerateResponse {
+            text: cumulative,
+            usage,
+        })
+    }
+
     pub fn generate(&self, cfg: &GenerateConfig) -> Result<GenerateResponse, GeminiError> {
         let model = if cfg.model.is_empty() {
             DEFAULT_MODEL

--- a/crates/mogen-llm/src/gemini.rs
+++ b/crates/mogen-llm/src/gemini.rs
@@ -492,14 +492,22 @@ impl GeminiClient {
 
         let mut cumulative = String::new();
         let mut last_usage: Option<RawUsageMetadata> = None;
-        let mut sse_err: Option<GeminiError> = None;
+        // First per-frame parse error, retained only as a fallback for
+        // the empty-response case. Gemini emits a few candidate shapes
+        // mid-stream (text frames, `finishReason`-only tails, safety
+        // ratings) and the wire format drifts between model versions —
+        // a bad frame in the middle of an otherwise good response
+        // should not amputate the whole stream.
+        let mut first_parse_err: Option<GeminiError> = None;
 
         crate::stream_sse::for_each_sse_data(resp, |payload: &str| {
             let parsed: RawGenerateResponse = match serde_json::from_str(payload) {
                 Ok(v) => v,
                 Err(e) => {
-                    sse_err = Some(GeminiError::InvalidResponse(e.to_string()));
-                    return false;
+                    if first_parse_err.is_none() {
+                        first_parse_err = Some(GeminiError::InvalidResponse(e.to_string()));
+                    }
+                    return true;
                 }
             };
             if let Some(delta_text) = parsed
@@ -520,15 +528,13 @@ impl GeminiClient {
         })
         .map_err(|e| GeminiError::InvalidResponse(format!("SSE read error: {e}")))?;
 
-        if let Some(e) = sse_err {
-            return Err(e);
-        }
         // Mirror the OpenAI streaming path: a whitespace-only response
         // is just as useless as an empty one (no parser anchors land,
         // the repair loop has nothing to feed back), so treat them the
-        // same.
+        // same. Surface the first parse error if we have one so callers
+        // can debug *why* nothing arrived.
         if cumulative.trim().is_empty() {
-            return Err(GeminiError::EmptyResponse);
+            return Err(first_parse_err.unwrap_or(GeminiError::EmptyResponse));
         }
 
         let usage = last_usage

--- a/crates/mogen-llm/src/lib.rs
+++ b/crates/mogen-llm/src/lib.rs
@@ -37,6 +37,8 @@ pub mod provider;
 pub mod refine;
 pub mod repair;
 pub mod settings_store;
+pub mod stream_sse;
+pub mod stream_status;
 pub mod textures;
 pub mod style;
 pub mod types;
@@ -68,6 +70,7 @@ pub use repair::{
     generate_edits_with_repair, generate_with_repair, repair_message, validate_text,
     GenerateOutcome, RepairConfig, EDIT_BLOCK_INSTRUCTIONS,
 };
+pub use stream_status::StreamStatus;
 pub use settings_store::{
     load_api_keys, read_api_key, settings_path as settings_store_path, zai_base_url, ApiKeys,
 };

--- a/crates/mogen-llm/src/openai.rs
+++ b/crates/mogen-llm/src/openai.rs
@@ -113,14 +113,25 @@ impl OpenAIClient {
 
         let mut cumulative = String::new();
         let mut last_usage: Option<RawUsage> = None;
-        let mut sse_err: Option<OpenAIError> = None;
+        // First per-frame parse error, surfaced only if we end up with
+        // zero accumulated text. Real OpenAI-compatible servers ship a
+        // grab-bag of frame shapes that drift between models (reasoning
+        // deltas, `delta: null` finish frames on some compatibility
+        // gateways, server-side error envelopes embedded as SSE data,
+        // …). Aborting the whole stream on the first surprise turned a
+        // mostly-good response into a one-token cut-off, so we now
+        // tolerate per-frame parse failures and only error out if
+        // nothing usable arrived.
+        let mut first_parse_err: Option<OpenAIError> = None;
 
         crate::stream_sse::for_each_sse_data(resp, |payload| {
             let parsed: RawChatChunk = match serde_json::from_str(payload) {
                 Ok(v) => v,
                 Err(e) => {
-                    sse_err = Some(OpenAIError::InvalidResponse(e.to_string()));
-                    return false;
+                    if first_parse_err.is_none() {
+                        first_parse_err = Some(OpenAIError::InvalidResponse(e.to_string()));
+                    }
+                    return true;
                 }
             };
             // A streamed chunk usually has exactly one delta on the first
@@ -130,7 +141,8 @@ impl OpenAIClient {
             if let Some(delta_text) = parsed
                 .choices
                 .first()
-                .and_then(|c| c.delta.content.as_deref())
+                .and_then(|c| c.delta.as_ref())
+                .and_then(|d| d.content.as_deref())
             {
                 if !delta_text.is_empty() {
                     cumulative.push_str(delta_text);
@@ -144,11 +156,10 @@ impl OpenAIClient {
         })
         .map_err(|e| OpenAIError::InvalidResponse(format!("SSE read error: {e}")))?;
 
-        if let Some(e) = sse_err {
-            return Err(e);
-        }
         if cumulative.trim().is_empty() {
-            return Err(OpenAIError::EmptyResponse);
+            // Prefer the underlying parse error if we have one — gives
+            // the caller a chance to see *why* nothing accumulated.
+            return Err(first_parse_err.unwrap_or(OpenAIError::EmptyResponse));
         }
 
         let usage = last_usage
@@ -366,8 +377,13 @@ struct RawChatChunk {
 
 #[derive(Debug, Deserialize)]
 struct RawChunkChoice {
+    // `Option` rather than `#[serde(default)]` on a concrete `RawDelta`
+    // because some OpenAI-compatible gateways (and a few of OpenAI's
+    // own finish-reason frames) ship `"delta": null` explicitly — and
+    // `null` is not a valid input for a struct-typed field, so the
+    // frame would fail to parse and abort the stream.
     #[serde(default)]
-    delta: RawDelta,
+    delta: Option<RawDelta>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/crates/mogen-llm/src/openai.rs
+++ b/crates/mogen-llm/src/openai.rs
@@ -76,6 +76,109 @@ impl OpenAIClient {
         Ok(Self::new(key))
     }
 
+    /// Streaming variant of [`Self::generate`]. Sets `stream: true` plus
+    /// `stream_options.include_usage: true` on the request body and invokes
+    /// `on_chunk(delta, cumulative)` once per SSE frame. Returns the same
+    /// [`GenerateResponse`] shape as `generate` at end-of-stream so callers
+    /// can swap the two transparently.
+    ///
+    /// OpenAI emits the `usage` tally on the final non-`[DONE]` frame when
+    /// `include_usage` is set — that's the value reflected in the returned
+    /// [`Usage`], so token accounting stays accurate vs the non-streaming
+    /// path.
+    pub fn stream_generate(
+        &self,
+        cfg: &GenerateConfig,
+        on_chunk: &mut dyn FnMut(&str, &str),
+    ) -> Result<GenerateResponse, OpenAIError> {
+        let url = format!("{}/chat/completions", self.base_url);
+        let mut body = build_request(cfg);
+        body["stream"] = serde_json::json!(true);
+        body["stream_options"] = serde_json::json!({ "include_usage": true });
+
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()?;
+        let status = resp.status();
+        if !status.is_success() {
+            let bytes = resp.bytes()?;
+            return Err(OpenAIError::Api {
+                status: status.as_u16(),
+                message: parse_error_message(&bytes),
+            });
+        }
+
+        let mut cumulative = String::new();
+        let mut last_usage: Option<RawUsage> = None;
+        let mut sse_err: Option<OpenAIError> = None;
+
+        crate::stream_sse::for_each_sse_data(resp, |payload| {
+            let parsed: RawChatChunk = match serde_json::from_str(payload) {
+                Ok(v) => v,
+                Err(e) => {
+                    sse_err = Some(OpenAIError::InvalidResponse(e.to_string()));
+                    return false;
+                }
+            };
+            // A streamed chunk usually has exactly one delta on the first
+            // choice. Some frames carry only `usage` (the include_usage
+            // tail frame) with no choices — handled by the empty-iterator
+            // path below.
+            if let Some(delta_text) = parsed
+                .choices
+                .iter()
+                .filter_map(|c| c.delta.content.as_deref())
+                .next()
+            {
+                if !delta_text.is_empty() {
+                    cumulative.push_str(delta_text);
+                    on_chunk(delta_text, cumulative.as_str());
+                }
+            }
+            if let Some(u) = parsed.usage {
+                last_usage = Some(u);
+            }
+            true
+        })
+        .map_err(|e| OpenAIError::InvalidResponse(format!("SSE read error: {e}")))?;
+
+        if let Some(e) = sse_err {
+            return Err(e);
+        }
+        if cumulative.trim().is_empty() {
+            return Err(OpenAIError::EmptyResponse);
+        }
+
+        let usage = last_usage
+            .map(|u| Usage {
+                prompt_tokens: u.prompt_tokens,
+                response_tokens: u.completion_tokens,
+                total_tokens: u.total_tokens,
+                cached_tokens: u
+                    .prompt_tokens_details
+                    .and_then(|d| d.cached_tokens)
+                    .unwrap_or(0),
+            })
+            .unwrap_or_default();
+
+        if let Some(budget) = cfg.budget_tokens {
+            if usage.total_tokens > budget {
+                return Err(OpenAIError::BudgetExceeded {
+                    used: usage.total_tokens,
+                    budget,
+                });
+            }
+        }
+
+        Ok(GenerateResponse {
+            text: cumulative,
+            usage,
+        })
+    }
+
     pub fn generate(&self, cfg: &GenerateConfig) -> Result<GenerateResponse, OpenAIError> {
         let url = format!("{}/chat/completions", self.base_url);
         let body = build_request(cfg);
@@ -247,6 +350,31 @@ struct RawUsage {
 struct RawPromptDetails {
     #[serde(default)]
     cached_tokens: Option<u32>,
+}
+
+/// Streaming frame from `chat/completions` with `stream:true`. Differs
+/// from [`RawChatResponse`] only in the `choices[].delta` shape vs
+/// `choices[].message`. `usage` is `None` on every frame until the
+/// final `include_usage` tail frame, which carries an empty `choices`
+/// array and the cumulative usage tally.
+#[derive(Debug, Deserialize)]
+struct RawChatChunk {
+    #[serde(default)]
+    choices: Vec<RawChunkChoice>,
+    #[serde(default)]
+    usage: Option<RawUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawChunkChoice {
+    #[serde(default)]
+    delta: RawDelta,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawDelta {
+    #[serde(default)]
+    content: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/mogen-llm/src/openai.rs
+++ b/crates/mogen-llm/src/openai.rs
@@ -125,13 +125,12 @@ impl OpenAIClient {
             };
             // A streamed chunk usually has exactly one delta on the first
             // choice. Some frames carry only `usage` (the include_usage
-            // tail frame) with no choices — handled by the empty-iterator
-            // path below.
+            // tail frame) with no choices — `first()` returns `None` there
+            // and we just fall through to the usage update below.
             if let Some(delta_text) = parsed
                 .choices
-                .iter()
-                .filter_map(|c| c.delta.content.as_deref())
-                .next()
+                .first()
+                .and_then(|c| c.delta.content.as_deref())
             {
                 if !delta_text.is_empty() {
                     cumulative.push_str(delta_text);

--- a/crates/mogen-llm/src/provider.rs
+++ b/crates/mogen-llm/src/provider.rs
@@ -568,6 +568,32 @@ impl LlmClient {
             LlmClient::Zai(c) => c.generate(cfg).map_err(Into::into),
         }
     }
+
+    /// Streaming variant of [`Self::generate`]. `on_chunk(delta,
+    /// cumulative)` fires once per provider frame — `delta` is the new
+    /// text just received, `cumulative` is the full response so far.
+    /// Returns the same [`GenerateResponse`] shape as `generate` at
+    /// end-of-stream.
+    ///
+    /// Providers without an SSE/NDJSON implementation transparently
+    /// fall through to [`Self::generate`]; the callback simply never
+    /// fires in that case. Today: Gemini (API-key surface) and OpenAI
+    /// stream; everything else falls through.
+    pub fn stream_generate(
+        &self,
+        cfg: &GenerateConfig,
+        on_chunk: &mut dyn FnMut(&str, &str),
+    ) -> Result<GenerateResponse, ProviderError> {
+        match self {
+            LlmClient::Gemini(c) => c.stream_generate(cfg, on_chunk).map_err(Into::into),
+            LlmClient::OpenAI(c) => c.stream_generate(cfg, on_chunk).map_err(Into::into),
+            LlmClient::Anthropic(c) => c.generate(cfg).map_err(Into::into),
+            LlmClient::Ollama(c) => c.generate(cfg).map_err(Into::into),
+            LlmClient::ClaudeCode(c) => c.generate(cfg).map_err(Into::into),
+            LlmClient::Fireworks(c) => c.generate(cfg).map_err(Into::into),
+            LlmClient::Zai(c) => c.generate(cfg).map_err(Into::into),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/mogen-llm/src/repair.rs
+++ b/crates/mogen-llm/src/repair.rs
@@ -175,14 +175,28 @@ fn run_repair_loop(
     let mut prev_dsl: Option<String> = prev_dsl_init;
 
     for iter in 0..=repair.max_iters {
-        // When the caller supplied a chunk callback, stream the model
-        // response so progress can be reported mid-call. Providers
-        // without a streaming implementation transparently fall back
-        // to non-streaming inside `stream_generate`.
+        // When the caller supplied a chunk callback, *try* to stream
+        // the model response so progress can be reported mid-call. If
+        // streaming fails for any reason — a provider-specific frame
+        // shape the SSE accumulator can't make sense of, a connection
+        // that drops mid-stream, an empty/short response that won't
+        // validate — transparently fall back to a fresh non-streaming
+        // call. The non-streaming path is the source of truth for the
+        // response content; streaming is opportunistic UX sugar layered
+        // on top, and a streaming bug must never block the user's
+        // request from completing.
+        //
+        // The fallback re-issues the call rather than reusing whatever
+        // partial text streaming managed to accumulate, because a
+        // partial response would just push the repair loop into a
+        // wasted iteration on garbage.
         let resp = match &repair.on_chunk {
             Some(cb) => {
                 let mut adapter = |delta: &str, cumulative: &str| cb(delta, cumulative);
-                client.stream_generate(&cfg, &mut adapter)?
+                match client.stream_generate(&cfg, &mut adapter) {
+                    Ok(r) => r,
+                    Err(_) => client.generate(&cfg)?,
+                }
             }
             None => client.generate(&cfg)?,
         };

--- a/crates/mogen-llm/src/repair.rs
+++ b/crates/mogen-llm/src/repair.rs
@@ -189,27 +189,25 @@ fn run_repair_loop(
         // Two fallback triggers:
         // - `Err(_)`: the SSE accumulator or HTTP layer rejected the
         //   stream outright.
-        // - Suspiciously short successful response: a "successful"
-        //   stream that returns under `STREAM_MIN_USEFUL_LEN` bytes
-        //   means the model only managed a brief preamble like
-        //   "I'll modify…" or "Thinking…" before the server closed
-        //   the body, which is almost always a stream-transport
-        //   hiccup rather than a genuine model output. The threshold
-        //   is deliberately small (30 bytes) so any real edit-block
-        //   response or even a minimal `scene { … }` rewrite gets
-        //   through, while a preamble-only truncation triggers the
-        //   re-issue.
+        // - Content-shape rejection: a "successful" stream whose body
+        //   is neither SEARCH/REPLACE markup nor parseable DSL is a
+        //   prose-only response (preamble truncation, server-side
+        //   safety reply, the model giving up). Re-issuing through
+        //   the non-streaming endpoint is the cheapest way to discover
+        //   whether the streamed text was a transport hiccup or a
+        //   genuine response — and if it really is genuine, the loop
+        //   uses it on the next iteration with a real diagnostic for
+        //   the model to act on.
         //
         // The fallback re-issues the call rather than reusing whatever
         // partial text streaming managed to accumulate, because a
         // partial response would just push the repair loop into a
         // wasted iteration on garbage.
-        const STREAM_MIN_USEFUL_LEN: usize = 30;
         let resp = match &repair.on_chunk {
             Some(cb) => {
                 let mut adapter = |delta: &str, cumulative: &str| cb(delta, cumulative);
                 match client.stream_generate(&cfg, &mut adapter) {
-                    Ok(r) if r.text.trim().len() >= STREAM_MIN_USEFUL_LEN => r,
+                    Ok(r) if stream_response_is_useful(&r.text) => r,
                     Ok(_) | Err(_) => client.generate(&cfg)?,
                 }
             }
@@ -218,24 +216,52 @@ fn run_repair_loop(
         calls += 1;
         total_usage.add(&resp.usage);
 
-        // Materialise the candidate DSL. Edit-mode: try to parse + apply
-        // SEARCH/REPLACE blocks against the previous attempt; on any failure
-        // (no blocks, malformed, missing/ambiguous match) fall through to
-        // treating the response as a full rewrite. The validator will catch
-        // it if neither interpretation is valid DSL.
-        let dsl = if asked_for_edits {
+        // Materialise the candidate DSL. Edit-mode has three sub-cases:
+        //   - parse + apply succeed → use the merged DSL.
+        //   - parse fails outright (no markers, malformed) → treat the
+        //     response as a full rewrite. `validate_text` catches it if
+        //     the body isn't actually DSL.
+        //   - parse succeeds but apply fails (`SearchNotFound`,
+        //     `SearchAmbiguous`, `EmptySearch`) → the model emitted
+        //     valid markers but the SEARCH text didn't match the
+        //     baseline. Carrying the raw markup forward as if it were
+        //     DSL was the old bug; instead, keep `prev` as the
+        //     candidate and surface a synthetic E0801 diagnostic so the
+        //     repair loop has actionable feedback for the next
+        //     iteration.
+        let (dsl, edit_apply_error) = if asked_for_edits {
             let prev = prev_dsl.as_deref().unwrap_or("");
-            match parse_edit_blocks(&resp.text)
-                .and_then(|blocks| apply_edit_blocks(prev, &blocks))
-            {
-                Ok(merged) => merged,
-                Err(_) => strip_markdown_fences(&resp.text),
+            match parse_edit_blocks(&resp.text) {
+                Ok(blocks) => match apply_edit_blocks(prev, &blocks) {
+                    Ok(merged) => (merged, None),
+                    Err(e) => (prev.to_string(), Some(e)),
+                },
+                Err(_) => (strip_markdown_fences(&resp.text), None),
             }
         } else {
-            strip_markdown_fences(&resp.text)
+            (strip_markdown_fences(&resp.text), None)
         };
 
-        let diags = validate_text(&dsl);
+        let mut diags = validate_text(&dsl);
+        if let Some(e) = edit_apply_error {
+            // Synthetic diagnostic so the repair loop has an actionable
+            // message to feed back. Inserted at the head of the list so
+            // the model sees it first when `repair_message` renders the
+            // diagnostics. The detail names the failure mode (search
+            // not found / ambiguous / empty) and the offending snippet
+            // — `EditError::Display` already formats both.
+            diags.insert(
+                0,
+                Diagnostic::error(
+                    "E0801",
+                    format!(
+                        "SEARCH/REPLACE block could not be applied to the existing file: {e}. \
+                         Re-emit each block with SEARCH copied BYTE-FOR-BYTE from the existing \
+                         file — match whitespace, punctuation, and indentation exactly."
+                    ),
+                ),
+            );
+        }
 
         if !has_errors(&diags) {
             return Ok(GenerateOutcome {
@@ -291,6 +317,40 @@ fn run_repair_loop(
     unreachable!("for loop always returns");
 }
 
+/// True when a streamed response is shaped like content we can actually do
+/// something with. Used as the gate before accepting a streaming response as
+/// authoritative; failures trigger the non-streaming fallback.
+///
+/// Three pass conditions:
+/// - Too short to be a real model output (< 30 bytes after trimming) is
+///   almost always a server-side truncation, regardless of content shape.
+///   The length floor is the cheap pre-filter the old gate did, preserved
+///   so an obviously-truncated response doesn't even make it to the
+///   parse-trial below.
+/// - Contains the SEARCH marker → the model attempted the surgical-edit
+///   form. Whether each block applies is decided downstream; if it doesn't,
+///   the repair loop's `E0801` synthetic diagnostic gives the next
+///   iteration a real lever to pull. We do *not* require the closing
+///   `REPLACE` marker because a truncated edit-block response is still
+///   recognisable as one and should follow the same downstream path
+///   rather than re-issuing the call (which would just produce the same
+///   truncation).
+/// - Trial-parses as DSL → the model returned a full rewrite, or a
+///   well-formed file alongside markup. We rely on `mogen_dsl::parse`
+///   instead of substring matching so a prose response that happens to
+///   include the word "scene" doesn't sneak past.
+pub(crate) fn stream_response_is_useful(text: &str) -> bool {
+    const STREAM_MIN_USEFUL_LEN: usize = 30;
+    let trimmed = text.trim();
+    if trimmed.len() < STREAM_MIN_USEFUL_LEN {
+        return false;
+    }
+    if trimmed.contains("<<<<<<< SEARCH") {
+        return true;
+    }
+    mogen_dsl::parse(&strip_markdown_fences(text)).is_ok()
+}
+
 /// Validate DSL text, producing a Diagnostic list. Parse errors are promoted to
 /// a synthetic E0001 diagnostic; lowering failures (e.g. unresolved `attach`
 /// references) are promoted to E0701 so the repair loop can emit them in the
@@ -342,6 +402,10 @@ pub fn is_local_only(diags: &[Diagnostic]) -> bool {
             | "E0413" | "E0414" | "E0421"
             // attach attrs
             | "E0601" | "E0602"
+            // SEARCH/REPLACE apply failure — model already attempted
+            // edit mode, the right retry is another edit-block call
+            // with the hint that SEARCH must match byte-for-byte.
+            | "E0801"
         );
         if !local {
             return false;
@@ -655,6 +719,7 @@ pub fn fix_hint(code: &str) -> Option<&'static str> {
         "E1006" => "Joint index out of range — a bone referenced by a `track` isn't in the declared skeleton. Add it or rename the track.",
         "E1007" => "Vertex weights don't sum to 1.0 — the mesh has vertices outside every bone's envelope. Widen `envelope=` on the nearest bone so each vertex sits inside at least one bone's radius (0.15–0.25 m for a humanoid limb).",
         "E1101" => "Disconnected part clusters — either `attach` the orphan parts to the main body (directly or through an intermediate), or put `tags=\"floating\"` on the orphan subtree (or an ancestor) if the gap is intentional (chandelier, rotor, orbiting body).",
+        "E0801" => "Your SEARCH text didn't appear verbatim in the file. Copy the SEARCH region BYTE-FOR-BYTE from the source (preserve every space, newline, and punctuation mark). If a fragment is ambiguous, expand SEARCH with surrounding context until it appears exactly once.",
         _ => return None,
     })
 }
@@ -991,6 +1056,7 @@ mod tests {
             "E0411", "E0412", "E0413", "E0414", "E0421",
             "E0501", "E0502", "E0503", "E0504", "E0505",
             "E0601", "E0602", "E0701",
+            "E0801",
             "E1001", "E1002", "E1003", "E1004", "E1005", "E1006", "E1007",
             "E1101",
         ] {
@@ -999,5 +1065,50 @@ mod tests {
         // Warnings and unknowns fall through.
         assert!(fix_hint("W0102").is_none());
         assert!(fix_hint("E9999").is_none());
+    }
+
+    #[test]
+    fn stream_response_is_useful_accepts_edit_blocks() {
+        let body = "I'll edit the file.\n\n<<<<<<< SEARCH\nfoo\n=======\nbar\n>>>>>>> REPLACE\n";
+        assert!(stream_response_is_useful(body));
+    }
+
+    #[test]
+    fn stream_response_is_useful_accepts_parseable_dsl() {
+        let body = "scene { box \"b\" (size=[1,1,1]) }\n";
+        assert!(stream_response_is_useful(body));
+    }
+
+    #[test]
+    fn stream_response_is_useful_accepts_dsl_inside_markdown_fences() {
+        let body = "```mogen\nscene { box \"b\" (size=[1,1,1]) }\n```\n";
+        assert!(stream_response_is_useful(body));
+    }
+
+    #[test]
+    fn stream_response_is_useful_rejects_short_response() {
+        // The old 30-byte length floor is preserved as a fast pre-filter.
+        assert!(!stream_response_is_useful("I'll modify"));
+    }
+
+    #[test]
+    fn stream_response_is_useful_rejects_long_prose_preamble() {
+        // The exact bug from the trace test: a 60+ byte prose preamble
+        // that mentions "scene" in a sentence but doesn't parse as DSL.
+        // The old 30-byte gate accepted this; the content-aware gate
+        // rejects it so the fallback re-issues the call.
+        let body = "Sure — I'll modify the scene to make the legs taller. Stand by while I work on it.";
+        assert!(!stream_response_is_useful(body));
+    }
+
+    #[test]
+    fn stream_response_is_useful_accepts_edit_blocks_even_when_search_wont_match() {
+        // The downstream `apply_edit_blocks` may still reject the body
+        // (mismatched SEARCH text), but that's handled by the E0801
+        // synthetic diagnostic — the stream-gate's job is just to
+        // decide whether to re-issue. A SEARCH marker means the model
+        // tried; re-issuing would only produce the same response.
+        let body = "<<<<<<< SEARCH\nthis won't match anything\n=======\nreplacement\n>>>>>>> REPLACE\n";
+        assert!(stream_response_is_useful(body));
     }
 }

--- a/crates/mogen-llm/src/repair.rs
+++ b/crates/mogen-llm/src/repair.rs
@@ -29,6 +29,23 @@ pub struct RepairConfig {
     /// Called with each repair feedback message (for CLI progress output).
     /// Keeps this crate free of println! noise.
     pub on_iteration: Option<Box<dyn Fn(u32, &[Diagnostic])>>,
+    /// When `Some`, the loop switches each iteration to
+    /// [`LlmClient::stream_generate`] and invokes this callback with
+    /// `(delta, cumulative)` once per provider frame. Used by the Studio
+    /// progress card to render fine-grained status messages mid-call
+    /// ("writing geometry", "authoring animation", …) without waiting
+    /// for the response to land. Cleared automatically between
+    /// iterations so the same callback drives each repair retry.
+    ///
+    /// Providers without a streaming implementation see no per-chunk
+    /// calls — they transparently fall back to non-streaming and the
+    /// callback simply never fires.
+    ///
+    /// Symmetric with [`Self::on_iteration`]: takes `&self`, so any
+    /// mutable progress state (a `StreamStatus`, a last-emit
+    /// [`Instant`](std::time::Instant), …) must live behind interior
+    /// mutability in the caller's closure.
+    pub on_chunk: Option<Box<dyn Fn(&str, &str)>>,
     /// When all errors on a turn are "local" (typo / wrong attr type / unknown
     /// material), ask the model for SEARCH/REPLACE blocks instead of a full
     /// rewrite. Cuts output tokens dramatically on small fix-ups; falls back
@@ -39,7 +56,12 @@ pub struct RepairConfig {
 
 impl Default for RepairConfig {
     fn default() -> Self {
-        Self { max_iters: 2, on_iteration: None, allow_edit_mode: true }
+        Self {
+            max_iters: 2,
+            on_iteration: None,
+            on_chunk: None,
+            allow_edit_mode: true,
+        }
     }
 }
 
@@ -48,6 +70,7 @@ impl std::fmt::Debug for RepairConfig {
         f.debug_struct("RepairConfig")
             .field("max_iters", &self.max_iters)
             .field("on_iteration", &self.on_iteration.is_some())
+            .field("on_chunk", &self.on_chunk.is_some())
             .field("allow_edit_mode", &self.allow_edit_mode)
             .finish()
     }
@@ -152,7 +175,17 @@ fn run_repair_loop(
     let mut prev_dsl: Option<String> = prev_dsl_init;
 
     for iter in 0..=repair.max_iters {
-        let resp = client.generate(&cfg)?;
+        // When the caller supplied a chunk callback, stream the model
+        // response so progress can be reported mid-call. Providers
+        // without a streaming implementation transparently fall back
+        // to non-streaming inside `stream_generate`.
+        let resp = match &repair.on_chunk {
+            Some(cb) => {
+                let mut adapter = |delta: &str, cumulative: &str| cb(delta, cumulative);
+                client.stream_generate(&cfg, &mut adapter)?
+            }
+            None => client.generate(&cfg)?,
+        };
         calls += 1;
         total_usage.add(&resp.usage);
 

--- a/crates/mogen-llm/src/repair.rs
+++ b/crates/mogen-llm/src/repair.rs
@@ -179,23 +179,38 @@ fn run_repair_loop(
         // the model response so progress can be reported mid-call. If
         // streaming fails for any reason — a provider-specific frame
         // shape the SSE accumulator can't make sense of, a connection
-        // that drops mid-stream, an empty/short response that won't
-        // validate — transparently fall back to a fresh non-streaming
-        // call. The non-streaming path is the source of truth for the
-        // response content; streaming is opportunistic UX sugar layered
-        // on top, and a streaming bug must never block the user's
-        // request from completing.
+        // that drops mid-stream, an empty/short response, a server
+        // that closes the body after one token — transparently fall
+        // back to a fresh non-streaming call. The non-streaming path
+        // is the source of truth for the response content; streaming
+        // is opportunistic UX sugar layered on top, and a streaming
+        // bug must never block the user's request from completing.
+        //
+        // Two fallback triggers:
+        // - `Err(_)`: the SSE accumulator or HTTP layer rejected the
+        //   stream outright.
+        // - Suspiciously short successful response: a "successful"
+        //   stream that returns under `STREAM_MIN_USEFUL_LEN` bytes
+        //   means the model only managed a brief preamble like
+        //   "I'll modify…" or "Thinking…" before the server closed
+        //   the body, which is almost always a stream-transport
+        //   hiccup rather than a genuine model output. The threshold
+        //   is deliberately small (30 bytes) so any real edit-block
+        //   response or even a minimal `scene { … }` rewrite gets
+        //   through, while a preamble-only truncation triggers the
+        //   re-issue.
         //
         // The fallback re-issues the call rather than reusing whatever
         // partial text streaming managed to accumulate, because a
         // partial response would just push the repair loop into a
         // wasted iteration on garbage.
+        const STREAM_MIN_USEFUL_LEN: usize = 30;
         let resp = match &repair.on_chunk {
             Some(cb) => {
                 let mut adapter = |delta: &str, cumulative: &str| cb(delta, cumulative);
                 match client.stream_generate(&cfg, &mut adapter) {
-                    Ok(r) => r,
-                    Err(_) => client.generate(&cfg)?,
+                    Ok(r) if r.text.trim().len() >= STREAM_MIN_USEFUL_LEN => r,
+                    Ok(_) | Err(_) => client.generate(&cfg)?,
                 }
             }
             None => client.generate(&cfg)?,

--- a/crates/mogen-llm/src/stream_sse.rs
+++ b/crates/mogen-llm/src/stream_sse.rs
@@ -1,0 +1,123 @@
+//! Minimal blocking SSE reader for streaming LLM responses.
+//!
+//! Both Gemini's `:streamGenerateContent?alt=sse` and OpenAI's Chat
+//! Completions with `stream: true` use the standard text/event-stream
+//! framing: a sequence of `field: value` lines terminated by a blank
+//! line. We only care about the `data:` payload (the per-frame JSON) so
+//! this helper passes the trimmed payload string to a caller-supplied
+//! callback once per frame, filtering out comments, empty payloads, and
+//! the OpenAI-style `[DONE]` terminator.
+//!
+//! The callback returns `bool`: `false` stops reading early — used by
+//! callers that need to abort mid-stream (cancel button, budget tripped
+//! in a streamed usage frame, etc.). Stops automatically on EOF.
+//!
+//! No tokio — `BufRead::read_line` on a `reqwest::blocking::Response`
+//! is enough for the blocking client this crate already runs on.
+
+use std::io::{BufRead, BufReader, Read};
+
+/// Drive `on_data` once per SSE frame's `data:` payload. Returns when
+/// the stream EOFs or the callback returns `false`. Bubbles up the
+/// first read error.
+pub fn for_each_sse_data<R, F>(reader: R, mut on_data: F) -> std::io::Result<()>
+where
+    R: Read,
+    F: FnMut(&str) -> bool,
+{
+    let mut reader = BufReader::new(reader);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line)?;
+        if n == 0 {
+            break;
+        }
+        let trimmed = line.trim_end_matches(['\n', '\r']);
+        if trimmed.is_empty() {
+            // Frame boundary — Gemini emits one frame per `data:` line so
+            // we don't need to buffer multi-line frames.
+            continue;
+        }
+        // Strip `data:` (with or without the leading space servers usually
+        // include). Drop other field lines silently — we don't care about
+        // `event:`, `id:`, retries, or `:` comments.
+        let payload = match trimmed.strip_prefix("data:") {
+            Some(rest) => rest.trim_start(),
+            None => continue,
+        };
+        if payload.is_empty() || payload == "[DONE]" {
+            continue;
+        }
+        if !on_data(payload) {
+            break;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn yields_each_data_payload() {
+        let body = b"data: {\"a\":1}\n\ndata: {\"b\":2}\n\n";
+        let mut got = Vec::new();
+        for_each_sse_data(Cursor::new(&body[..]), |p| {
+            got.push(p.to_string());
+            true
+        })
+        .unwrap();
+        assert_eq!(got, vec!["{\"a\":1}".to_string(), "{\"b\":2}".to_string()]);
+    }
+
+    #[test]
+    fn skips_done_terminator_and_blank_data() {
+        let body = b"data: hello\n\ndata:\n\ndata: [DONE]\n\n";
+        let mut got = Vec::new();
+        for_each_sse_data(Cursor::new(&body[..]), |p| {
+            got.push(p.to_string());
+            true
+        })
+        .unwrap();
+        assert_eq!(got, vec!["hello".to_string()]);
+    }
+
+    #[test]
+    fn ignores_non_data_lines() {
+        let body = b"event: ping\n: comment\ndata: payload\n\n";
+        let mut got = Vec::new();
+        for_each_sse_data(Cursor::new(&body[..]), |p| {
+            got.push(p.to_string());
+            true
+        })
+        .unwrap();
+        assert_eq!(got, vec!["payload".to_string()]);
+    }
+
+    #[test]
+    fn callback_returning_false_stops_iteration() {
+        let body = b"data: 1\n\ndata: 2\n\ndata: 3\n\n";
+        let mut got = Vec::new();
+        for_each_sse_data(Cursor::new(&body[..]), |p| {
+            got.push(p.to_string());
+            p != "2" // stop after the 2nd frame
+        })
+        .unwrap();
+        assert_eq!(got, vec!["1".to_string(), "2".to_string()]);
+    }
+
+    #[test]
+    fn tolerates_data_with_no_leading_space() {
+        let body = b"data:tight\n\n";
+        let mut got = Vec::new();
+        for_each_sse_data(Cursor::new(&body[..]), |p| {
+            got.push(p.to_string());
+            true
+        })
+        .unwrap();
+        assert_eq!(got, vec!["tight".to_string()]);
+    }
+}

--- a/crates/mogen-llm/src/stream_sse.rs
+++ b/crates/mogen-llm/src/stream_sse.rs
@@ -4,9 +4,16 @@
 //! Completions with `stream: true` use the standard text/event-stream
 //! framing: a sequence of `field: value` lines terminated by a blank
 //! line. We only care about the `data:` payload (the per-frame JSON) so
-//! this helper passes the trimmed payload string to a caller-supplied
+//! this helper passes the assembled payload string to a caller-supplied
 //! callback once per frame, filtering out comments, empty payloads, and
 //! the OpenAI-style `[DONE]` terminator.
+//!
+//! Per the WHATWG SSE spec, multiple `data:` lines within a single
+//! event are concatenated with `\n` and dispatched together on the
+//! blank-line boundary. Today both Gemini and OpenAI emit single-line
+//! `data:` frames so this rarely matters, but we follow the spec so a
+//! future envelope change (or a new provider) doesn't silently corrupt
+//! payloads.
 //!
 //! The callback returns `bool`: `false` stops reading early — used by
 //! callers that need to abort mid-stream (cancel button, budget tripped
@@ -27,31 +34,45 @@ where
 {
     let mut reader = BufReader::new(reader);
     let mut line = String::new();
+    // Accumulator for `data:` lines within the current event. The spec
+    // says to join them with `\n` and dispatch on the blank-line
+    // boundary; we trim the trailing `\n` before handing the payload
+    // off so single-line frames stay byte-identical to the wire form.
+    let mut data_buf = String::new();
     loop {
         line.clear();
         let n = reader.read_line(&mut line)?;
-        if n == 0 {
-            break;
-        }
+        let eof = n == 0;
         let trimmed = line.trim_end_matches(['\n', '\r']);
         if trimmed.is_empty() {
-            // Frame boundary — Gemini emits one frame per `data:` line so
-            // we don't need to buffer multi-line frames.
+            // Blank line (or EOF) → dispatch the accumulated event.
+            if !data_buf.is_empty() {
+                // Strip the trailing `\n` the spec appends after every
+                // `data:` line; for single-line frames this leaves the
+                // payload exactly as it appeared on the wire.
+                if data_buf.ends_with('\n') {
+                    data_buf.pop();
+                }
+                let payload = data_buf.as_str();
+                if !payload.is_empty() && payload != "[DONE]" && !on_data(payload) {
+                    return Ok(());
+                }
+                data_buf.clear();
+            }
+            if eof {
+                break;
+            }
             continue;
         }
-        // Strip `data:` (with or without the leading space servers usually
-        // include). Drop other field lines silently — we don't care about
-        // `event:`, `id:`, retries, or `:` comments.
+        // Strip `data:` (with or without the leading space servers
+        // usually include). Drop other field lines silently — we don't
+        // care about `event:`, `id:`, retries, or `:` comments.
         let payload = match trimmed.strip_prefix("data:") {
-            Some(rest) => rest.trim_start(),
+            Some(rest) => rest.strip_prefix(' ').unwrap_or(rest),
             None => continue,
         };
-        if payload.is_empty() || payload == "[DONE]" {
-            continue;
-        }
-        if !on_data(payload) {
-            break;
-        }
+        data_buf.push_str(payload);
+        data_buf.push('\n');
     }
     Ok(())
 }
@@ -119,5 +140,37 @@ mod tests {
         })
         .unwrap();
         assert_eq!(got, vec!["tight".to_string()]);
+    }
+
+    #[test]
+    fn joins_multiple_data_lines_in_one_event_with_newlines() {
+        // Per the SSE spec, two `data:` lines before the blank line are
+        // one event whose payload is `line1\nline2`. Neither Gemini nor
+        // OpenAI ships this today, but the reader has to honour it so a
+        // future provider (or a JSON payload that contains a literal
+        // newline) doesn't get silently truncated to the last line.
+        let body = b"data: line1\ndata: line2\n\n";
+        let mut got = Vec::new();
+        for_each_sse_data(Cursor::new(&body[..]), |p| {
+            got.push(p.to_string());
+            true
+        })
+        .unwrap();
+        assert_eq!(got, vec!["line1\nline2".to_string()]);
+    }
+
+    #[test]
+    fn dispatches_final_event_without_trailing_blank_line() {
+        // Streams sometimes close mid-event (server EOFs after the last
+        // `data:` line). Anything we already buffered should still fire
+        // so the caller doesn't lose the tail frame.
+        let body = b"data: tail";
+        let mut got = Vec::new();
+        for_each_sse_data(Cursor::new(&body[..]), |p| {
+            got.push(p.to_string());
+            true
+        })
+        .unwrap();
+        assert_eq!(got, vec!["tail".to_string()]);
     }
 }

--- a/crates/mogen-llm/src/stream_status.rs
+++ b/crates/mogen-llm/src/stream_status.rs
@@ -17,6 +17,16 @@
 //! [`observe`] returns `Some(headline)` only when the label or the
 //! rough geometry-node count has changed since the previous call,
 //! keeping the studio's status channel quiet between transitions.
+//!
+//! ## Known limitations
+//!
+//! Substring matching is content-blind: an anchor like `clip(` will
+//! also fire if the model emits the literal text `clip(` inside a
+//! string attribute (most plausibly `meta(prompt="…clip(spin)…")`).
+//! Because anchors are walked in order and **last-anchor-wins**, a
+//! false positive on an early stage gets overridden as soon as a real
+//! later anchor lands, so the worst observable outcome is a brief
+//! flicker in the status line — not a stuck or wrong final state.
 
 /// Per-call state for one streaming run. Tracks the last status the
 /// caller emitted so [`observe`] can suppress unchanged updates.

--- a/crates/mogen-llm/src/stream_status.rs
+++ b/crates/mogen-llm/src/stream_status.rs
@@ -1,0 +1,206 @@
+//! Turn a partially-streamed DSL response into a short status string.
+//!
+//! The streaming clients call [`StreamStatus::observe`] with the cumulative
+//! response text on every SSE frame. We deliberately do **not** parse the
+//! source — mid-edit it would parse-fail most frames — so this module uses
+//! cheap substring scans for the keyword that opens each top-level
+//! declaration kind and reports the latest stage the model has reached.
+//!
+//! The progression mirrors how a Coder model is instructed to write a
+//! `mogen` DSL file: `meta(` first, then `material(`, then optional
+//! `module` declarations, then `scene { … }` for the geometry, then any
+//! rigging / animation declarations at the bottom. Stages are walked in
+//! order so the **last hit wins** — once `clip(` appears we settle on
+//! "authoring animation" even though `meta(` and `scene` are still in
+//! the buffer.
+//!
+//! [`observe`] returns `Some(headline)` only when the label or the
+//! rough geometry-node count has changed since the previous call,
+//! keeping the studio's status channel quiet between transitions.
+
+/// Per-call state for one streaming run. Tracks the last status the
+/// caller emitted so [`observe`] can suppress unchanged updates.
+#[derive(Default, Debug, Clone)]
+pub struct StreamStatus {
+    last_label: Option<&'static str>,
+    last_nodes: usize,
+}
+
+/// Stage anchors in the order a `mogen` Coder typically emits them. The
+/// last entry whose substring appears in the cumulative buffer wins, so
+/// the user sees the progression `thinking → header → materials →
+/// geometry → animation` instead of getting stuck on the first stage
+/// that ever appeared.
+///
+/// Substrings are intentionally tight enough that they don't trip
+/// inside an identifier or attribute value (`material(` vs the literal
+/// word "material" in a comment, `scene ` with the trailing space vs
+/// `scene_thing`). Each anchor is the byte-exact form the grammar
+/// emits at the start of a declaration.
+const STAGES: &[(&str, &str)] = &[
+    ("meta(", "writing header"),
+    ("meta (", "writing header"),
+    ("material(", "choosing materials"),
+    ("material \"", "choosing materials"),
+    ("module ", "defining modules"),
+    ("scene {", "writing geometry"),
+    ("scene{", "writing geometry"),
+    // Inside-scene structure tells us the model is mid-geometry rather
+    // than just opening the block.
+    ("connector(", "placing connectors"),
+    ("connector \"", "placing connectors"),
+    ("array(", "arraying parts"),
+    ("mirror(", "mirroring parts"),
+    ("difference(", "carving with CSG"),
+    ("union(", "combining shapes"),
+    ("intersect(", "combining shapes"),
+    ("attach(", "linking parts"),
+    ("attach (", "linking parts"),
+    ("skeleton ", "rigging skeleton"),
+    ("bone ", "rigging skeleton"),
+    ("skin=", "binding skin"),
+    // Animation declarations are top-level after `scene { … }`, so any
+    // of these landing in the buffer means we're past geometry.
+    ("joint ", "authoring animation"),
+    ("clip ", "authoring animation"),
+    ("clip(", "authoring animation"),
+    ("spin ", "authoring animation"),
+    ("open_close ", "authoring animation"),
+    ("wave ", "authoring animation"),
+    ("flap ", "authoring animation"),
+    ("idle ", "authoring animation"),
+];
+
+impl StreamStatus {
+    /// Re-evaluate the latest streamed text. Returns `Some(headline)`
+    /// when the displayable status has changed since the previous call,
+    /// `None` otherwise. Pre-anchor frames (the model is still thinking
+    /// or has only emitted whitespace / a markdown fence) report
+    /// `"thinking…"`.
+    pub fn observe(&mut self, cumulative: &str) -> Option<String> {
+        let nodes = count_geometry_nodes(cumulative);
+
+        let label = pick_label(cumulative).unwrap_or("thinking…");
+
+        let label_changed = self.last_label != Some(label);
+        let nodes_changed = nodes != self.last_nodes;
+        if !label_changed && !nodes_changed {
+            return None;
+        }
+        self.last_label = Some(label);
+        self.last_nodes = nodes;
+
+        Some(if nodes > 0 {
+            format!("{label} · {nodes} nodes")
+        } else {
+            label.to_string()
+        })
+    }
+}
+
+fn pick_label(cumulative: &str) -> Option<&'static str> {
+    // Walk the table in order; the last anchor present wins so we land
+    // on the most recently entered stage rather than the first stage
+    // the model ever emitted.
+    let mut chosen: Option<&'static str> = None;
+    for (anchor, label) in STAGES {
+        if cumulative.contains(anchor) {
+            chosen = Some(label);
+        }
+    }
+    chosen
+}
+
+/// Rough proxy for "how many primitives has the model declared so far".
+/// Every primitive (`box`, `cylinder`, `sphere`, …) emits exactly one
+/// `(size=`, `(radius=`, or `(pos=` attribute opener. Counting those
+/// substrings is much cheaper than tokenizing and good enough for a
+/// status counter — over-counting by one or two doesn't matter.
+fn count_geometry_nodes(s: &str) -> usize {
+    let mut n = 0usize;
+    for needle in &["(size=", "(radius=", "(height="] {
+        n += s.matches(needle).count();
+    }
+    n
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_thinking_before_any_anchor() {
+        let mut s = StreamStatus::default();
+        assert_eq!(s.observe(""), Some("thinking…".to_string()));
+        // No change → no further emit.
+        assert_eq!(s.observe("```"), None);
+    }
+
+    #[test]
+    fn picks_meta_then_material_then_scene() {
+        let mut s = StreamStatus::default();
+        assert_eq!(s.observe(""), Some("thinking…".to_string()));
+        assert_eq!(
+            s.observe("meta(name=\"x\")"),
+            Some("writing header".to_string()),
+        );
+        assert_eq!(
+            s.observe("meta(name=\"x\")\nmaterial(\"wood\""),
+            Some("choosing materials".to_string()),
+        );
+        let geom = "meta(name=\"x\")\nmaterial(\"wood\")\nscene {\n  box \"a\" (size=[1,1,1])";
+        let out = s.observe(geom).expect("status should advance");
+        assert!(out.starts_with("writing geometry"), "got {out:?}");
+        assert!(out.contains("1 nodes"), "node count missing: {out:?}");
+    }
+
+    #[test]
+    fn animation_anchor_overrides_earlier_stages() {
+        let mut s = StreamStatus::default();
+        let full = "meta(x)\nmaterial(\"w\")\nscene { box \"b\" (size=[1,1,1]) }\nclip \"c\" (seconds=1.0)";
+        let out = s.observe(full).unwrap();
+        assert!(out.starts_with("authoring animation"), "got {out:?}");
+    }
+
+    #[test]
+    fn suppresses_unchanged_status() {
+        let mut s = StreamStatus::default();
+        let buf = "meta(name=\"x\")";
+        assert_eq!(s.observe(buf), Some("writing header".to_string()));
+        // Same anchor, same node count → no re-emit.
+        assert_eq!(s.observe(buf), None);
+        assert_eq!(s.observe("meta(name=\"x\", version=\"1\""), None);
+    }
+
+    #[test]
+    fn node_count_drives_emit_even_when_label_stable() {
+        let mut s = StreamStatus::default();
+        let one = "scene { box \"a\" (size=[1,1,1])";
+        let first = s.observe(one).unwrap();
+        assert!(first.contains("1 nodes"));
+        let two = "scene { box \"a\" (size=[1,1,1]) box \"b\" (size=[2,2,2])";
+        let second = s.observe(two).unwrap();
+        assert!(second.contains("2 nodes"), "got {second:?}");
+    }
+
+    #[test]
+    fn skeleton_and_skin_distinguished() {
+        let mut s = StreamStatus::default();
+        let rig = "meta(x)\nscene {\n  skeleton \"arm\" { bone \"root\" (pos=[0,0,0]) }\n";
+        let out = s.observe(rig).unwrap();
+        assert!(out.starts_with("rigging skeleton"), "got {out:?}");
+
+        let mut s2 = StreamStatus::default();
+        let skin = "meta(x)\nscene {\n  skeleton \"arm\" {}\n  cylinder \"c\" (radius=0.1, skin=\"arm\"";
+        let out = s2.observe(skin).unwrap();
+        assert!(out.starts_with("binding skin"), "got {out:?}");
+    }
+
+    #[test]
+    fn csg_overrides_plain_geometry() {
+        let mut s = StreamStatus::default();
+        let csg = "scene { difference(\n  box \"shell\" (size=[1,1,1])";
+        let out = s.observe(csg).unwrap();
+        assert!(out.starts_with("carving with CSG"), "got {out:?}");
+    }
+}

--- a/crates/mogen-llm/src/stream_status.rs
+++ b/crates/mogen-llm/src/stream_status.rs
@@ -48,6 +48,13 @@ pub struct StreamStatus {
 /// `scene_thing`). Each anchor is the byte-exact form the grammar
 /// emits at the start of a declaration.
 const STAGES: &[(&str, &str)] = &[
+    // Modify-with-edits responses (SEARCH/REPLACE blocks) come first
+    // so they win on Modify calls — the model emits these top-down
+    // and rarely also contains a top-level `meta(` or `scene {` in
+    // the search/replace bodies. Anchored on the marker text the
+    // repair loop's `parse_edit_blocks` expects byte-for-byte.
+    ("<<<<<<< SEARCH", "writing edits"),
+    (">>>>>>> REPLACE", "applying edits"),
     ("meta(", "writing header"),
     ("meta (", "writing header"),
     ("material(", "choosing materials"),
@@ -204,6 +211,23 @@ mod tests {
         let skin = "meta(x)\nscene {\n  skeleton \"arm\" {}\n  cylinder \"c\" (radius=0.1, skin=\"arm\"";
         let out = s2.observe(skin).unwrap();
         assert!(out.starts_with("binding skin"), "got {out:?}");
+    }
+
+    #[test]
+    fn search_replace_block_surfaces_writing_edits_label() {
+        // Modify-with-edit responses start with `<<<<<<< SEARCH` and
+        // rarely embed top-level DSL kind keywords in their bodies, so
+        // without an edit-block anchor `pick_label` falls through to
+        // `None` and the status stays at "thinking…" for the whole
+        // call — that was confusing users into thinking modify had
+        // hung.
+        let mut s = StreamStatus::default();
+        let mid = "<<<<<<< SEARCH\nfoo\n=======\nbar\n";
+        let out = s.observe(mid).unwrap();
+        assert!(out.starts_with("writing edits"), "got {out:?}");
+        let complete = "<<<<<<< SEARCH\nfoo\n=======\nbar\n>>>>>>> REPLACE\n";
+        let out = s.observe(complete).unwrap();
+        assert!(out.starts_with("applying edits"), "got {out:?}");
     }
 
     #[test]

--- a/crates/mogen-llm/tests/mock_server.rs
+++ b/crates/mogen-llm/tests/mock_server.rs
@@ -675,6 +675,53 @@ fn repair_loop_falls_back_to_non_streaming_when_stream_returns_truncated_text() 
 }
 
 #[test]
+fn repair_loop_falls_back_to_non_streaming_when_stream_returns_long_prose_preamble() {
+    // A 60+ byte prose preamble (well past the old 30-byte length gate)
+    // that doesn't contain edit-block markers and doesn't parse as DSL.
+    // The content-aware `stream_response_is_useful` predicate rejects it
+    // so the loop falls back to the non-streaming endpoint, which here
+    // returns valid DSL — proving the gate isn't being defeated by long
+    // preambles the way the old length-only gate was.
+    let prose_preamble = "Sure, I'll help with that. Let me think about how to modify the file to satisfy your request.";
+    let prose_frame = serde_json::json!({
+        "candidates": [{"content":{"parts":[{"text": prose_preamble}]}}],
+        "usageMetadata": {"promptTokenCount":4,"candidatesTokenCount":20,"totalTokenCount":24},
+    })
+    .to_string();
+    let good_dsl = "scene { box \"b\" (size=[1,1,1]) }";
+    let non_streaming = serde_json::json!({
+        "candidates": [{"content":{"parts":[{"text": good_dsl}]}}],
+        "usageMetadata": {
+            "promptTokenCount": 8,
+            "candidatesTokenCount": 16,
+            "totalTokenCount": 24,
+        }
+    })
+    .to_string();
+    let port = start_gemini_dual_endpoint_mock(vec![prose_frame], non_streaming);
+    let client = LlmClient::with_base_url(
+        Provider::Gemini,
+        "test-key",
+        format!("http://127.0.0.1:{}/v1beta", port),
+    );
+
+    let outcome = generate_with_repair(
+        &client,
+        GenerateConfig::new("a box"),
+        &RepairConfig {
+            max_iters: 0,
+            on_iteration: None,
+            on_chunk: Some(Box::new(|_d, _c| {})),
+            allow_edit_mode: false,
+        },
+    )
+    .expect("fallback should rescue the call");
+
+    assert!(outcome.is_ok(), "diagnostics: {:?}", outcome.diagnostics);
+    assert!(outcome.dsl.contains("box \"b\""), "got: {:?}", outcome.dsl);
+}
+
+#[test]
 fn repair_loop_falls_back_to_non_streaming_when_stream_errors() {
     // Streaming endpoint returns zero text-bearing frames — the
     // accumulator surfaces an `EmptyResponse` error. The repair loop
@@ -1126,3 +1173,170 @@ fn edit_mode_falls_back_to_rewrite_when_model_returns_full_dsl() {
         outcome.dsl
     );
 }
+
+// ---------------------------------------------------------------------------
+// Trace: what does the Studio Modify path actually do when the model emits a
+// realistic-but-unhelpful response? Runs `generate_edits_with_repair` against
+// a mock that streams a typical "preamble + non-matching SEARCH block" and
+// prints the candidate DSL + diagnostics at each iteration so we can watch
+// where the response goes wrong. Run with:
+//
+//   cargo test -p mogen-llm --test mock_server trace_modify_preamble_then_bad_edit_block -- --nocapture
+// ---------------------------------------------------------------------------
+#[test]
+fn trace_modify_preamble_then_bad_edit_block() {
+    // Baseline matches what a real `.mog` looks like — a meta header plus a
+    // small scene. The non-matching SEARCH block paraphrases the source so
+    // it doesn't match byte-for-byte, which is the dominant real failure
+    // mode for SEARCH/REPLACE responses. `seed` is a string per the meta
+    // schema (the production `embed_seed_header` writes it that way).
+    let baseline = "meta(seed=\"1\", prompt=\"a box\")\n\
+                    scene {\n  \
+                      box \"b\" (size=[1,1,1])\n\
+                    }\n";
+    // Model response: a 60+ byte preamble (well past the 30-byte gate),
+    // then a SEARCH block whose SEARCH text uses different whitespace from
+    // the baseline so `apply_edit_blocks` rejects it.
+    let response_text = "Sure — I'll make the box taller.\n\n\
+                         <<<<<<< SEARCH\n\
+                         box \"b\"(size=[1,1,1])\n\
+                         =======\n\
+                         box \"b\" (size=[1,2,1])\n\
+                         >>>>>>> REPLACE\n";
+
+    // Per-iteration counters so we can see whether streaming or non-streaming
+    // fired. Both endpoints return the SAME response — real-world failure mode.
+    let stream_calls = Arc::new(Mutex::new(0u32));
+    let nonstream_calls = Arc::new(Mutex::new(0u32));
+    let stream_clone = stream_calls.clone();
+    let nonstream_clone = nonstream_calls.clone();
+
+    let port = {
+        let server = tiny_http::Server::http("127.0.0.1:0").expect("bind");
+        let port = server.server_addr().to_ip().expect("ipv4").port();
+        let frame = serde_json::json!({
+            "candidates": [{"content":{"parts":[{"text": response_text}]}}],
+            "usageMetadata": {"promptTokenCount":10,"candidatesTokenCount":40,"totalTokenCount":50},
+        })
+        .to_string();
+        let non_streaming = frame.clone();
+        thread::spawn(move || {
+            for mut req in server.incoming_requests() {
+                let mut body = String::new();
+                req.as_reader().read_to_string(&mut body).ok();
+                let url = req.url().to_string();
+                if url.contains(":streamGenerateContent") {
+                    *stream_clone.lock().unwrap() += 1;
+                    let mut payload = String::new();
+                    payload.push_str("data: ");
+                    payload.push_str(&frame);
+                    payload.push_str("\n\ndata: [DONE]\n\n");
+                    let resp = tiny_http::Response::from_string(payload).with_header(
+                        "Content-Type: text/event-stream"
+                            .parse::<tiny_http::Header>()
+                            .unwrap(),
+                    );
+                    let _ = req.respond(resp);
+                } else {
+                    *nonstream_clone.lock().unwrap() += 1;
+                    let resp = tiny_http::Response::from_string(non_streaming.clone())
+                        .with_header(
+                            "Content-Type: application/json"
+                                .parse::<tiny_http::Header>()
+                                .unwrap(),
+                        );
+                    let _ = req.respond(resp);
+                }
+            }
+        });
+        port
+    };
+
+    let client = LlmClient::with_base_url(
+        Provider::Gemini,
+        "test-key",
+        format!("http://127.0.0.1:{}/v1beta", port),
+    );
+
+    // on_iteration prints the diagnostics the loop saw between calls.
+    let on_iter = Box::new(|iter: u32, diags: &[mogen_core::Diagnostic]| {
+        eprintln!("\n--- repair iteration {iter} starting ---");
+        for d in diags {
+            eprintln!(
+                "  diag [{}] {:?} {}",
+                d.code, d.severity, d.message
+            );
+        }
+    });
+
+    let chunk_fires = Arc::new(Mutex::new(0u32));
+    let chunk_fires_cb = chunk_fires.clone();
+
+    eprintln!("=== baseline ===");
+    eprintln!("{baseline}");
+    eprintln!("=== model response (literal, will be returned by EVERY call) ===");
+    eprintln!("{response_text}");
+    eprintln!("=== response length (trimmed) = {} bytes (>= 30 byte gate? {}) ===",
+        response_text.trim().len(),
+        response_text.trim().len() >= 30,
+    );
+
+    let outcome = generate_edits_with_repair(
+        &client,
+        GenerateConfig::new("make the box taller"),
+        &RepairConfig {
+            max_iters: 2,
+            on_iteration: Some(on_iter),
+            on_chunk: Some(Box::new(move |_d, c| {
+                *chunk_fires_cb.lock().unwrap() += 1;
+                eprintln!("on_chunk: cumulative={:?}", c);
+            })),
+            allow_edit_mode: true,
+        },
+        baseline,
+    )
+    .expect("loop should not error — it must return Ok with diagnostics");
+
+    eprintln!("\n=== FINAL OUTCOME ===");
+    eprintln!("call_count   = {}", outcome.call_count);
+    eprintln!("stream_calls = {}", *stream_calls.lock().unwrap());
+    eprintln!("nonstream    = {}", *nonstream_calls.lock().unwrap());
+    eprintln!("chunk_fires  = {}", *chunk_fires.lock().unwrap());
+    eprintln!("is_ok        = {}", outcome.is_ok());
+    eprintln!("diagnostics  = {} entry/entries", outcome.diagnostics.len());
+    for d in &outcome.diagnostics {
+        eprintln!("  [{}] {}", d.code, d.message);
+    }
+    eprintln!("--- outcome.dsl (this is what apply_llm_outcome writes to f.source) ---");
+    eprintln!("{}", outcome.dsl);
+    eprintln!("--- end outcome.dsl ---");
+
+    // Post-fix contract: the loop should NEVER hand a caller back markup
+    // pretending to be DSL. When `apply_edit_blocks` fails the loop must
+    //   1) keep the previous (valid) DSL as the candidate, and
+    //   2) surface a synthetic E0801 diagnostic so the next iteration has
+    //      something actionable.
+    // The pre-fix behaviour returned the edit-block markup as `outcome.dsl`,
+    // which `apply_llm_outcome` then wrote to the user's file. These
+    // assertions pin the new contract.
+    assert!(
+        !outcome.is_ok(),
+        "loop should still flag the call as failed",
+    );
+    assert!(
+        !outcome.dsl.contains("<<<<<<< SEARCH"),
+        "outcome.dsl must NOT carry edit-block markup forward (would clobber the user's file): {}",
+        outcome.dsl,
+    );
+    assert!(
+        outcome.dsl.contains("box \"b\""),
+        "outcome.dsl should be the baseline DSL when apply fails, got: {}",
+        outcome.dsl,
+    );
+    assert!(
+        outcome.diagnostics.iter().any(|d| d.code == "E0801"),
+        "expected an E0801 synthetic diagnostic in: {:?}",
+        outcome.diagnostics,
+    );
+}
+

--- a/crates/mogen-llm/tests/mock_server.rs
+++ b/crates/mogen-llm/tests/mock_server.rs
@@ -533,6 +533,199 @@ fn openai_stream_accumulates_deltas_and_surfaces_tail_usage() {
     assert_eq!(body["stream_options"]["include_usage"], true);
 }
 
+/// Variant of [`start_sse_server`] that hands out a different frame
+/// sequence per incoming request (the repair-loop test needs distinct
+/// streaming responses across iterations). `responses[i]` is the SSE
+/// frames returned to request `i`; once exhausted, additional requests
+/// are answered with an empty stream.
+fn start_sse_server_per_request(
+    responses: Vec<Vec<String>>,
+) -> (u16, std::sync::Arc<std::sync::Mutex<Vec<String>>>) {
+    let server = tiny_http::Server::http("127.0.0.1:0").expect("bind sse server");
+    let port = server.server_addr().to_ip().expect("ipv4").port();
+    let requests = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let requests_clone = requests.clone();
+    let queue = std::sync::Arc::new(std::sync::Mutex::new(responses));
+    let queue_clone = queue.clone();
+    thread::spawn(move || {
+        for mut req in server.incoming_requests() {
+            let mut body = String::new();
+            req.as_reader().read_to_string(&mut body).ok();
+            requests_clone.lock().unwrap().push(body);
+            let frames = {
+                let mut q = queue_clone.lock().unwrap();
+                if q.is_empty() {
+                    Vec::new()
+                } else {
+                    q.remove(0)
+                }
+            };
+            let mut payload = String::new();
+            for frame in &frames {
+                payload.push_str("data: ");
+                payload.push_str(frame);
+                payload.push_str("\n\n");
+            }
+            payload.push_str("data: [DONE]\n\n");
+            let resp = tiny_http::Response::from_string(payload).with_header(
+                "Content-Type: text/event-stream"
+                    .parse::<tiny_http::Header>()
+                    .unwrap(),
+            );
+            let _ = req.respond(resp);
+        }
+    });
+    (port, requests)
+}
+
+fn gemini_stream_frame(text: &str) -> String {
+    serde_json::json!({
+        "candidates": [{"content":{"parts":[{"text": text}]}}],
+    })
+    .to_string()
+}
+
+fn gemini_stream_tail(prompt: u32, candidates: u32, total: u32) -> String {
+    serde_json::json!({
+        "candidates": [{"content":{"parts":[{"text":""}]}}],
+        "usageMetadata": {
+            "promptTokenCount": prompt,
+            "candidatesTokenCount": candidates,
+            "totalTokenCount": total,
+        }
+    })
+    .to_string()
+}
+
+#[test]
+fn repair_loop_streams_each_iteration_and_invokes_on_chunk() {
+    // The repair loop must route through `stream_generate` whenever
+    // `on_chunk` is set, on every iteration — not just the first.
+    // A refactor that accidentally calls `client.generate` after the
+    // initial attempt would silently lose progress updates mid-repair.
+    // This test pins the contract by serving two streaming responses
+    // (a bad one, then a fixed one) and asserting `on_chunk` fires
+    // across both.
+    let bad = "scene { wombat \"oops\" (size=[1,1,1]) }";
+    let good = "scene { box \"b\" (size=[1,1,1]) }";
+    let attempt1 = vec![
+        gemini_stream_frame(bad),
+        gemini_stream_tail(10, 20, 30),
+    ];
+    let attempt2 = vec![
+        gemini_stream_frame(good),
+        gemini_stream_tail(10, 20, 30),
+    ];
+    let (port, _reqs) = start_sse_server_per_request(vec![attempt1, attempt2]);
+    let client = LlmClient::with_base_url(
+        Provider::Gemini,
+        "test-key",
+        format!("http://127.0.0.1:{}/v1beta", port),
+    );
+
+    // `on_chunk` is boxed into a `'static` callback, so the shared
+    // buffer it writes through must outlive the closure — `Arc` here,
+    // not a stack-local `Mutex`.
+    let snapshots: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let snapshots_cb = snapshots.clone();
+    let outcome = generate_with_repair(
+        &client,
+        GenerateConfig::new("a box"),
+        &RepairConfig {
+            max_iters: 1,
+            on_iteration: None,
+            on_chunk: Some(Box::new(move |_delta, cumulative| {
+                snapshots_cb.lock().unwrap().push(cumulative.to_string());
+            })),
+            allow_edit_mode: false,
+        },
+    )
+    .expect("request ok");
+
+    assert!(outcome.is_ok(), "diagnostics: {:?}", outcome.diagnostics);
+    assert_eq!(outcome.call_count, 2);
+
+    // One non-empty text frame per attempt → at least one snapshot per
+    // call, with the second iteration's payload distinct from the first.
+    let snaps = snapshots.lock().unwrap();
+    assert!(
+        snaps.iter().any(|s| s.contains("wombat")),
+        "expected first-attempt text in snapshots: {snaps:?}"
+    );
+    assert!(
+        snaps.iter().any(|s| s.contains("box \"b\"")),
+        "expected repaired text in snapshots: {snaps:?}"
+    );
+}
+
+#[test]
+fn gemini_stream_enforces_budget_tokens_against_tail_usage() {
+    // Streaming must apply the same client-side budget cap as the
+    // non-streaming path. Tail-frame usage of 33 against a 20-token
+    // budget should produce `BudgetExceeded`, not a successful response.
+    let frames = vec![
+        gemini_stream_frame("scene { box \"a\" (size=[1,1,1]) }"),
+        gemini_stream_tail(11, 22, 33),
+    ];
+    let (port, _reqs) = start_sse_server(frames);
+    let client = GeminiClient::with_base_url(
+        "test-key",
+        format!("http://127.0.0.1:{}/v1beta", port),
+    );
+
+    let mut cfg = GenerateConfig::new("a box");
+    cfg.budget_tokens = Some(20);
+    let mut cb = |_d: &str, _c: &str| {};
+    let err = client
+        .stream_generate(&cfg, &mut cb)
+        .expect_err("budget should trip");
+    assert!(
+        matches!(
+            err,
+            mogen_llm::gemini::GeminiError::BudgetExceeded { used: 33, budget: 20 }
+        ),
+        "expected BudgetExceeded, got {err:?}",
+    );
+}
+
+#[test]
+fn openai_stream_enforces_budget_tokens_against_tail_usage() {
+    // Same contract as the Gemini test above, exercised through the
+    // OpenAI streaming path so a regression in either client surfaces
+    // as a dedicated failure rather than an unexplained drift in the
+    // generic `LlmClient` wrapper.
+    let f1 = serde_json::json!({
+        "choices": [{"index":0, "delta":{"content":"scene { box \"a\" (size=[1,1,1]) }"}}],
+    })
+    .to_string();
+    let tail = serde_json::json!({
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 5,
+            "completion_tokens": 12,
+            "total_tokens": 17,
+        }
+    })
+    .to_string();
+    let (port, _reqs) = start_sse_server(vec![f1, tail]);
+    let client = LlmClient::with_base_url(
+        Provider::OpenAI,
+        "test-key",
+        format!("http://127.0.0.1:{}/v1", port),
+    );
+    let mut cfg = GenerateConfig::new("a box");
+    cfg.budget_tokens = Some(10);
+    let mut cb = |_d: &str, _c: &str| {};
+    let err = client
+        .stream_generate(&cfg, &mut cb)
+        .expect_err("budget should trip");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("BudgetExceeded") && msg.contains("17") && msg.contains("10"),
+        "expected BudgetExceeded with 17/10, got {msg}",
+    );
+}
+
 /// Helper that produces a Z.ai-shaped chat-completions response carrying
 /// `text` as the assistant's reply. Mirrors `candidate_body` for Gemini.
 fn zai_chat_body(text: &str) -> String {

--- a/crates/mogen-llm/tests/mock_server.rs
+++ b/crates/mogen-llm/tests/mock_server.rs
@@ -625,6 +625,56 @@ fn start_gemini_dual_endpoint_mock(
 }
 
 #[test]
+fn repair_loop_falls_back_to_non_streaming_when_stream_returns_truncated_text() {
+    // Server-side truncation (max_tokens, content filter, body
+    // closed after a brief preamble) is a real production failure
+    // mode that the SSE accumulator can't detect — from its
+    // perspective the stream completed cleanly. The repair loop has
+    // to look at the returned text length and treat a few-byte
+    // "successful" response as a stream-transport hiccup, re-issuing
+    // the call against the non-streaming endpoint so the user gets
+    // the proper response instead of having their file overwritten
+    // with a junk preamble like "I'll modify…".
+    let truncated = "I'll modify";
+    let truncated_frame = serde_json::json!({
+        "candidates": [{"content":{"parts":[{"text": truncated}]}}],
+        "usageMetadata": {"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2},
+    })
+    .to_string();
+    let good_dsl = "scene { box \"b\" (size=[1,1,1]) }";
+    let non_streaming = serde_json::json!({
+        "candidates": [{"content":{"parts":[{"text": good_dsl}]}}],
+        "usageMetadata": {
+            "promptTokenCount": 8,
+            "candidatesTokenCount": 16,
+            "totalTokenCount": 24,
+        }
+    })
+    .to_string();
+    let port = start_gemini_dual_endpoint_mock(vec![truncated_frame], non_streaming);
+    let client = LlmClient::with_base_url(
+        Provider::Gemini,
+        "test-key",
+        format!("http://127.0.0.1:{}/v1beta", port),
+    );
+
+    let outcome = generate_with_repair(
+        &client,
+        GenerateConfig::new("a box"),
+        &RepairConfig {
+            max_iters: 0,
+            on_iteration: None,
+            on_chunk: Some(Box::new(|_d, _c| {})),
+            allow_edit_mode: false,
+        },
+    )
+    .expect("fallback should rescue the call");
+
+    assert!(outcome.is_ok(), "diagnostics: {:?}", outcome.diagnostics);
+    assert!(outcome.dsl.contains("box \"b\""), "got: {:?}", outcome.dsl);
+}
+
+#[test]
 fn repair_loop_falls_back_to_non_streaming_when_stream_errors() {
     // Streaming endpoint returns zero text-bearing frames — the
     // accumulator surfaces an `EmptyResponse` error. The repair loop

--- a/crates/mogen-llm/tests/mock_server.rs
+++ b/crates/mogen-llm/tests/mock_server.rs
@@ -659,6 +659,44 @@ fn repair_loop_streams_each_iteration_and_invokes_on_chunk() {
 }
 
 #[test]
+fn gemini_stream_tolerates_intermediate_frame_without_content() {
+    // Real Gemini streams interleave text-bearing frames with metadata
+    // frames that carry only `finishReason` (and sometimes only
+    // `safetyRatings`) — no `content` block. If the SSE accumulator
+    // treats the absent field as a parse error it aborts the entire
+    // stream and the caller sees a one-token response. Replay that
+    // exact shape: first frame text, second frame finish-only, then a
+    // usage tail. Expect the full text to round-trip and usage to land.
+    let text_frame = serde_json::json!({
+        "candidates": [{"content":{"parts":[{"text":"scene { box \"a\" (size=[1,1,1]) }"}], "role":"model"}, "index":0}],
+    })
+    .to_string();
+    let finish_frame = serde_json::json!({
+        "candidates": [{"finishReason":"STOP", "index":0}],
+    })
+    .to_string();
+    let tail = serde_json::json!({
+        "usageMetadata": {
+            "promptTokenCount": 7,
+            "candidatesTokenCount": 14,
+            "totalTokenCount": 21,
+        }
+    })
+    .to_string();
+    let (port, _reqs) = start_sse_server(vec![text_frame, finish_frame, tail]);
+    let client = GeminiClient::with_base_url(
+        "test-key",
+        format!("http://127.0.0.1:{}/v1beta", port),
+    );
+    let mut cb = |_d: &str, _c: &str| {};
+    let resp = client
+        .stream_generate(&GenerateConfig::new("a box"), &mut cb)
+        .expect("stream must survive content-less frames");
+    assert_eq!(resp.text, "scene { box \"a\" (size=[1,1,1]) }");
+    assert_eq!(resp.usage.total_tokens, 21);
+}
+
+#[test]
 fn gemini_stream_enforces_budget_tokens_against_tail_usage() {
     // Streaming must apply the same client-side budget cap as the
     // non-streaming path. Tail-frame usage of 33 against a 20-token

--- a/crates/mogen-llm/tests/mock_server.rs
+++ b/crates/mogen-llm/tests/mock_server.rs
@@ -145,7 +145,7 @@ fn repair_loop_respects_max_iters_and_returns_last_attempt() {
     let outcome = generate_with_repair(
         &client,
         GenerateConfig::new("anything"),
-        &RepairConfig { max_iters: 1, on_iteration: None, allow_edit_mode: false },
+        &RepairConfig { max_iters: 1, on_iteration: None, on_chunk: None, allow_edit_mode: false },
     )
     .expect("request ok");
 
@@ -187,7 +187,7 @@ fn user_images_become_inline_data_parts_on_the_user_turn() {
         // Three bytes the test can spot once base64-encoded ("AQID").
         data: vec![0x01, 0x02, 0x03],
     });
-    let _ = generate_with_repair(&client, cfg, &RepairConfig { max_iters: 0, on_iteration: None, allow_edit_mode: false })
+    let _ = generate_with_repair(&client, cfg, &RepairConfig { max_iters: 0, on_iteration: None, on_chunk: None, allow_edit_mode: false })
         .expect("request ok");
 
     let reqs = server.requests.lock().unwrap();
@@ -261,7 +261,7 @@ fn planner_then_coder_threads_plan_into_user_turn() {
     let outcome = generate_with_repair(
         &client,
         coder_cfg,
-        &RepairConfig { max_iters: 0, on_iteration: None, allow_edit_mode: false },
+        &RepairConfig { max_iters: 0, on_iteration: None, on_chunk: None, allow_edit_mode: false },
     )
     .expect("coder call ok");
     assert!(outcome.is_ok(), "diagnostics: {:?}", outcome.diagnostics);
@@ -307,7 +307,7 @@ fn visual_refine_attaches_image_and_dsl() {
     let outcome = mogen_llm::visual_refine(
         &client,
         &base,
-        &RepairConfig { max_iters: 0, on_iteration: None, allow_edit_mode: false },
+        &RepairConfig { max_iters: 0, on_iteration: None, on_chunk: None, allow_edit_mode: false },
         registry,
         "a wooden stool",
         previous_dsl,
@@ -335,6 +335,202 @@ fn visual_refine_attaches_image_and_dsl() {
         text.contains("box \"old\""),
         "reviewer turn must inline the previous DSL so the model can edit it: {text}"
     );
+}
+
+/// Spin up a tiny_http server that responds to every request with an
+/// SSE-framed body and the `text/event-stream` content type. `frames`
+/// is the list of JSON payloads that go into `data: {…}\n\n` events,
+/// in order. Used by the streaming-client tests to verify that
+/// `stream_generate` correctly accumulates deltas, surfaces usage from
+/// the tail frame, and invokes the per-chunk callback once per frame.
+fn start_sse_server(frames: Vec<String>) -> (u16, std::sync::Arc<std::sync::Mutex<Vec<String>>>) {
+    let server = tiny_http::Server::http("127.0.0.1:0").expect("bind sse server");
+    let port = server.server_addr().to_ip().expect("ipv4").port();
+    let requests = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let requests_clone = requests.clone();
+    thread::spawn(move || {
+        for mut req in server.incoming_requests() {
+            let mut body = String::new();
+            req.as_reader().read_to_string(&mut body).ok();
+            requests_clone.lock().unwrap().push(body);
+            let mut payload = String::new();
+            for frame in &frames {
+                payload.push_str("data: ");
+                payload.push_str(frame);
+                payload.push_str("\n\n");
+            }
+            payload.push_str("data: [DONE]\n\n");
+            let resp = tiny_http::Response::from_string(payload).with_header(
+                "Content-Type: text/event-stream"
+                    .parse::<tiny_http::Header>()
+                    .unwrap(),
+            );
+            let _ = req.respond(resp);
+        }
+    });
+    (port, requests)
+}
+
+#[test]
+fn gemini_stream_accumulates_deltas_and_invokes_on_chunk_each_frame() {
+    // Three SSE frames: two text deltas, then a tail frame carrying the
+    // usage tally only (Gemini emits usageMetadata on the final frame).
+    // The client must concatenate the text parts and surface the tail
+    // frame's usage in the returned `GenerateResponse`.
+    let f1 = serde_json::json!({
+        "candidates": [{"content":{"parts":[{"text":"scene { box \"a\" "}]}}],
+    })
+    .to_string();
+    let f2 = serde_json::json!({
+        "candidates": [{"content":{"parts":[{"text":"(size=[1,1,1]) }"}]}}],
+    })
+    .to_string();
+    let tail = serde_json::json!({
+        "candidates": [{"content":{"parts":[{"text":""}]}}],
+        "usageMetadata": {
+            "promptTokenCount": 11,
+            "candidatesTokenCount": 22,
+            "totalTokenCount": 33,
+        }
+    })
+    .to_string();
+    let (port, _reqs) = start_sse_server(vec![f1, f2, tail]);
+
+    let client = GeminiClient::with_base_url(
+        "test-key",
+        format!("http://127.0.0.1:{}/v1beta", port),
+    );
+
+    let cumulative_snapshots: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+    let mut on_chunk = |_delta: &str, cumulative: &str| {
+        cumulative_snapshots
+            .lock()
+            .unwrap()
+            .push(cumulative.to_string());
+    };
+
+    let resp = client
+        .stream_generate(&GenerateConfig::new("a box"), &mut on_chunk)
+        .expect("stream ok");
+
+    assert_eq!(resp.text, "scene { box \"a\" (size=[1,1,1]) }");
+    assert_eq!(resp.usage.total_tokens, 33);
+    assert_eq!(resp.usage.prompt_tokens, 11);
+    assert_eq!(resp.usage.response_tokens, 22);
+
+    // Two text frames → two callbacks (the tail's empty-string delta is
+    // skipped so the panel doesn't get a no-op transition).
+    let snaps = cumulative_snapshots.lock().unwrap();
+    assert_eq!(snaps.len(), 2, "got: {snaps:?}");
+    assert_eq!(snaps[0], "scene { box \"a\" ");
+    assert_eq!(snaps[1], "scene { box \"a\" (size=[1,1,1]) }");
+}
+
+#[test]
+fn gemini_stream_targets_the_stream_endpoint_with_sse_alt() {
+    // The streaming path must hit `:streamGenerateContent?alt=sse`, not
+    // `:generateContent`. If a future refactor accidentally aliases the
+    // method to the non-streaming URL the deltas would never arrive
+    // — pin the URL shape against the mock's recorded request.
+    let frame = serde_json::json!({
+        "candidates": [{"content":{"parts":[{"text":"x"}]}}],
+        "usageMetadata": {"promptTokenCount":1, "candidatesTokenCount":1, "totalTokenCount":2}
+    })
+    .to_string();
+    let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+    let port = server.server_addr().to_ip().unwrap().port();
+    let urls = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let urls_clone = urls.clone();
+    thread::spawn(move || {
+        for req in server.incoming_requests() {
+            urls_clone.lock().unwrap().push(req.url().to_string());
+            let body = format!("data: {frame}\n\ndata: [DONE]\n\n");
+            let resp = tiny_http::Response::from_string(body).with_header(
+                "Content-Type: text/event-stream"
+                    .parse::<tiny_http::Header>()
+                    .unwrap(),
+            );
+            let _ = req.respond(resp);
+        }
+    });
+
+    let client = GeminiClient::with_base_url(
+        "test-key",
+        format!("http://127.0.0.1:{}/v1beta", port),
+    );
+    let mut cb = |_d: &str, _c: &str| {};
+    let _ = client
+        .stream_generate(&GenerateConfig::new("x"), &mut cb)
+        .expect("stream ok");
+
+    let urls = urls.lock().unwrap();
+    assert_eq!(urls.len(), 1);
+    assert!(
+        urls[0].contains(":streamGenerateContent"),
+        "expected streaming endpoint, got {}",
+        urls[0]
+    );
+    assert!(urls[0].contains("alt=sse"), "expected SSE alt, got {}", urls[0]);
+}
+
+#[test]
+fn openai_stream_accumulates_deltas_and_surfaces_tail_usage() {
+    // OpenAI streams `choices[0].delta.content` deltas, then a
+    // choice-less tail frame with `usage` when `include_usage` is set.
+    // Mirror the same accumulation+tail-usage contract Gemini's test
+    // exercises so a regression in either provider is caught by its
+    // own test.
+    let f1 = serde_json::json!({
+        "choices": [{"index":0, "delta":{"content":"scene { box \"a\" "}}],
+    })
+    .to_string();
+    let f2 = serde_json::json!({
+        "choices": [{"index":0, "delta":{"content":"(size=[1,1,1]) }"}}],
+    })
+    .to_string();
+    let tail = serde_json::json!({
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 5,
+            "completion_tokens": 12,
+            "total_tokens": 17,
+        }
+    })
+    .to_string();
+    let (port, reqs) = start_sse_server(vec![f1, f2, tail]);
+
+    let client = LlmClient::with_base_url(
+        Provider::OpenAI,
+        "test-key",
+        format!("http://127.0.0.1:{}/v1", port),
+    );
+
+    let cumulative_snapshots: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+    let mut on_chunk = |_delta: &str, cumulative: &str| {
+        cumulative_snapshots
+            .lock()
+            .unwrap()
+            .push(cumulative.to_string());
+    };
+    let resp = client
+        .stream_generate(&GenerateConfig::new("a box"), &mut on_chunk)
+        .expect("stream ok");
+
+    assert_eq!(resp.text, "scene { box \"a\" (size=[1,1,1]) }");
+    assert_eq!(resp.usage.total_tokens, 17);
+    assert_eq!(resp.usage.prompt_tokens, 5);
+    assert_eq!(resp.usage.response_tokens, 12);
+
+    // Two non-empty deltas → two callbacks.
+    let snaps = cumulative_snapshots.lock().unwrap();
+    assert_eq!(snaps.len(), 2, "got: {snaps:?}");
+
+    // Request body must carry `stream:true` and request usage on the tail.
+    let reqs = reqs.lock().unwrap();
+    assert_eq!(reqs.len(), 1);
+    let body: serde_json::Value = serde_json::from_str(&reqs[0]).expect("valid JSON");
+    assert_eq!(body["stream"], true);
+    assert_eq!(body["stream_options"]["include_usage"], true);
 }
 
 /// Helper that produces a Z.ai-shaped chat-completions response carrying
@@ -371,7 +567,7 @@ fn zai_vision_uses_image_url_content() {
         // Three bytes that base64-encode to "AQID".
         data: vec![0x01, 0x02, 0x03],
     });
-    let _ = generate_with_repair(&client, cfg, &RepairConfig { max_iters: 0, on_iteration: None, allow_edit_mode: false })
+    let _ = generate_with_repair(&client, cfg, &RepairConfig { max_iters: 0, on_iteration: None, on_chunk: None, allow_edit_mode: false })
         .expect("request ok");
 
     let reqs = server.requests.lock().unwrap();
@@ -412,7 +608,7 @@ fn fireworks_vision_uses_image_url_content() {
         // Three bytes that base64-encode to "AQID".
         data: vec![0x01, 0x02, 0x03],
     });
-    let _ = generate_with_repair(&client, cfg, &RepairConfig { max_iters: 0, on_iteration: None, allow_edit_mode: false })
+    let _ = generate_with_repair(&client, cfg, &RepairConfig { max_iters: 0, on_iteration: None, on_chunk: None, allow_edit_mode: false })
         .expect("request ok");
 
     let reqs = server.requests.lock().unwrap();

--- a/crates/mogen-llm/tests/mock_server.rs
+++ b/crates/mogen-llm/tests/mock_server.rs
@@ -578,6 +578,105 @@ fn start_sse_server_per_request(
     (port, requests)
 }
 
+/// Mock that answers `:streamGenerateContent` with SSE `sse_frames` and
+/// any other path (notably `:generateContent`) with `non_streaming_json`.
+/// Used to exercise the repair loop's transparent stream-to-non-stream
+/// fallback: streaming hits the bad endpoint, non-streaming hits the
+/// good one.
+fn start_gemini_dual_endpoint_mock(
+    sse_frames: Vec<String>,
+    non_streaming_json: String,
+) -> u16 {
+    let server = tiny_http::Server::http("127.0.0.1:0").expect("bind dual mock");
+    let port = server.server_addr().to_ip().expect("ipv4").port();
+    let sse_frames = std::sync::Arc::new(sse_frames);
+    let non_streaming_json = std::sync::Arc::new(non_streaming_json);
+    thread::spawn(move || {
+        for mut req in server.incoming_requests() {
+            let mut body = String::new();
+            req.as_reader().read_to_string(&mut body).ok();
+            let url = req.url().to_string();
+            if url.contains(":streamGenerateContent") {
+                let mut payload = String::new();
+                for frame in sse_frames.iter() {
+                    payload.push_str("data: ");
+                    payload.push_str(frame);
+                    payload.push_str("\n\n");
+                }
+                payload.push_str("data: [DONE]\n\n");
+                let resp = tiny_http::Response::from_string(payload).with_header(
+                    "Content-Type: text/event-stream"
+                        .parse::<tiny_http::Header>()
+                        .unwrap(),
+                );
+                let _ = req.respond(resp);
+            } else {
+                let resp = tiny_http::Response::from_string((*non_streaming_json).clone())
+                    .with_header(
+                        "Content-Type: application/json"
+                            .parse::<tiny_http::Header>()
+                            .unwrap(),
+                    );
+                let _ = req.respond(resp);
+            }
+        }
+    });
+    port
+}
+
+#[test]
+fn repair_loop_falls_back_to_non_streaming_when_stream_errors() {
+    // Streaming endpoint returns zero text-bearing frames — the
+    // accumulator surfaces an `EmptyResponse` error. The repair loop
+    // must transparently re-issue the call against the non-streaming
+    // endpoint and use *that* response as the source of truth. Without
+    // this fallback, a single streaming hiccup turns into a hard
+    // failure even when the underlying `:generateContent` endpoint is
+    // perfectly healthy — which is exactly what was happening in
+    // production when Gemini/OpenAI returned an unparseable
+    // intermediate frame.
+    let bad_stream = vec![]; // forces the SSE accumulator to see only `[DONE]`
+    let good_dsl = "scene { box \"b\" (size=[1,1,1]) }";
+    let non_streaming = serde_json::json!({
+        "candidates": [{"content":{"parts":[{"text": good_dsl}]}}],
+        "usageMetadata": {
+            "promptTokenCount": 8,
+            "candidatesTokenCount": 16,
+            "totalTokenCount": 24,
+        }
+    })
+    .to_string();
+    let port = start_gemini_dual_endpoint_mock(bad_stream, non_streaming);
+    let client = LlmClient::with_base_url(
+        Provider::Gemini,
+        "test-key",
+        format!("http://127.0.0.1:{}/v1beta", port),
+    );
+
+    let chunk_fires: Arc<Mutex<u32>> = Arc::new(Mutex::new(0));
+    let chunk_fires_cb = chunk_fires.clone();
+    let outcome = generate_with_repair(
+        &client,
+        GenerateConfig::new("a box"),
+        &RepairConfig {
+            max_iters: 0,
+            on_iteration: None,
+            on_chunk: Some(Box::new(move |_d, _c| {
+                *chunk_fires_cb.lock().unwrap() += 1;
+            })),
+            allow_edit_mode: false,
+        },
+    )
+    .expect("fallback should rescue the call");
+
+    assert!(outcome.is_ok(), "diagnostics: {:?}", outcome.diagnostics);
+    assert!(outcome.dsl.contains("box \"b\""), "got: {:?}", outcome.dsl);
+    // The bad stream had no text frames, so on_chunk should never
+    // have fired even once — confirms the fallback didn't double-emit
+    // progress from streaming's partial state.
+    assert_eq!(*chunk_fires.lock().unwrap(), 0);
+}
+
 fn gemini_stream_frame(text: &str) -> String {
     serde_json::json!({
         "candidates": [{"content":{"parts":[{"text": text}]}}],

--- a/crates/mogen-llm/tests/mock_server.rs
+++ b/crates/mogen-llm/tests/mock_server.rs
@@ -727,6 +727,60 @@ fn gemini_stream_enforces_budget_tokens_against_tail_usage() {
 }
 
 #[test]
+fn openai_stream_tolerates_null_delta_and_unparseable_intermediate_frame() {
+    // Two production-realistic failure modes to verify a single bad
+    // frame doesn't tear down the stream:
+    // 1. `"delta": null` on a finish-reason frame — emitted by some
+    //    OpenAI-compatible gateways and historically by OpenAI's own
+    //    reasoning models. `null` can't deserialize into a struct, so
+    //    a naive `serde_json::from_str::<RawChatChunk>` rejects it.
+    // 2. A complete-garbage interleaved frame (server-side error
+    //    envelope, dropped chunk, partial body). The accumulator must
+    //    skip it and keep reading.
+    // Expect the full text from the surrounding good frames to land.
+    let text_frame = serde_json::json!({
+        "choices": [{"index":0, "delta":{"content":"scene { box \"a\" "}}],
+    })
+    .to_string();
+    let null_delta_frame = serde_json::json!({
+        "choices": [{"index":0, "delta": serde_json::Value::Null, "finish_reason":"stop"}],
+    })
+    .to_string();
+    let garbage_frame = String::from("not even json");
+    let text_frame_2 = serde_json::json!({
+        "choices": [{"index":0, "delta":{"content":"(size=[1,1,1]) }"}}],
+    })
+    .to_string();
+    let tail = serde_json::json!({
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 5,
+            "completion_tokens": 12,
+            "total_tokens": 17,
+        }
+    })
+    .to_string();
+    let (port, _reqs) = start_sse_server(vec![
+        text_frame,
+        null_delta_frame,
+        garbage_frame,
+        text_frame_2,
+        tail,
+    ]);
+    let client = LlmClient::with_base_url(
+        Provider::OpenAI,
+        "test-key",
+        format!("http://127.0.0.1:{}/v1", port),
+    );
+    let mut cb = |_d: &str, _c: &str| {};
+    let resp = client
+        .stream_generate(&GenerateConfig::new("a box"), &mut cb)
+        .expect("stream must survive a null delta and a garbage interleaved frame");
+    assert_eq!(resp.text, "scene { box \"a\" (size=[1,1,1]) }");
+    assert_eq!(resp.usage.total_tokens, 17);
+}
+
+#[test]
 fn openai_stream_enforces_budget_tokens_against_tail_usage() {
     // Same contract as the Gemini test above, exercised through the
     // OpenAI streaming path so a regression in either client surfaces

--- a/crates/mogen-studio/src/app/llm/poll.rs
+++ b/crates/mogen-studio/src/app/llm/poll.rs
@@ -128,6 +128,60 @@ impl MogenStudioApp {
             }
         }
 
+        // Defence in depth: refuse to clobber a previously-parseable file
+        // with an unparseable response. The repair loop already does its
+        // best to keep `outcome.dsl` valid (the edit-mode apply-failure
+        // path now preserves the baseline + emits E0801), but a separate
+        // class of bugs — model returning prose-as-rewrite, providers we
+        // haven't shipped a stream-fallback for yet, future regressions —
+        // can still produce a `meta(…)` block prepended to whatever
+        // markup the model emitted. Silently writing that to the file is
+        // the worst-case studio behaviour: the user's working DSL gets
+        // replaced with something they can't compile, and the only way
+        // back is the undo stack.
+        //
+        // Scope intentionally narrow:
+        //   - only when the response has diagnostics (success path
+        //     untouched),
+        //   - only when the response fails to even parse (E0001) — a
+        //     parseable-but-validator-flagged response is still useful
+        //     to surface to the user,
+        //   - only when the pre-LLM source itself parsed (otherwise
+        //     we're guarding nothing).
+        // Textures keeps its existing behaviour because the texture
+        // splice runs against an AST the worker already validated.
+        let dsl_has_parse_error = outcome.diagnostics.iter().any(|d| d.code == "E0001");
+        let prev_parses = mogen_llm::validate_text(&pre_source)
+            .iter()
+            .all(|d| d.code != "E0001");
+        if dsl_has_parse_error
+            && prev_parses
+            && !matches!(outcome.kind, LlmKind::Textures)
+        {
+            if let Some(p) = outcome.retry_prompt {
+                f.llm_last_prompt = Some((outcome.kind, p));
+            }
+            let headline = format!(
+                "{}: model returned unparseable response",
+                outcome.kind.label(),
+            );
+            f.llm_error = Some(crate::app::types::LlmErrorInfo {
+                headline: headline.clone(),
+                detail: format!(
+                    "After {} call(s), the model never produced valid DSL. The file \
+                     was left unchanged to avoid overwriting it with the broken \
+                     response. Retry, or rephrase the prompt — the error banner \
+                     stays until you Dismiss or Retry.",
+                    outcome.calls,
+                ),
+                class: crate::app::types::LlmErrorClass::Other,
+                retryable: true,
+                action: None,
+            });
+            f.status = format!("{}: response not applied — see banner", outcome.kind.label());
+            return;
+        }
+
         // Remember the prompt so a post-success Retry (e.g. to re-roll the
         // seed) can reuse it.
         if let Some(p) = outcome.retry_prompt {

--- a/crates/mogen-studio/src/app/util/llm.rs
+++ b/crates/mogen-studio/src/app/util/llm.rs
@@ -481,6 +481,23 @@ pub(in crate::app) fn run_llm(
 
     let max_iters = run_cfg.max_repair_iters;
     let tx_for_repair = tx.clone();
+    // Stream the model response so the progress card can surface
+    // fine-grained DSL milestones ("writing geometry", "binding skin",
+    // …) as the file is emitted. `StreamStatus` lives behind a
+    // `Mutex` because `RepairConfig::on_chunk` takes `&self`, but the
+    // adapter inside `mogen_llm::StreamStatus::observe` needs to
+    // mutate the last-emitted-stage memo. Providers without an SSE
+    // implementation transparently fall through to non-streaming
+    // inside `LlmClient::stream_generate`, so this is safe across
+    // every active backend.
+    //
+    // Throttling: a 250 ms floor between emits keeps egui from
+    // re-laying-out the panel on every byte during a fast Flash
+    // response. Status transitions still feel instant — DSL stages
+    // change much more slowly than the per-token frame rate.
+    let tx_for_chunk = tx.clone();
+    let stream_state =
+        std::sync::Mutex::new((mogen_llm::StreamStatus::default(), std::time::Instant::now()));
     let repair = RepairConfig {
         max_iters,
         on_iteration: Some(Box::new(move |iter, diags| {
@@ -493,6 +510,19 @@ pub(in crate::app) fn run_llm(
                 max: max_iters,
                 errors,
             }));
+        })),
+        on_chunk: Some(Box::new(move |_delta, cumulative| {
+            let mut guard = match stream_state.lock() {
+                Ok(g) => g,
+                Err(_) => return,
+            };
+            if guard.1.elapsed() < std::time::Duration::from_millis(250) {
+                return;
+            }
+            if let Some(line) = guard.0.observe(cumulative) {
+                guard.1 = std::time::Instant::now();
+                let _ = tx_for_chunk.send(LlmMessage::Progress(LlmProgress::Status(line)));
+            }
         })),
         allow_edit_mode: true,
     };

--- a/crates/mogen/src/commands/animate.rs
+++ b/crates/mogen/src/commands/animate.rs
@@ -139,6 +139,7 @@ Existing file:\n\n{existing}",
                 "animate: repair {attempt}/{total_attempts} — fixing {summary}"
             ));
         })),
+        on_chunk: None,
         allow_edit_mode: true,
     };
 

--- a/crates/mogen/src/commands/bench.rs
+++ b/crates/mogen/src/commands/bench.rs
@@ -105,6 +105,7 @@ pub(crate) fn bench(
         let repair = RepairConfig {
             max_iters: max_repair_iters,
             on_iteration: None,
+            on_chunk: None,
             allow_edit_mode: true,
         };
 

--- a/crates/mogen/src/commands/generate.rs
+++ b/crates/mogen/src/commands/generate.rs
@@ -155,6 +155,7 @@ pub(crate) fn generate(args: GenerateArgs) -> Result<()> {
                 "generate: repair {attempt}/{total_attempts} — fixing {summary}"
             ));
         })),
+        on_chunk: None,
         allow_edit_mode: true,
     };
 
@@ -217,6 +218,7 @@ pub(crate) fn generate(args: GenerateArgs) -> Result<()> {
                         "generate: {label_for_cb} repair {attempt}/{total_attempts} — fixing {summary}"
                     ));
                 })),
+                on_chunk: None,
                 allow_edit_mode: true,
             };
 

--- a/crates/mogen/src/commands/modify.rs
+++ b/crates/mogen/src/commands/modify.rs
@@ -239,6 +239,7 @@ Existing file:\n\n{existing}",
                 "modify: repair {attempt}/{total_attempts} — fixing {summary}"
             ));
         })),
+        on_chunk: None,
         allow_edit_mode: true,
     };
 
@@ -312,6 +313,7 @@ Existing file:\n\n{existing}",
                         "modify: {label_for_cb} repair {attempt}/{total_attempts} — fixing {summary}"
                     ));
                 })),
+                on_chunk: None,
                 allow_edit_mode: true,
             };
 

--- a/crates/mogen/src/commands/repair.rs
+++ b/crates/mogen/src/commands/repair.rs
@@ -157,6 +157,7 @@ pub(crate) fn repair(args: RepairArgs) -> Result<()> {
                 "repair: repair {attempt}/{total_attempts} — fixing {summary}"
             ));
         })),
+        on_chunk: None,
         allow_edit_mode: true,
     };
 


### PR DESCRIPTION
## Summary
This PR adds streaming support for LLM responses, enabling real-time progress feedback during code generation. Users now see fine-grained status updates ("writing geometry", "authoring animation", etc.) as the model emits tokens, rather than waiting for the entire response to complete.

## Key Changes

- **New streaming infrastructure**:
  - Added `stream_sse.rs`: Minimal SSE (Server-Sent Events) reader for both Gemini and OpenAI streaming responses
  - Added `stream_status.rs`: Status tracker that observes cumulative response text and emits human-readable progress labels ("thinking…", "writing header", "choosing materials", etc.) and geometry node counts

- **Provider streaming implementations**:
  - `gemini.rs`: Added `stream_generate()` method that hits `:streamGenerateContent?alt=sse` endpoint (API-key auth only; OAuth falls back to non-streaming)
  - `openai.rs`: Added `stream_generate()` method with `stream: true` and `stream_options.include_usage: true` request parameters

- **Repair loop integration**:
  - `repair.rs`: Added `on_chunk` callback field to `RepairConfig` for per-frame progress updates
  - `provider.rs`: Added `stream_generate()` dispatcher that routes to provider implementations or falls back to non-streaming

- **Studio UI integration**:
  - `llm.rs`: Integrated streaming with 250ms throttling to prevent excessive UI re-layouts while maintaining responsive status transitions
  - Uses `StreamStatus` behind a `Mutex` to track and emit only when progress changes

- **CLI/batch updates**:
  - Updated all CLI commands (`generate.rs`, `modify.rs`, `animate.rs`, `repair.rs`, `bench.rs`) to pass `on_chunk: None` in `RepairConfig` initialization

- **Test coverage**:
  - Added comprehensive streaming tests in `mock_server.rs`:
    - `gemini_stream_accumulates_deltas_and_invokes_on_chunk_each_frame`: Validates delta accumulation and callback invocation
    - `gemini_stream_targets_the_stream_endpoint_with_sse_alt`: Ensures correct endpoint targeting
    - `openai_stream_accumulates_deltas_and_surfaces_tail_usage`: Validates OpenAI's usage tail frame handling
  - Added unit tests for `StreamStatus` and SSE parsing

## Implementation Details

- **Graceful degradation**: Providers without streaming support transparently fall back to non-streaming; the callback simply never fires
- **Usage handling**: Gemini emits usage on the final frame; OpenAI uses `include_usage` tail frame — both properly surfaced in the returned `GenerateResponse`
- **Empty delta filtering**: Skips invoking callbacks for empty-string deltas to avoid spurious UI updates
- **Status progression**: DSL authoring stages are tracked in order (meta → material → scene → animation), with later stages overriding earlier ones so the user sees the most recent progress
- **Node counting**: Geometry node count is tracked via substring matching of attribute openers (`(size=`, `(radius=`, `(height=`) for cheap, parse-free progress indication

https://claude.ai/code/session_01MxoYW1qdsuviSjrujdSW2R