### PR TITLE
fix(building): constrain stairwell doors to the south entry zone via per-cell door slots

### DIFF
--- a/crates/mogen-dsl/src/lower/building/circulation.rs
+++ b/crates/mogen-dsl/src/lower/building/circulation.rs
@@ -30,6 +30,26 @@ const STAIR_WIDTH: f32 = 2.0;
 // 1 m north mid-landing — comfortable enough for two ~8-step flights
 // at ~0.18 m rise per step.
 const STAIR_DEPTH: f32 = 4.0;
+
+/// Depth (along Z) of the staircase's south entry/exit platform — the
+/// flat slab at every storey's floor height that a user steps onto when
+/// passing through a door into the stairwell. The stair flights begin
+/// `STAIR_ENTRY_DEPTH` north of `rect.z_min`; everything north of that
+/// is at half-storey height (mid-landing) or empty (flight cutout), so a
+/// door whose anchor falls outside the entry zone opens into mid-air.
+///
+/// Lives on the planner side (not in `emit/`) because `layout` builds
+/// `RoomCell::door_slots` from this value and `emit/openings.rs` clamps
+/// door anchors against it; the geometry emitter in `emit/circulation`
+/// merely realises the same slab the planner already promised.
+pub(super) const STAIR_ENTRY_DEPTH: f32 = 1.0;
+
+/// Depth (along Z) of the staircase's north mid-landing slab. Symmetric
+/// counterpart to `STAIR_ENTRY_DEPTH`: a half-storey-high platform that
+/// the two switchback flights meet at. Doors are never allowed onto this
+/// strip because at storey-floor height there is no walkable surface.
+pub(super) const STAIR_LANDING_DEPTH: f32 = 1.0;
+
 const ELEVATOR_WIDTH: f32 = 2.0;
 const ELEVATOR_DEPTH: f32 = 2.0;
 const COLUMN_INSET: f32 = 0.2;

--- a/crates/mogen-dsl/src/lower/building/emit/circulation.rs
+++ b/crates/mogen-dsl/src/lower/building/emit/circulation.rs
@@ -32,7 +32,9 @@ use mogen_geom::{box_mesh, transform_mesh};
 use crate::ast::{Node, Value};
 use crate::module::expand_modules;
 
-use super::super::circulation::{CirculationCell, CirculationKind};
+use super::super::circulation::{
+    CirculationCell, CirculationKind, STAIR_ENTRY_DEPTH, STAIR_LANDING_DEPTH,
+};
 use super::super::config::BuildingCfg;
 use super::super::layout::{BuildingLayout, CellKind, Floorplate, Rect2, StoreyPlate};
 use super::openings::elevator_door_z;
@@ -64,10 +66,10 @@ use super::wall_build::wall_with_holes;
 /// The entry zone preserves the floor slab on every storey — it's the
 /// landing the door from the adjacent room opens onto and the platform
 /// the user steps off onto after climbing. Shell.rs reads these to
-/// build the matching slab cutout (everything north of the entry zone).
-pub(in super::super) const STAIR_ENTRY_DEPTH: f32 = 1.0;
-pub(in super::super) const STAIR_LANDING_DEPTH: f32 = 1.0;
-
+/// build the matching slab cutout (everything north of the entry zone);
+/// the planner side (`super::super::circulation`) owns the constants so
+/// `layout` can derive `RoomCell::door_slots` from the same source.
+///
 /// Width of the central spine between the two parallel half-flights.
 /// Just enough to keep the flights from sharing a tread vertex and to
 /// leave a visible slot for the inner handrail to live in.

--- a/crates/mogen-dsl/src/lower/building/emit/openings.rs
+++ b/crates/mogen-dsl/src/lower/building/emit/openings.rs
@@ -12,7 +12,7 @@
 
 use super::super::circulation::CirculationPlan;
 use super::super::config::BuildingCfg;
-use super::super::layout::{CellKind, Floorplate, Rect2, RoomCell};
+use super::super::layout::{CellKind, Floorplate, Rect2, RoomCell, WallSide};
 use super::super::rng::{attempt_seed, rand_f01, rand_range};
 use super::StoreyCtx;
 
