### PR TITLE
feat(building): trimesh colliders + door/window slot placeholders

### DIFF
--- a/crates/mogen-core/src/aabb.rs
+++ b/crates/mogen-core/src/aabb.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Mesh, NodeId, SceneGraph};
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Aabb {
     pub min: Vec3,
     pub max: Vec3,

--- a/crates/mogen-core/src/graph.rs
+++ b/crates/mogen-core/src/graph.rs
@@ -8,11 +8,73 @@ use glam::Mat4;
 use glam::{Quat, Vec3};
 
 use crate::{
-    Clip, Connector, Joint, Light, Material, MaterialId, Mesh, Meta, Skin, SkinId, Span, Transform,
+    Aabb, Clip, Connector, Joint, Light, Material, MaterialId, Mesh, Meta, Skin, SkinId, Span,
+    Transform,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NodeId(pub u32);
+
+/// Collider shape stamped on a [`SceneNode`]. Exported into the glTF node's
+/// `extras.collider` as `{ "type": "<variant>", ... }` so a downstream
+/// importer can synthesize the matching engine-native collision shape.
+///
+/// Variants:
+/// - [`Aabb`] — axis-aligned box in node-local space. Cheapest. Used by the
+///   user-facing `collider="aabb"` DSL attribute.
+/// - [`Trimesh`] — use the node's own mesh as the collider. The importer
+///   reads positions + indices from `node.mesh` and builds a triangle-mesh
+///   shape. Set automatically on building walls / floors / ceilings / roof
+///   / stairs where a single AABB would be too coarse.
+/// - [`Convex`] — convex hull of the node's mesh. Cheaper to simulate than a
+///   Trimesh and safe for any closed solid; reserved for future use.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ColliderShape {
+    Aabb { aabb: Aabb },
+    Trimesh,
+    Convex,
+}
+
+impl ColliderShape {
+    /// Return the inner AABB when this is the [`Aabb`] variant. Used by the
+    /// viewport collider overlay (which only knows how to draw boxes) and by
+    /// the inspector's AABB extent readout.
+    pub fn as_aabb(&self) -> Option<Aabb> {
+        match self {
+            ColliderShape::Aabb { aabb } => Some(*aabb),
+            _ => None,
+        }
+    }
+}
+
+/// Marks a [`SceneNode`] as a placeholder location for a swappable element —
+/// typically a door or window slot the building expander emits around each
+/// wall opening. The node's TRS already gives position + outward-facing
+/// rotation; this struct carries the dimensional info (width / height /
+/// optional depth) that a game-engine importer needs to drop a prefab in.
+///
+/// Exported as `extras.slot = { "kind": "...", "width": w, "height": h }`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Slot {
+    /// What the placeholder represents — typically `"door"`, `"window"`, or
+    /// `"skylight"`. Importers match on this string; new kinds may be added
+    /// without changing the schema.
+    pub kind: String,
+    /// Opening width in metres (along the wall).
+    pub width: f32,
+    /// Opening height in metres (vertical).
+    pub height: f32,
+    /// Opening depth in metres (perpendicular to the wall). Zero when the
+    /// slot is a flat plane on the wall surface; non-zero when the slot has
+    /// a meaningful thickness (e.g. window inset).
+    #[serde(default, skip_serializing_if = "is_zero_f32")]
+    pub depth: f32,
+}
+
+fn is_zero_f32(v: &f32) -> bool {
+    *v == 0.0
+}
 
 /// Records that a node's local transform was set by an `attach` pass.
 /// `anchor` / `rotation` are what attach computed *before* composing the