@@ -37,14 +37,6 @@ pub(super) enum WindowClass {
     Small,
     Medium,
     Large,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum WallSide {
-    North,
-    East,
-    South,
-    West,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -277,7 +269,7 @@ fn place_interior_doors(
     if n < 2 {
         return;
     }
-    let mut edges: Vec<(usize, usize, f32, [f32; 2], f32)> = Vec::new();
+    let mut edges: Vec<(usize, usize, SharedEdge, f32)> = Vec::new();
     for i in 0..n {
         for j in (i + 1)..n {
             // Never carve a door between two circulation cells — you
@@ -299,19 +291,21 @@ fn place_interior_doors(
             {
                 continue;
             }
-            let edge = plate.rooms[i].rect.shared_edge_length(&plate.rooms[j].rect);
+            // Cell-aware edge: shared range clipped to each cell's
+            // `door_slots`. For staircases this rejects any edge that
+            // doesn't overlap the south entry zone, so the BFS won't
+            // try to attach via the flight cutout or the mid-landing.
+            let Some(edge) = slot_clipped_edge(&plate.rooms[i], &plate.rooms[j]) else {
+                continue;
+            };
+            let raw_edge_len = plate.rooms[i].rect.shared_edge_length(&plate.rooms[j].rect);
+            let door_w = edge_door_width(cfg, &plate.rooms[i], &plate.rooms[j], raw_edge_len);
             // Eligibility uses the standard door width so the BFS can
             // still reach an elevator whose neighbour is too narrow to
             // hold the wider 1.5× doorway — connectivity beats ideal
-            // sizing. Width selection happens per-edge below.
-            if edge >= cfg.door_w * 1.1 {
-                let door_w = edge_door_width(cfg, &plate.rooms[i], &plate.rooms[j], edge);
-                let mid = shared_edge_door_anchor(
-                    &plate.rooms[i],
-                    &plate.rooms[j],
-                    cfg,
-                );
-                edges.push((i, j, edge, mid, door_w));
+            // sizing. Width selection happens per-edge above.
+            if edge.span() >= cfg.door_w * 1.1 {
+                edges.push((i, j, edge, door_w));
             }
         }
     }
@@ -323,7 +317,7 @@ fn place_interior_doors(
     while let Some(u) = queue.pop_front() {
         let mut neighbours: Vec<usize> = edges
             .iter()
-            .filter_map(|(a, b, _, _, _)| {
+            .filter_map(|(a, b, _, _)| {
                 if *a == u && !visited[*b] {
                     Some(*b)
                 } else if *b == u && !visited[*a] {
@@ -342,24 +336,22 @@ fn place_interior_doors(
                 continue;
             }
             visited[v] = true;
-            if let Some((_, _, _, mid, door_w)) = edges
+            if let Some((_, _, edge, door_w)) = edges
                 .iter()
-                .find(|(a, b, _, _, _)| (*a == u && *b == v) || (*a == v && *b == u))
+                .find(|(a, b, _, _)| (*a == u && *b == v) || (*a == v && *b == u))
             {
                 let facing = interior_facing(&plate.rooms[u].rect, &plate.rooms[v].rect);
-                // `shared_edge_midpoint` already gave us the geometric
-                // midpoint along the shared edge; we additionally clamp it
-                // away from the corner so the door clears any perpendicular
-                // wall sitting at a T-junction. Corner margin =
-                // door_w/2 + wall_thickness so the door's edge stops at
-                // least a wall-thickness short of the adjacent corner.
+                // The slot-clipped range already encodes whatever bias
+                // the cell wanted (e.g. staircase → south entry zone),
+                // so a plain midpoint anchor lands inside the valid
+                // strip by construction. We still corner-clamp to keep
+                // the door a wall-thickness clear of any perpendicular
+                // wall at a T-junction; for slots shorter than 2×
+                // `corner_margin` the clamp degrades to the slot
+                // midpoint, which is the best we can do.
                 let corner_margin = 0.5 * door_w + cfg.wall_thickness;
-                let (x, z) = clamp_door_to_edge(
-                    &plate.rooms[u].rect,
-                    &plate.rooms[v].rect,
-                    *mid,
-                    corner_margin,
-                );
+                let along = clamp_centre(edge.midpoint(), edge.lo, edge.hi, corner_margin);
+                let (x, z) = edge.world_xz(along);
                 plan.interior_doors.push(Opening {
                     kind: OpeningKind::InteriorDoor,
                     x,
@@ -376,26 +368,123 @@ fn place_interior_doors(
     }
 }
 
-/// Clamp a door's anchor along its shared edge so it stops at least
-/// `corner_margin` from each end. If the edge is shorter than 2× the
-/// margin (a very small shared edge from BSP), we centre the door and
-/// accept the corner overlap — the door has to land somewhere.
-fn clamp_door_to_edge(a: &Rect2, b: &Rect2, mid: [f32; 2], corner_margin: f32) -> (f32, f32) {
-    // Vertical shared edge (along Z) at x = a.x_max or b.x_max.
-    if (a.x_max - b.x_min).abs() < 1e-3 || (b.x_max - a.x_min).abs() < 1e-3 {
+/// Which axis a shared edge runs along, plus the fixed perpendicular
+/// coordinate of the face. Carried alongside the clipped range so the
+/// BFS can rebuild `(x, z)` from a 1D anchor without re-deriving which
+/// side the edge was on.
+#[derive(Clone, Copy, Debug)]
+enum EdgeAxis {
+    /// Edge runs along Z (vertical wall at fixed x = `fixed`).
+    Z { fixed: f32 },
+    /// Edge runs along X (horizontal wall at fixed z = `fixed`).
+    X { fixed: f32 },
+}
+
+/// A door-eligible segment of the shared edge between two cells:
+/// the raw shared range intersected with each cell's `door_slots`.
+#[derive(Clone, Copy, Debug)]
+struct SharedEdge {
+    axis: EdgeAxis,
+    lo: f32,
+    hi: f32,
+}
+
+impl SharedEdge {
+    fn span(&self) -> f32 {
+        (self.hi - self.lo).max(0.0)
+    }
+    fn midpoint(&self) -> f32 {
+        0.5 * (self.lo + self.hi)
+    }
+    fn world_xz(&self, along: f32) -> (f32, f32) {
+        match self.axis {
+            EdgeAxis::Z { fixed } => (fixed, along),
+            EdgeAxis::X { fixed } => (along, fixed),
+        }
+    }
+}
+
+/// Compute the shared edge between `a` and `b`, clipped to each cell's
+/// `door_slots`. Returns `None` when:
+/// - the rects do not share a full edge,
+/// - the raw overlap is degenerate, or
+/// - either cell publishes door slots and none of them cover the shared
+///   edge (e.g. a staircase whose neighbour only touches its flight
+///   cutout — no walkable platform behind the door at storey-floor
+///   height).
+fn slot_clipped_edge(a: &RoomCell, b: &RoomCell) -> Option<SharedEdge> {
+    let (a_side, b_side, axis, lo, hi) = shared_edge_sides(&a.rect, &b.rect)?;
+    if hi <= lo {
+        return None;
+    }
+    let (lo, hi) = clip_to_slots(a, a_side, lo, hi)?;
+    let (lo, hi) = clip_to_slots(b, b_side, lo, hi)?;
+    if hi <= lo {
+        return None;
+    }
+    Some(SharedEdge { axis, lo, hi })
+}
+
+/// Identify the shared edge between two adjacent rects: which face of
+/// each cell touches, which axis the edge runs along (with the fixed
+/// perpendicular coordinate), and the raw overlap range along that axis.
+fn shared_edge_sides(
+    a: &Rect2,
+    b: &Rect2,
+) -> Option<(WallSide, WallSide, EdgeAxis, f32, f32)> {
+    if (a.x_max - b.x_min).abs() < 1e-3 {
         let lo = a.z_min.max(b.z_min);
         let hi = a.z_max.min(b.z_max);
-        let z = clamp_centre(mid[1], lo, hi, corner_margin);
-        return (mid[0], z);
+        return Some((WallSide::East, WallSide::West, EdgeAxis::Z { fixed: a.x_max }, lo, hi));
     }
-    // Horizontal shared edge (along X).
-    if (a.z_max - b.z_min).abs() < 1e-3 || (b.z_max - a.z_min).abs() < 1e-3 {
+    if (b.x_max - a.x_min).abs() < 1e-3 {
+        let lo = a.z_min.max(b.z_min);
+        let hi = a.z_max.min(b.z_max);
+        return Some((WallSide::West, WallSide::East, EdgeAxis::Z { fixed: a.x_min }, lo, hi));
+    }
+    if (a.z_max - b.z_min).abs() < 1e-3 {
         let lo = a.x_min.max(b.x_min);
         let hi = a.x_max.min(b.x_max);
-        let x = clamp_centre(mid[0], lo, hi, corner_margin);
-        return (x, mid[1]);
+        return Some((WallSide::North, WallSide::South, EdgeAxis::X { fixed: a.z_max }, lo, hi));
     }
-    (mid[0], mid[1])
+    if (b.z_max - a.z_min).abs() < 1e-3 {
+        let lo = a.x_min.max(b.x_min);
+        let hi = a.x_max.min(b.x_max);
+        return Some((WallSide::South, WallSide::North, EdgeAxis::X { fixed: a.z_min }, lo, hi));
+    }
+    None
+}
+
+/// Intersect `[lo, hi]` with the widest matching slot on `cell`'s `side`.
+/// Cells with no slots are unrestricted (`Some((lo, hi))`); cells that
+/// publish slots but none overlap the edge return `None`, which kills
+/// the candidate edge.
+fn clip_to_slots(
+    cell: &RoomCell,
+    side: WallSide,
+    lo: f32,
+    hi: f32,
+) -> Option<(f32, f32)> {
+    if cell.door_slots.is_empty() {
+        return Some((lo, hi));
+    }
+    let mut best: Option<(f32, f32)> = None;
+    for slot in &cell.door_slots {
+        if slot.side != side {
+            continue;
+        }
+        let s_lo = slot.along_min.max(lo);
+        let s_hi = slot.along_max.min(hi);
+        if s_hi <= s_lo {
+            continue;
+        }
+        best = Some(match best {
+            None => (s_lo, s_hi),
+            Some((blo, bhi)) if (s_hi - s_lo) > (bhi - blo) => (s_lo, s_hi),
+            Some(b) => b,
+        });
+    }
+    best
 }
 
 fn is_circulation(kind: &CellKind) -> bool {
@@ -680,85 +769,6 @@ fn exterior_segment(
         WallSide::East => (cell.rect.z_min, cell.rect.z_max, bounds.x_max, [1.0, 0.0, 0.0]),
         WallSide::West => (cell.rect.z_min, cell.rect.z_max, bounds.x_min, [-1.0, 0.0, 0.0]),
     }
-}
-
-/// Pick a door anchor along the shared edge between two cells.
-///
-/// Defaults to the geometric midpoint of the shared edge, with two
-/// per-kind biases:
-/// - **Staircase ↔ room:** the door is shifted toward the staircase's
-///   south entry zone so it lands on the platform the switchback
-///   expects users to step onto (off-centre would put it next to the
-///   mid-landing slab edge or over the flight cutout).
-/// - **Elevator ↔ room:** the door is anchored on the elevator's
-///   geometric centre so it sits midway across the 2 m face regardless
-///   of how the neighbouring room is sized along the shared axis. For
-///   the common case where the room fully overlaps the elevator's
-///   range this is identical to the midpoint; for partial overlaps it
-///   pulls the door toward the centred position the elevator presents
-///   on its open face, instead of sliding to whichever third of the
-///   2 m face the room happens to cover.
-fn shared_edge_door_anchor(
-    a: &RoomCell,
-    b: &RoomCell,
-    cfg: &BuildingCfg,
-) -> [f32; 2] {
-    let mid = shared_edge_midpoint(&a.rect, &b.rect);
-    let stair_target = |s: &Rect2| -> Option<f32> {
-        // South entry zone runs from s.z_min to s.z_min + STAIR_ENTRY_DEPTH.
-        // Anchor at the centre of that zone so the door lands squarely
-        // on the platform.
-        Some(s.z_min + 0.5 * super::circulation::STAIR_ENTRY_DEPTH)
-    };
-    let elev_target = |e: &Rect2| -> Option<f32> {
-        Some(0.5 * (e.z_min + e.z_max))
-    };
-    let target_z = match (a.kind, b.kind) {
-        (CellKind::Staircase, _) if !matches!(b.kind, CellKind::Staircase) => stair_target(&a.rect),
-        (_, CellKind::Staircase) if !matches!(a.kind, CellKind::Staircase) => stair_target(&b.rect),
-        (CellKind::Elevator, _) if !matches!(b.kind, CellKind::Elevator) => elev_target(&a.rect),
-        (_, CellKind::Elevator) if !matches!(a.kind, CellKind::Elevator) => elev_target(&b.rect),
-        _ => None,
-    };
-    let Some(target_z) = target_z else {
-        return mid;
-    };
-    // Only bias the Z component if the shared edge is vertical (runs
-    // along Z) — that's the wall the door sits in. Horizontal edges
-    // get the unchanged midpoint.
-    let vertical_edge = (a.rect.x_max - b.rect.x_min).abs() < 1e-3
-        || (b.rect.x_max - a.rect.x_min).abs() < 1e-3;
-    if !vertical_edge {
-        return mid;
-    }
-    let lo = a.rect.z_min.max(b.rect.z_min);
-    let hi = a.rect.z_max.min(b.rect.z_max);
-    let margin = 0.5 * cfg.door_w + cfg.wall_thickness;
-    let z = if hi - lo > 2.0 * margin {
-        target_z.clamp(lo + margin, hi - margin)
-    } else {
-        0.5 * (lo + hi)
-    };
-    [mid[0], z]
-}
-
-fn shared_edge_midpoint(a: &Rect2, b: &Rect2) -> [f32; 2] {
-    if (a.x_max - b.x_min).abs() < 1e-3 {
-        return [a.x_max, 0.5 * (a.z_min.max(b.z_min) + a.z_max.min(b.z_max))];
-    }
-    if (b.x_max - a.x_min).abs() < 1e-3 {
-        return [b.x_max, 0.5 * (a.z_min.max(b.z_min) + a.z_max.min(b.z_max))];
-    }
-    if (a.z_max - b.z_min).abs() < 1e-3 {
-        return [0.5 * (a.x_min.max(b.x_min) + a.x_max.min(b.x_max)), a.z_max];
-    }
-    if (b.z_max - a.z_min).abs() < 1e-3 {
-        return [0.5 * (a.x_min.max(b.x_min) + a.x_max.min(b.x_max)), b.z_max];
-    }
-    [
-        0.5 * (a.centre()[0] + b.centre()[0]),
-        0.5 * (a.centre()[1] + b.centre()[1]),
-    ]
 }
 
 fn interior_facing(a: &Rect2, b: &Rect2) -> [f32; 3] {

--- a/crates/mogen-dsl/src/lower/building/emit/shell.rs
+++ b/crates/mogen-dsl/src/lower/building/emit/shell.rs
@@ -12,11 +12,10 @@ use mogen_geom::{box_mesh, clean_csg_output, difference_many, transform_mesh};
 
 use crate::ast::Node;
 
-use super::super::circulation::{CirculationKind, CirculationPlan};
+use super::super::circulation::{CirculationKind, CirculationPlan, STAIR_ENTRY_DEPTH};
 use super::super::config::BuildingCfg;
-use super::super::layout::{Floorplate, Rect2};
-use super::circulation::STAIR_ENTRY_DEPTH;
-use super::openings::{Opening, OpeningPlan, WallSide};
+use super::super::layout::{Floorplate, Rect2, WallSide};
+use super::openings::{Opening, OpeningPlan};
 use super::wall_build::wall_with_holes;
 use super::StoreyCtx;
 

--- a/crates/mogen-dsl/src/lower/building/layout/bsp.rs
+++ b/crates/mogen-dsl/src/lower/building/layout/bsp.rs
@@ -34,6 +34,7 @@ pub(super) fn layout(
             rect,
             room_type_index: type_at(i, assigned_types),
             kind: CellKind::Room,
+            door_slots: Vec::new(),
         });
     }
     cells

--- a/crates/mogen-dsl/src/lower/building/layout/corridor.rs
+++ b/crates/mogen-dsl/src/lower/building/layout/corridor.rs
@@ -55,6 +55,7 @@ pub(super) fn layout(
         rect: split.corridor,
         room_type_index: corridor_type_idx,
         kind: CellKind::Room,
+        door_slots: Vec::new(),
     });
     if count_a > 0 {
         cells.extend(bsp::layout(split.half_a, types_a, state));

--- a/crates/mogen-dsl/src/lower/building/layout/grid.rs
+++ b/crates/mogen-dsl/src/lower/building/layout/grid.rs
@@ -55,6 +55,7 @@ pub(super) fn layout(
                 },
                 room_type_index: assigned_types[idx],
                 kind: CellKind::Room,
+                door_slots: Vec::new(),
             });
             idx += 1;
             if idx >= rooms {

--- a/crates/mogen-dsl/src/lower/building/layout/hotel.rs
+++ b/crates/mogen-dsl/src/lower/building/layout/hotel.rs
@@ -81,6 +81,7 @@ pub(super) fn layout_with_target(
         rect: split.corridor,
         room_type_index: corridor_type_idx,
         kind: CellKind::Room,
+        door_slots: Vec::new(),
     });
     cells.extend(tile_along(split.half_a, types_a, along_x));
     cells.extend(tile_along(split.half_b, types_b, along_x));
@@ -107,6 +108,7 @@ fn tile_along(half: Rect2, types: &[usize], along_x: bool) -> Vec<RoomCell> {
                 },
                 room_type_index: t,
                 kind: CellKind::Room,
+                door_slots: Vec::new(),
             });
         }
     } else {
@@ -123,6 +125,7 @@ fn tile_along(half: Rect2, types: &[usize], along_x: bool) -> Vec<RoomCell> {
                 },
                 room_type_index: t,
                 kind: CellKind::Room,
+                door_slots: Vec::new(),
             });
         }
     }

--- a/crates/mogen-dsl/src/lower/building/layout/maze.rs
+++ b/crates/mogen-dsl/src/lower/building/layout/maze.rs
@@ -106,6 +106,7 @@ pub(super) fn layout(
         rect: corridor_rect,
         room_type_index: type_at(0, assigned_types),
         kind: CellKind::Room,
+        door_slots: Vec::new(),
     });
 
     let mut emitted = 1usize;
@@ -117,6 +118,7 @@ pub(super) fn layout(
             rect: to_rect(idx),
             room_type_index: type_at(emitted, assigned_types),
             kind: CellKind::Room,
+            door_slots: Vec::new(),
         });
         emitted += 1;
     }

--- a/crates/mogen-dsl/src/lower/building/layout/mod.rs
+++ b/crates/mogen-dsl/src/lower/building/layout/mod.rs
@@ -21,7 +21,9 @@ mod score;
 
 use anyhow::{bail, Result};
 
-use super::circulation::{CirculationKind, CirculationPlan};
+use super::circulation::{
+    CirculationKind, CirculationPlan, STAIR_ENTRY_DEPTH,
+};
 use super::config::{BuildingCfg, RoomType, Style};
 use super::rng::{attempt_seed, weighted_pick};
 
@@ -75,6 +77,17 @@ impl Rect2 {
 
 const EDGE_EPS: f32 = 1e-3;
 
+/// Which of the four axis-aligned faces of a cell or floorplate something
+/// sits on. Lives here (not in the `emit` layer) because layout-time data
+/// — specifically `DoorSlot` on a `RoomCell` — needs to name a face.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum WallSide {
+    North,
+    East,
+    South,
+    West,
+}
+
 /// Kind discriminator for a `RoomCell`. Most cells are normal rooms; a
 /// minority are circulation cells (staircase or elevator) that share XY
 /// across every storey.
@@ -85,14 +98,39 @@ pub(super) enum CellKind {
     Elevator,
 }
 
+/// A strip along one face of a cell where a door is allowed to land.
+///
+/// Used by `place_interior_doors` to constrain door placement on cells
+/// that have internal structure the shared-edge math doesn't know about
+/// — most notably staircases, whose only valid storey-floor-height entry
+/// is the south entry zone (the back half of the cell is a half-storey
+/// landing or a flight cutout, so a door there opens into mid-air).
+///
+/// `along_min..along_max` is in world-space layout coordinates: x for
+/// North/South faces, z for East/West faces.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct DoorSlot {
+    pub side: WallSide,
+    pub along_min: f32,
+    pub along_max: f32,
+}
+
 /// A single cell on a floorplate. `room_type_index` indexes into
 /// `BuildingCfg.room_types` only when `kind == Room`; for circulation it's
 /// left at `usize::MAX` and downstream code branches on `kind`.
+///
+/// `door_slots` restricts where interior doors may be carved on this
+/// cell's perimeter. An empty vec means "anywhere along a shared edge"
+/// (the default for plain rooms and for elevators, which run their own
+/// shaft-door pipeline). A non-empty vec means a candidate edge must
+/// overlap at least one slot by a door's width before the door planner
+/// will consider it.
 #[derive(Clone, Debug)]
 pub(super) struct RoomCell {
     pub rect: Rect2,
     pub room_type_index: usize,
     pub kind: CellKind,
+    pub door_slots: Vec<DoorSlot>,
 }
 
 #[derive(Clone, Debug)]
@@ -330,16 +368,41 @@ fn solve_storey(
 
 fn with_circulation(mut rooms: Vec<RoomCell>, circ: &CirculationPlan) -> Vec<RoomCell> {
     for cell in &circ.cells {
+        let kind = match cell.kind {
+            CirculationKind::Staircase => CellKind::Staircase,
+            CirculationKind::Elevator => CellKind::Elevator,
+        };
+        let door_slots = match kind {
+            CellKind::Staircase => staircase_door_slots(&cell.rect),
+            // Elevators have their own shaft-door pipeline that places a
+            // centred opening on the open face; leaving slots empty here
+            // means `place_interior_doors` skips the elevator entirely
+            // (it already explicitly bails on elevator edges).
+            CellKind::Elevator | CellKind::Room => Vec::new(),
+        };
         rooms.push(RoomCell {
             rect: cell.rect,
             room_type_index: usize::MAX,
-            kind: match cell.kind {
-                CirculationKind::Staircase => CellKind::Staircase,
-                CirculationKind::Elevator => CellKind::Elevator,
-            },
+            kind,
+            door_slots,
         });
     }
     rooms
+}
+
+/// Door slots for a switchback staircase: the south entry zone is the
+/// only strip at storey-floor height that touches a walkable platform.
+/// We expose it on three faces (east, west, south) so whichever neighbour
+/// the BFS picks can attach there. The north face has no slot — its
+/// neighbour would walk through the door onto the half-storey mid-landing,
+/// which sits 1.5 m above the storey floor.
+fn staircase_door_slots(r: &Rect2) -> Vec<DoorSlot> {
+    let entry_z_max = r.z_min + STAIR_ENTRY_DEPTH;
+    vec![
+        DoorSlot { side: WallSide::East,  along_min: r.z_min, along_max: entry_z_max },
+        DoorSlot { side: WallSide::West,  along_min: r.z_min, along_max: entry_z_max },
+        DoorSlot { side: WallSide::South, along_min: r.x_min, along_max: r.x_max },
+    ]
 }
 
 fn storey_indices(cfg: &BuildingCfg) -> Vec<i32> {

--- a/crates/mogen-dsl/src/lower/building/layout/organic.rs
+++ b/crates/mogen-dsl/src/lower/building/layout/organic.rs
@@ -86,6 +86,7 @@ pub(super) fn layout(
                 },
                 room_type_index: assigned_types[idx],
                 kind: CellKind::Room,
+                door_slots: Vec::new(),
             });
             idx += 1;
         }

--- a/crates/mogen-dsl/src/lower/building/layout/radial.rs
+++ b/crates/mogen-dsl/src/lower/building/layout/radial.rs
@@ -56,6 +56,7 @@ pub(super) fn layout(
             rect,
             room_type_index: type_at(*emitted, assigned_types),
             kind: CellKind::Room,
+            door_slots: Vec::new(),
         });
         *emitted += 1;
     };

--- a/crates/mogen-dsl/src/lower/building/layout/score.rs
+++ b/crates/mogen-dsl/src/lower/building/layout/score.rs
@@ -263,7 +263,7 @@ mod tests {
     }
 
     fn room_cell(rect: Rect2, idx: usize) -> RoomCell {
-        RoomCell { rect, room_type_index: idx, kind: CellKind::Room }
+        RoomCell { rect, room_type_index: idx, kind: CellKind::Room, door_slots: Vec::new() }
     }
 
     #[test]
@@ -302,7 +302,7 @@ mod tests {
             rooms: vec![
                 room_cell(rect(0.0, 4.0, 0.0, 4.0), 0),
                 // A circulation cell sharing an edge — must be ignored.
-                RoomCell { rect: rect(4.0, 8.0, 0.0, 4.0), room_type_index: usize::MAX, kind: CellKind::Staircase },
+                RoomCell { rect: rect(4.0, 8.0, 0.0, 4.0), room_type_index: usize::MAX, kind: CellKind::Staircase, door_slots: Vec::new() },
             ],
         };
         let s = score(&cfg, &plate);


### PR DESCRIPTION
## Summary

- Stairwell doors were landing on the wrong strip of the stair cell, opening onto half-storey mid-landing (no slab at storey floor height) or directly onto a flight tread. The previous `shared_edge_door_anchor` bias only covered the simple case (vertical edge, full overlap with the cell); north-face neighbours, partial overlaps confined to the flight zone, and corner-margin clamps could all push doors back into the unsafe region.
- Fix: move the *where can a door land?* decision from `openings.rs` reverse-engineering the constraint to the staircase publishing it as data via a new `door_slots: Vec<DoorSlot>` field on `RoomCell`. Empty = unrestricted (rooms / elevators); non-empty = candidate shared edges must overlap a matching slot.
- `with_circulation` populates three slots on every staircase (east, west, south faces, all spanning `[z_min, z_min + STAIR_ENTRY_DEPTH]` — the only strip with a walkable platform at storey floor height). `place_interior_doors` now intersects the shared edge with each cell's slots; edges that don't fit are dropped from the BFS edge list entirely so connectivity routes through a different neighbour rather than carving a bad door.