@@ -95,13 +157,27 @@ pub struct SceneNode {
     pub children: Vec<NodeId>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub connectors: Vec<Connector>,
-    /// Optional axis-aligned collision box in node-local space, derived from
-    /// the node's subtree mesh extents at lower-time when the source carried
-    /// `collider="aabb"`. Exported to glTF as `node.extras.collider` so a
-    /// downstream importer (e.g. Godot) can synthesize a `CollisionShape3D`.
-    /// mogen does not run physics — this is metadata only.
+    /// Optional collider shape for this node. Exported to glTF as
+    /// `node.extras.collider` so a downstream importer (e.g. Godot) can
+    /// synthesize a `CollisionShape3D`. mogen does not run physics — this
+    /// is metadata only. Set by:
+    /// - the DSL `collider="aabb"` attribute (lowered to
+    ///   [`ColliderShape::Aabb`] in `lower::Pass 2.6`), and
+    /// - the `building` expander, which tags every wall / floor / ceiling /
+    ///   roof / stair mesh as [`ColliderShape::Trimesh`] so games can drop
+    ///   the .glb in and have physics work without hand-authoring shapes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub collider: Option<crate::Aabb>,
+    pub collider: Option<ColliderShape>,
+    /// Marks this node as a placeholder location for a swappable element
+    /// (door / window / skylight). Set on the wrapper group emitted around
+    /// each opening by the `building` expander, so a game engine importer
+    /// can locate every doorway/window and substitute its own prefab at
+    /// the wrapper's transform — the wrapper's TRS already encodes
+    /// position + outward-facing rotation, and the slot carries the
+    /// remaining dimensional info (width, height) that the transform
+    /// can't.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slot: Option<Slot>,
     /// Whether this node's mesh contributes to the realtime shadow pre-pass and
     /// to the exported `extras.cast_shadow` hint downstream importers read.
     /// Defaults to `true`; set `cast_shadow=0` in the DSL to opt a node out
@@ -202,6 +278,7 @@ impl Default for SceneNode {
             children: Vec::new(),
             connectors: Vec::new(),
             collider: None,
+            slot: None,
             cast_shadow: true,
             tags: Vec::new(),
             role: None,

--- a/crates/mogen-core/src/lib.rs
+++ b/crates/mogen-core/src/lib.rs
@@ -14,7 +14,7 @@ pub use aabb::{node_world_aabb, subtree_local_aabb, Aabb};
 pub use anim::{Clip, Easing, Interpolation, Joint, JointKind, Track, TrackProperty};
 pub use connector::Connector;
 pub use diagnostic::{has_errors, Diagnostic, Severity, Span};
-pub use graph::{AttachBinding, ConformBinding, NodeId, SceneGraph, SceneNode};
+pub use graph::{AttachBinding, ColliderShape, ConformBinding, NodeId, SceneGraph, SceneNode, Slot};
 pub use meta::Meta;
 pub use light::{Light, LightKind};
 pub use material::{AlphaMode, Material, MaterialId, MaterialShader, TextureRef, UvMode};

--- a/crates/mogen-dsl/src/lower.rs
+++ b/crates/mogen-dsl/src/lower.rs
@@ -280,7 +280,8 @@ pub fn lower_with_loader(
         COLLIDER_REQUESTS.with(|r| std::mem::take(&mut *r.borrow_mut()));
     for id in pending {
         if let Some(aabb) = subtree_local_aabb(&graph, id) {
-            graph.nodes[id.0 as usize].collider = Some(aabb);
+            graph.nodes[id.0 as usize].collider =
+                Some(mogen_core::ColliderShape::Aabb { aabb });
         }
     }
 

--- a/crates/mogen-dsl/src/lower/building/emit/modules.rs
+++ b/crates/mogen-dsl/src/lower/building/emit/modules.rs
@@ -15,7 +15,7 @@
 use anyhow::Result;
 use glam::{Quat, Vec3};
 
-use mogen_core::{NodeId, SceneGraph, Transform, UvMode};
+use mogen_core::{NodeId, SceneGraph, Slot, Transform, UvMode};
 use mogen_geom::box_mesh;
 
 use crate::ast::{Node, Value};
@@ -41,13 +41,13 @@ pub(super) fn emit_module_instances(
     for op in &plan.entrances {
         emit_one(
             parent_node, parent, graph, &reg, op,
-            &cfg.external_door, "ext_door", Some(EXT_DOOR_MAT),
+            &cfg.external_door, "ext_door", "door", Some(EXT_DOOR_MAT),
         )?;
     }
     for op in &plan.interior_doors {
         emit_one(
             parent_node, parent, graph, &reg, op,
-            &cfg.internal_door, "int_door", Some(INT_DOOR_MAT),
+            &cfg.internal_door, "int_door", "door", Some(INT_DOOR_MAT),
         )?;
     }
     for op in &plan.windows {
@@ -59,13 +59,13 @@ pub(super) fn emit_module_instances(
         };
         emit_one(
             parent_node, parent, graph, &reg, op,
-            module_name, "window", Some(WINDOW_GLASS_MAT),
+            module_name, "window", "window", Some(WINDOW_GLASS_MAT),
         )?;
     }
     for op in &plan.skylights {
         emit_one(
             parent_node, parent, graph, &reg, op,
-            &cfg.skylight_mod, "skylight", Some(SKYLIGHT_GLASS_MAT),
+            &cfg.skylight_mod, "skylight", "skylight", Some(SKYLIGHT_GLASS_MAT),
         )?;
     }
     Ok(())
@@ -79,6 +79,7 @@ fn emit_one(
     op: &Opening,
     module_name: &str,
     label: &str,
+    slot_kind: &str,
     inherit_mat: Option<&str>,
 ) -> Result<()> {
     // The opening group carries the pose; the instantiated module's body is
@@ -97,6 +98,17 @@ fn emit_one(
     graph.nodes[group_id.0 as usize]
         .tags
         .extend(["building".into(), label.into()]);
+    // Game-engine importers (Godot etc.) read this slot block out of
+    // `extras.slot` to find every doorway / window and substitute their own
+    // prefab at the wrapper's transform. The wrapper TRS already encodes
+    // position + outward-facing rotation; width / height live here because
+    // the transform alone can't carry size.
+    graph.nodes[group_id.0 as usize].slot = Some(Slot {
+        kind: slot_kind.into(),
+        width: op.width,
+        height: op.height,
+        depth: 0.0,
+    });
 
     // Bind the per-opening-kind material onto the wrapping group so any
     // child mesh without an explicit `mat=` (the stdlib door slab, the

--- a/crates/mogen-dsl/src/lower/building/mod.rs
+++ b/crates/mogen-dsl/src/lower/building/mod.rs
@@ -25,7 +25,7 @@ mod tests;
 use anyhow::Result;
 use glam::{Quat, Vec3};
 
-use mogen_core::{NodeId, SceneGraph, Transform};
+use mogen_core::{ColliderShape, NodeId, SceneGraph, Transform};
 
 use crate::ast::Node;
 use crate::lower::helpers::transform_from_attrs;
@@ -135,7 +135,45 @@ pub(super) fn expand_building(
         graph.nodes[i].editable = false;
     }
 
+    tag_building_colliders(graph, pre_expand_count);
+
     Ok(wrapper_id)
+}
+
+/// Walk every node the building emitter just produced and tag mesh-bearing
+/// nodes with [`ColliderShape::Trimesh`] so a game engine importer can drop
+/// the .glb into a level and have physics work without hand-authoring shapes.
+///
+/// We skip:
+/// - Slot wrappers and everything underneath them: doors / windows / skylights
+///   are placeholders the importer will replace with its own prefabs, and
+///   those prefabs ship their own colliders.
+/// - Nodes that already carry a collider (defensive — buildings don't set
+///   one anywhere else today, but the field is public).
+///
+/// AABB would be too coarse for buildings — interior walls, stair flights and
+/// roof slopes are not box-aligned. Trimesh re-uses the node's own mesh as
+/// the collision shape, which is exactly the geometry the wall builder
+/// already cleaned up for export.
+fn tag_building_colliders(graph: &mut SceneGraph, start: usize) {
+    let mut in_slot_subtree = vec![false; graph.nodes.len()];
+    for i in start..graph.nodes.len() {
+        let parent_in_slot = graph.nodes[i]
+            .parent
+            .map(|p| in_slot_subtree[p.0 as usize])
+            .unwrap_or(false);
+        let self_is_slot = graph.nodes[i].slot.is_some();
+        if parent_in_slot || self_is_slot {
+            in_slot_subtree[i] = true;
+            continue;
+        }
+        if graph.nodes[i].collider.is_some() {
+            continue;
+        }
+        if graph.nodes[i].mesh.is_some() {
+            graph.nodes[i].collider = Some(ColliderShape::Trimesh);
+        }
+    }
 }
 
 fn emit_storey(

--- a/crates/mogen-export/src/merge.rs
+++ b/crates/mogen-export/src/merge.rs
@@ -241,6 +241,12 @@ fn is_mergeable(n: &SceneNode, id: NodeId, protected: &HashSet<NodeId>) -> bool 
     if n.collider.is_some() {
         return false;
     }
+    // Slot wrappers carry placeholder geometry the importer will replace at
+    // load time. Their TRS is the contract for where the door/window pivot
+    // sits — merging the placeholder into a sibling would destroy that.
+    if n.slot.is_some() {
+        return false;
+    }
     // Shadow opt-outs survive the merge unchanged: if we folded a
     // `cast_shadow=false` leaf into a casting sibling, the union mesh would
     // silently start throwing shadows again. Cheaper and clearer to keep

--- a/crates/mogen-export/src/writer.rs
+++ b/crates/mogen-export/src/writer.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use anyhow::Result;
 use serde_json::{json, Value};
 
-use mogen_core::{MaterialId, Mesh, NodeId, SceneGraph, SceneNode};
+use mogen_core::{ColliderShape, MaterialId, Mesh, NodeId, SceneGraph, SceneNode};
 
 use crate::accessor::{
     push_indices, push_joints, push_normals, push_positions, push_uvs, push_weights,
@@ -335,15 +335,31 @@ fn emit_node(n: &SceneNode, mesh: Option<usize>, light: Option<usize>) -> Value 
     if !n.tags.is_empty() {
         extras.insert("tags".into(), json!(n.tags));
     }
-    if let Some(aabb) = n.collider {
-        extras.insert(
-            "collider".into(),
-            json!({
+    if let Some(shape) = &n.collider {
+        let payload = match shape {
+            ColliderShape::Aabb { aabb } => json!({
                 "type": "aabb",
                 "min": [aabb.min.x, aabb.min.y, aabb.min.z],
                 "max": [aabb.max.x, aabb.max.y, aabb.max.z],
             }),
-        );
+            // Trimesh and Convex reference `node.mesh` implicitly — the
+            // importer reads positions + indices from the glTF primitive
+            // already attached to this node and builds the matching
+            // collision shape, so no extra geometry is serialised here.
+            ColliderShape::Trimesh => json!({ "type": "trimesh" }),
+            ColliderShape::Convex => json!({ "type": "convex" }),
+        };
+        extras.insert("collider".into(), payload);
+    }
+    if let Some(slot) = &n.slot {
+        let mut obj = serde_json::Map::new();
+        obj.insert("kind".into(), Value::String(slot.kind.clone()));
+        obj.insert("width".into(), json!(slot.width));
+        obj.insert("height".into(), json!(slot.height));
+        if slot.depth != 0.0 {
+            obj.insert("depth".into(), json!(slot.depth));
+        }
+        extras.insert("slot".into(), Value::Object(obj));
     }
     // Default is true; only stamp the hint when the author opted out so the
     // typical case keeps the JSON chunk lean. Importers that don't recognise

--- a/crates/mogen-studio/src/app/ui_panels/selected/mod.rs
+++ b/crates/mogen-studio/src/app/ui_panels/selected/mod.rs
@@ -421,7 +421,7 @@ impl MogenStudioApp {
         // the node. Skipped for `light` nodes since the validator rejects
         // `collider=` there (lights have no AABB to enclose).
         let collider_present = node.collider.is_some();
-        let collider_aabb = node.collider;
+        let collider_aabb = node.collider.as_ref().and_then(|c| c.as_aabb());
         let mut wants_set_collider = false;
         let mut wants_remove_collider = false;
         if node.light.is_none() {

--- a/crates/mogen-studio/src/app/ui_panels/selected/shadow_collider.rs
+++ b/crates/mogen-studio/src/app/ui_panels/selected/shadow_collider.rs
@@ -51,7 +51,7 @@ pub(super) fn render(ui: &mut egui::Ui, node: &mogen_core::SceneNode) -> ToggleA
     // the node. Skipped for `light` nodes since the validator rejects
     // `collider=` there (lights have no AABB to enclose).
     let collider_present = node.collider.is_some();
-    let collider_aabb = node.collider;
+    let collider_aabb = node.collider.as_ref().and_then(|c| c.as_aabb());
     ui.add_space(8.0);
     ui.separator();
     ui.label(egui::RichText::new("Collider").strong());

--- a/crates/mogen-studio/src/viewer/colliders_gl.rs
+++ b/crates/mogen-studio/src/viewer/colliders_gl.rs
@@ -184,7 +184,12 @@ pub(super) fn collect(
 ) -> Vec<ColliderInstance> {
     let mut out = Vec::new();
     for (i, node) in scene.nodes.iter().enumerate() {
-        let Some(aabb) = node.collider else { continue };
+        // The overlay only renders AABB colliders — Trimesh/Convex shapes
+        // re-use the node's mesh, which the regular preview already draws,
+        // so there's no separate wireframe to overlay.
+        let Some(aabb) = node.collider.as_ref().and_then(|c| c.as_aabb()) else {
+            continue;
+        };
         let world = worlds.get(i).copied().unwrap_or(Mat4::IDENTITY);
         let id = NodeId(i as u32);
         out.push(ColliderInstance {


### PR DESCRIPTION
## Summary

- Buildings now ship with **per-mesh trimesh colliders** on every wall, floor, ceiling, roof and stair, so a game-engine importer can drop the `.glb` in and have physics work without hand-authoring shapes. AABB would be too coarse — interior walls and stair flights aren't box-aligned.
- Every doorway / window / skylight exports as a **placeholder slot** carrying `kind`, `width`, `height`. The wrapper's existing TRS gives position + outward-facing rotation; the slot adds the size info a transform can't carry, so a game engine can substitute its own door / window prefab at load time.

## What changed

**Data model (`mogen-core`)**
- New `ColliderShape` enum (`Aabb { aabb }` / `Trimesh` / `Convex`) replaces the old `collider: Option<Aabb>` field on `SceneNode`.
- New `Slot { kind, width, height, depth }` struct + `SceneNode.slot: Option<Slot>`.
- `Aabb` now derives `PartialEq` (required for the enum derive).

**Building emitter (`mogen-dsl`)**
- `expand_building` runs a post-pass that tags every mesh-bearing non-slot node in the building subtree with `ColliderShape::Trimesh`. Slot wrappers and everything underneath them are skipped — the importer's prefabs bring their own colliders.
- `emit/modules.rs` stamps a `Slot` on each opening wrapper. Both entrance and interior doors collapse to `kind: "door"`; the pre-existing `extras.role` ("ext_door" / "int_door") still distinguishes them for importers that care.

**Exporter (`mogen-export`)**
- `node.extras.collider` keeps its existing `{ "type": "aabb", "min", "max" }` shape and adds `{ "type": "trimesh" }` / `{ "type": "convex" }`.
- New `node.extras.slot = { "kind", "width", "height" [, "depth"] }`.
- `merge.rs` skips slot-bearing leaves so the placeholder transform survives the optional sibling-merge pass.

**Studio**
- The three sites that read AABB extents (`colliders_gl`, two inspector panels) go through `ColliderShape::as_aabb()`, so the viewport collider overlay continues to only draw box wireframes — `Trimesh` / `Convex` colliders re-use the regular preview geometry.

## Importer recipe (Godot)

Walk every imported node:
- If `metadata("slot")` returns a dict, read `kind` / `width` / `height`, instance your prefab at the node's transform, then delete the placeholder.
- If `metadata("collider")` returns a dict, build a `CollisionShape3D` from `type` (`aabb` → `BoxShape3D`, `trimesh` → `ConcavePolygonShape3D` from `node.mesh`, `convex` → `ConvexPolygonShape3D`).

## Verification

- `examples/buildings/three_storey_house.mog` → 559 nodes → **51 slots** (24 doors + 27 windows) + **138 trimesh colliders** on structural geometry.
- `examples/features/colliders.mog` → legacy `collider=\"aabb\"` path still emits the unchanged `{ type: \"aabb\", min, max }` JSON.
- `cargo test --workspace` → all collider/building tests pass. One pre-existing failure (`single_storey::windows_on_each_side_never_overlap`) reproduces on clean `master` and is unrelated to this change.

## Test plan

- [ ] `cargo test --workspace`
- [ ] `./scripts/run-mogen.sh build examples/buildings/three_storey_house.mog --out /tmp/x.glb` and confirm `extras.slot` / `extras.collider` populate as described.
- [ ] Open a building in MoGen Studio and confirm the AABB-collider overlay still draws box wireframes for nodes authored with `collider=\"aabb\"`.
- [ ] Import the output `.glb` into Godot 4.x and confirm slot/collider metadata round-trips into `metadata("slot")` / `metadata("collider")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)