## Notes for reviewers

- `STAIR_ENTRY_DEPTH` / `STAIR_LANDING_DEPTH` moved from `emit/circulation.rs` to `building/circulation.rs` (planner side) so layout and emit share a single source. `emit/circulation.rs` and `emit/shell.rs` now re-import them.
- `WallSide` moved from `emit/openings.rs` to `layout/mod.rs` since it's now part of layout-level data carried on `RoomCell`. `shell.rs` re-imports it from there.
- Dead helpers removed: `shared_edge_door_anchor`, `shared_edge_midpoint`, `clamp_door_to_edge`. Their behaviour folds into `slot_clipped_edge` + `SharedEdge::world_xz` + the existing `clamp_centre`. The slot's midpoint *is* the bias the old anchor helper was computing — the consumer no longer needs to know about `STAIR_ENTRY_DEPTH`.
- All ten layout-style modules (`grid`, `bsp`, `corridor`, `hotel`, `radial`, `organic`, `maze`) and the `score` test fixture were updated with `door_slots: Vec::new()` on plain rooms.

## Test plan

- [x] `cargo build -p mogen-dsl` — clean
- [x] `cargo test -p mogen-dsl` — 310 passed, 1 failed (`windows_on_each_side_never_overlap`); verified the same failure exists on `master` pre-change, so it's a pre-existing issue unrelated to this PR
- [ ] Manual visual check in Studio: open a multi-storey grid building and confirm stairwell doors land on the south entry platform (no doors opening onto flight treads or mid-landing edges)
- [ ] Manual visual check: hotel-corridor and office-core styles, where the staircase shares an edge with a corridor — door should still attach cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)