### PR TITLE
Fix switchback stair headroom + bundled building fixes

### DIFF
--- a/crates/mogen-dsl/src/lower/building/emit/circulation.rs
+++ b/crates/mogen-dsl/src/lower/building/emit/circulation.rs
@@ -575,10 +575,14 @@ fn emit_synthetic_stair(
     let tread = flight_d / steps as f32;
     let actual_rise = rise / steps as f32;
     for i in 0..steps {
-        let step_height = actual_rise * (i as f32 + 1.0);
-        let step_centre_y = 0.5 * step_height;
+        // Single-rise block at the step's true elevation — matches
+        // stair_simple. The under-side traces a stepped diagonal so a
+        // half-flight stacked directly above (same x-half on the next
+        // storey) leaves clear headroom for the climber below instead
+        // of capping it at half-rise.
+        let step_centre_y = actual_rise * (i as f32 + 0.5);
         let step_centre_z = -0.5 * flight_d + (i as f32 + 0.5) * tread;
-        let mesh = box_mesh([flight_w - 0.1, step_height, tread], UvMode::Tile);
+        let mesh = box_mesh([flight_w - 0.1, actual_rise, tread], UvMode::Tile);
         let step_id = graph.add_child(
             parent,
             format!("step_{i}"),

--- a/crates/mogen-dsl/src/lower/building/emit/circulation.rs
+++ b/crates/mogen-dsl/src/lower/building/emit/circulation.rs
@@ -120,6 +120,7 @@ pub(in super::super) fn emit_circulation(
                     i,
                     bottom_storey,
                     top_storey,
+                    &layout.storeys,
                     circ_group,
                     graph,
                 )?;
@@ -310,6 +311,7 @@ fn emit_staircase(
     idx: usize,
     bottom_storey: i32,
     top_storey: i32,
+    storeys: &[StoreyPlate],
     parent: NodeId,
     graph: &mut SceneGraph,
 ) -> Result<()> {
@@ -482,7 +484,10 @@ fn emit_staircase(
         ),
     );
     graph.nodes[enclosure.0 as usize].origin = origin.clone();
-    emit_shaft_enclosure(cell_w, cell_d, total_h, enclosure, graph, &origin);
+    let (adj_n, adj_e, adj_s) = shaft_face_adjacencies(&cell.rect, storeys);
+    emit_shaft_enclosure(
+        cell_w, cell_d, total_h, adj_n, adj_e, adj_s, enclosure, graph, &origin,
+    );
     Ok(())
 }
 
@@ -841,10 +846,14 @@ fn emit_elevator(
     // match its own room layout — a single full-height wall could only
     // hold one X column per door (wall_with_holes merges X-overlapping
     // spans), so the per-storey shifts would smear into one giant hole.
+    let (adj_n, adj_e, adj_s) = shaft_face_adjacencies(&cell.rect, storeys);
     emit_shaft_enclosure(
         cell.rect.width(),
         cell.rect.depth(),
         total_h,
+        adj_n,
+        adj_e,
+        adj_s,
         shaft_group,
         graph,
         &origin,
@@ -938,10 +947,19 @@ fn emit_elevator_west_walls(
 /// staircases let the per-storey cell-shared wall from `rooms.rs` carry
 /// the door cutout, while elevators emit per-storey west pieces via
 /// `emit_elevator_west_walls`.
+///
+/// `skip_n` / `skip_e` / `skip_s` extend that same exemption to the other
+/// faces whenever an adjacent `Room` cell already provides closure: the
+/// room's per-cell wall carries any door cutout the BFS placed there, and
+/// a solid shaft_wall on top would shadow the cutout (visually hiding
+/// the door slab and adding a trimesh collider that blocks passage).
 fn emit_shaft_enclosure(
     cell_w: f32,
     cell_d: f32,
     total_h: f32,
+    skip_n: bool,
+    skip_e: bool,
+    skip_s: bool,
     group: NodeId,
     graph: &mut SceneGraph,
     origin: &Option<std::path::PathBuf>,
@@ -953,24 +971,30 @@ fn emit_shaft_enclosure(
     // body's first/last step ends a few mm short of the cell boundary,
     // so this keeps the enclosure from z-fighting with the steps while
     // still presenting a flush wall to anyone inside the cell.
-    let walls: [(&str, [f32; 3], [f32; 3]); 3] = [
+    let walls: [(&str, bool, [f32; 3], [f32; 3]); 3] = [
         (
             "shaft_wall_n",
+            skip_n,
             [0.0, 0.0, 0.5 * cell_d + half],
             [cell_w + 0.1, total_h, thickness],
         ),
         (
             "shaft_wall_e",
+            skip_e,
             [0.5 * cell_w + half, 0.0, 0.0],
             [thickness, total_h, cell_d + 0.1],
         ),
         (
             "shaft_wall_s",
+            skip_s,
             [0.0, 0.0, -0.5 * cell_d - half],
             [cell_w + 0.1, total_h, thickness],
         ),
     ];
-    for (name, pos, size) in walls {
+    for (name, skip, pos, size) in walls {
+        if skip {
+            continue;
+        }
         let mesh = box_mesh(size, UvMode::Tile);
         let id = graph.add_child(
             group,
@@ -987,6 +1011,42 @@ fn emit_shaft_enclosure(
         graph.nodes[id.0 as usize].role = Some("shaft_wall".into());
         inherit_material_from_chain(id, graph);
     }
+}
+
+/// Compute which of the N/E/S faces of `cell_rect` are abutted by a
+/// `Room` cell on at least one storey. The west face is excluded —
+/// the caller handles it directly.
+fn shaft_face_adjacencies(
+    cell_rect: &Rect2,
+    storeys: &[StoreyPlate],
+) -> (bool, bool, bool) {
+    let mut adj_n = false;
+    let mut adj_e = false;
+    let mut adj_s = false;
+    for sp in storeys {
+        for r in &sp.plate.rooms {
+            if !matches!(r.kind, CellKind::Room) {
+                continue;
+            }
+            let rr = &r.rect;
+            // x ranges overlap (any positive intersection)?
+            let x_overlap = rr.x_min < cell_rect.x_max - 1e-3
+                && rr.x_max > cell_rect.x_min + 1e-3;
+            // z ranges overlap?
+            let z_overlap = rr.z_min < cell_rect.z_max - 1e-3
+                && rr.z_max > cell_rect.z_min + 1e-3;
+            if x_overlap && (rr.z_min - cell_rect.z_max).abs() < 1e-3 {
+                adj_n = true;
+            }
+            if x_overlap && (rr.z_max - cell_rect.z_min).abs() < 1e-3 {
+                adj_s = true;
+            }
+            if z_overlap && (rr.x_min - cell_rect.x_max).abs() < 1e-3 {
+                adj_e = true;
+            }
+        }
+    }
+    (adj_n, adj_e, adj_s)
 }
 
 fn synth_use(parent: &Node, name: &str, attrs: &[(&str, f32)]) -> Node {

--- a/crates/mogen-dsl/src/lower/building/emit/openings.rs
+++ b/crates/mogen-dsl/src/lower/building/emit/openings.rs
@@ -304,7 +304,19 @@ fn place_interior_doors(
             // still reach an elevator whose neighbour is too narrow to
             // hold the wider 1.5× doorway — connectivity beats ideal
             // sizing. Width selection happens per-edge above.
-            if edge.span() >= cfg.door_w * 1.1 {
+            //
+            // Threshold is exactly `door_w` (no extra margin): the only
+            // edges that hit this lower bound are the staircase's east /
+            // west entry slots, which are clipped to `STAIR_ENTRY_DEPTH
+            // = 1.0 m` along Z. Insisting on a 10 % overrun there left
+            // stairs unreachable on layouts where no room shared the
+            // stair's south face (see grid_office regression).
+            // The corner-clamp at door placement already degrades to
+            // the slot midpoint when the slot is narrower than
+            // 2 × corner_margin, so a slot exactly `door_w` wide just
+            // produces a door that fills the slot — geometrically
+            // valid and exactly what a stair entry strip wants.
+            if edge.span() >= cfg.door_w {
                 edges.push((i, j, edge, door_w));
             }
         }

--- a/crates/mogen-dsl/src/lower/building/tests/multi_storey.rs
+++ b/crates/mogen-dsl/src/lower/building/tests/multi_storey.rs
@@ -345,6 +345,99 @@ fn door_bfs_never_connects_stair_to_elevator() {
 }
 
 #[test]
+fn stair_entry_zone_gets_an_interior_door() {
+    // Regression for the grid_office example
+    // (examples/buildings/grid_office.mog): when the layout solver only
+    // exposes the staircase's *west* entry slot to an adjacent RoomCell
+    // (i.e. no room touches the stair's south face), the BFS in
+    // `place_interior_doors` must still place a door at that slot.
+    //
+    // The bug was that the eligibility threshold
+    // `edge.span() >= cfg.door_w * 1.1` excluded the slot, because
+    // `STAIR_ENTRY_DEPTH = 1.0` m exactly equals the slot span and
+    // `door_w * 1.1` is above it for any reasonable door width. With
+    // no other edge available, the stair was unreachable.
+    let src = r#"
+        material "concrete" (color=[0.78, 0.78, 0.75])
+        building "office" (
+          seed=7, style="office-core",
+          floor_area=500, floors_above=2, rooms=19,
+          windows=40, entrances=1, ceiling_height=2.8,
+          door_w=0.95, door_h=2.1, staircases=1,
+          mat="concrete",
+        ) {
+          room_type "office"   (kind=staff_only, density=4)
+          room_type "corridor" (kind=public,     density=1)
+        }
+    "#;
+    let g = lower_src(src);
+
+    // Compute world position by accumulating translation up the parent
+    // chain. Everything along the way is axis-aligned in the building
+    // (floor groups offset on Y, openings groups at identity), so a
+    // plain sum suffices for the (x, z) check the assertion needs.
+    let world_pos = |idx: usize| -> (f32, f32, f32) {
+        let mut x = 0.0;
+        let mut y = 0.0;
+        let mut z = 0.0;
+        let mut cur = Some(mogen_core::NodeId(idx as u32));
+        while let Some(id) = cur {
+            let n = &g.nodes[id.0 as usize];
+            x += n.transform.translation.x;
+            y += n.transform.translation.y;
+            z += n.transform.translation.z;
+            cur = n.parent;
+        }
+        (x, y, z)
+    };
+
+    // Locate the floor-0 staircase landing — that node sits at the
+    // (x, y, z) centre of the south entry strip.
+    let landing_idx = g
+        .nodes
+        .iter()
+        .position(|n| n.role.as_deref() == Some("staircase_landing"))
+        .expect("staircase_landing node");
+    let (stair_x, _, stair_z) = world_pos(landing_idx);
+
+    // The entry zone is the 1m strip at the south end of the stair cell.
+    // The landing centre sits at the stair-cell centre, so the entry
+    // zone runs from z = stair_z - STAIR_DEPTH/2 northward by
+    // STAIR_ENTRY_DEPTH = 1m. We tolerate a generous box around it to
+    // allow doors on east / west / south faces of the entry zone.
+    let stair_depth = 4.0_f32; // STAIR_DEPTH constant in circulation.rs
+    let entry_depth = 1.0_f32; // STAIR_ENTRY_DEPTH constant
+    let column_width = 2.0_f32; // typical office-core column width; bound is generous
+    let entry_x_min = stair_x - column_width;
+    let entry_x_max = stair_x + column_width;
+    let entry_z_min = stair_z - 0.5 * stair_depth - 0.5; // south face plus wall slack
+    let entry_z_max = stair_z - 0.5 * stair_depth + entry_depth + 0.5;
+
+    let mut door_in_entry: Option<(String, f32, f32)> = None;
+    for (i, n) in g.nodes.iter().enumerate() {
+        if n.role.as_deref() != Some("int_door") {
+            continue;
+        }
+        let (dx, _, dz) = world_pos(i);
+        if dx >= entry_x_min
+            && dx <= entry_x_max
+            && dz >= entry_z_min
+            && dz <= entry_z_max
+        {
+            door_in_entry = Some((n.name.clone(), dx, dz));
+            break;
+        }
+    }
+
+    assert!(
+        door_in_entry.is_some(),
+        "no interior door reaches the staircase entry zone \
+         (x∈[{entry_x_min:.2},{entry_x_max:.2}], z∈[{entry_z_min:.2},{entry_z_max:.2}]); \
+         landing at ({stair_x:.2}, {stair_z:.2})"
+    );
+}
+
+#[test]
 fn elevator_doorways_are_one_and_a_half_times_door_width() {
     // Doors that open onto an elevator cell are widened to 1.5 × the
     // standard interior door (so 0.9 × 1.5 = 1.35 m at default

--- a/crates/mogen-dsl/src/lower/building/tests/multi_storey.rs
+++ b/crates/mogen-dsl/src/lower/building/tests/multi_storey.rs
@@ -533,6 +533,58 @@ fn stair_entry_door_is_not_blocked_by_shaft_wall() {
 }
 
 #[test]
+fn shaft_wall_still_closes_faces_with_no_adjacent_room() {
+    // Counterpart to `stair_entry_door_is_not_blocked_by_shaft_wall`. The
+    // fix omits `shaft_wall_X` whenever a `Room` cell shares that face;
+    // it MUST still emit a wall when no room is there. Otherwise the
+    // shaft is open to the column gap (or beyond), which is what those
+    // walls existed to close.
+    //
+    // For seed=2 office-core / floor_area=500, slop-land's geometry:
+    //   - South face: corridor cell adjacent → shaft_wall_s skipped.
+    //   - North face: a column-filler gap, no adjacent room → must
+    //     still emit shaft_wall_n.
+    //   - East face: building exterior, no adjacent room → still emits
+    //     shaft_wall_e.
+    let src = r#"
+        material "concrete" (color=[0.78, 0.78, 0.75])
+        building "office" (
+          seed=2, style="office-core",
+          floor_area=500, floors_above=2, rooms=19,
+          windows=40, entrances=1, ceiling_height=2.8,
+          door_w=0.95, door_h=2.1, staircases=1,
+          mat="concrete",
+        ) {
+          room_type "office"   (kind=staff_only, density=4)
+          room_type "corridor" (kind=public,     density=1)
+        }
+    "#;
+    let g = lower_src(src);
+
+    let mut saw_n = false;
+    let mut saw_e = false;
+    let mut saw_s = false;
+    for n in &g.nodes {
+        if n.role.as_deref() != Some("shaft_wall") {
+            continue;
+        }
+        match n.name.as_str() {
+            "shaft_wall_n" => saw_n = true,
+            "shaft_wall_e" => saw_e = true,
+            "shaft_wall_s" => saw_s = true,
+            _ => {}
+        }
+    }
+    assert!(saw_n, "shaft_wall_n was omitted but no room is north of the stair");
+    assert!(saw_e, "shaft_wall_e was omitted but no room is east of the stair");
+    assert!(
+        !saw_s,
+        "shaft_wall_s was emitted but the corridor sits south of the stair; \
+         the room wall handles closure and would shadow the entry door"
+    );
+}
+
+#[test]
 fn elevator_doorways_are_one_and_a_half_times_door_width() {
     // Doors that open onto an elevator cell are widened to 1.5 × the
     // standard interior door (so 0.9 × 1.5 = 1.35 m at default

--- a/crates/mogen-dsl/src/lower/building/tests/multi_storey.rs
+++ b/crates/mogen-dsl/src/lower/building/tests/multi_storey.rs
@@ -91,6 +91,63 @@ fn switchback_emits_a_mid_landing_per_pair() {
 }
 
 #[test]
+fn stair_steps_have_constant_rise_not_growing_boxes() {
+    // Stair treads must be single-rise blocks at their true elevation,
+    // not growing boxes that span y=0..tread_top. The growing-box layout
+    // makes the under-side a flat plane at the flight base, so the
+    // half-flight stacked directly above (same x-half on the next
+    // storey) capped headroom at half_rise (= 1.4 m for a 2.8 m step).
+    // Constant-rise blocks keep the under-side parallel to the treads
+    // so the climber below has room to stand the whole way up.
+    let g = lower_src(MULTI_FLOOR_SRC);
+    // Walk every stair_flight subtree and grab the per-step box meshes.
+    // The stair_simple module emits them as `box "step_$i"` children
+    // (no role) so we match by name rather than role.
+    let mut heights: Vec<f32> = Vec::new();
+    let mut frontier: Vec<usize> = g
+        .nodes
+        .iter()
+        .enumerate()
+        .filter(|(_, n)| n.role.as_deref() == Some("stair_flight"))
+        .map(|(i, _)| i)
+        .collect();
+    while let Some(i) = frontier.pop() {
+        for c in &g.nodes[i].children {
+            let idx = c.0 as usize;
+            let n = &g.nodes[idx];
+            if n.name.starts_with("step_") {
+                if let Some(mesh) = &n.mesh {
+                    let (mut ymin, mut ymax) = (f32::INFINITY, f32::NEG_INFINITY);
+                    for p in &mesh.positions {
+                        ymin = ymin.min(p[1]);
+                        ymax = ymax.max(p[1]);
+                    }
+                    heights.push(ymax - ymin);
+                }
+            }
+            frontier.push(idx);
+        }
+    }
+    assert!(!heights.is_empty(), "no stair step meshes emitted");
+    let max_h = heights.iter().cloned().fold(0.0f32, f32::max);
+    let min_h = heights.iter().cloned().fold(f32::INFINITY, f32::min);
+    assert!(
+        (max_h - min_h).abs() < 1e-3,
+        "stair step heights should be constant (single-rise blocks), \
+         saw min={min_h} max={max_h} — a growing spread means the under-stair \
+         is flat and steals headroom from the flight below"
+    );
+    // Sanity: with half_rise = 1.4 m and target ~0.18 m per step, the
+    // half-flight gets 8 steps so actual_rise ≈ 0.175 m. Each block
+    // should hover near that, not the full half_rise.
+    assert!(
+        max_h < 0.5,
+        "step height {max_h} is suspiciously tall — looks like the old \
+         growing-box layout (top step ≈ half_rise) is back"
+    );
+}
+
+#[test]
 fn flight_handrails_sit_on_each_flights_own_spine_edge() {
     // The lower (east) flight's spine-facing edge is at +spine/2; its
     // rail centre belongs at +(spine/2 + thickness/2), with the rail's

--- a/crates/mogen-dsl/src/lower/building/tests/multi_storey.rs
+++ b/crates/mogen-dsl/src/lower/building/tests/multi_storey.rs
@@ -438,6 +438,101 @@ fn stair_entry_zone_gets_an_interior_door() {
 }
 
 #[test]
+fn stair_entry_door_is_not_blocked_by_shaft_wall() {
+    // Regression: `emit_shaft_enclosure` was emitting `shaft_wall_n/e/s` as
+    // solid 24-vert boxes that sat just outside each face of the stair cell.
+    // When the BFS placed a stair entry door on a face whose adjacent cell
+    // is a Room (the room's per-cell wall carries the door cutout, exactly
+    // like the always-exempted west face), the shaft_wall covering that
+    // face's z-range still had no hole — it shadowed the room wall's
+    // cutout, visually masking the door slab and blocking passage with its
+    // trimesh collider.
+    //
+    // Reproducer matches slop-land's seed=2 office-core layout: a corridor
+    // cell sits south of the stair, so the BFS places the entry door on the
+    // stair's south face. The fix omits shaft_wall_X whenever a Room shares
+    // that face — analogous to the existing west-face exemption.
+    let src = r#"
+        material "concrete" (color=[0.78, 0.78, 0.75])
+        building "office" (
+          seed=2, style="office-core",
+          floor_area=500, floors_above=2, rooms=19,
+          windows=40, entrances=1, ceiling_height=2.8,
+          door_w=0.95, door_h=2.1, staircases=1,
+          mat="concrete",
+        ) {
+          room_type "office"   (kind=staff_only, density=4)
+          room_type "corridor" (kind=public,     density=1)
+        }
+    "#;
+    let g = lower_src(src);
+
+    // Compute world translation by accumulating up the parent chain (every
+    // intermediate node is at identity rotation in this slice of the tree).
+    let world_pos = |idx: usize| -> (f32, f32, f32) {
+        let mut x = 0.0;
+        let mut y = 0.0;
+        let mut z = 0.0;
+        let mut cur = Some(mogen_core::NodeId(idx as u32));
+        while let Some(id) = cur {
+            let n = &g.nodes[id.0 as usize];
+            x += n.transform.translation.x;
+            y += n.transform.translation.y;
+            z += n.transform.translation.z;
+            cur = n.parent;
+        }
+        (x, y, z)
+    };
+
+    // Collect every interior/exterior door's xz position. A door wrapper
+    // carries no mesh, but its xz position is the door's centre.
+    let mut doors: Vec<(String, f32, f32)> = Vec::new();
+    for (i, n) in g.nodes.iter().enumerate() {
+        if n.role.as_deref() != Some("int_door") && n.role.as_deref() != Some("ext_door") {
+            continue;
+        }
+        let (x, _y, z) = world_pos(i);
+        doors.push((n.name.clone(), x, z));
+    }
+
+    // Every shaft_wall mesh: derive its world-space xz footprint from its
+    // mesh bounds + its world transform, then assert no door footprint
+    // overlaps it.
+    let door_w = 0.95;
+    let half_door = 0.5 * door_w;
+    for (i, n) in g.nodes.iter().enumerate() {
+        if n.role.as_deref() != Some("shaft_wall") {
+            continue;
+        }
+        let Some(mesh) = n.mesh.as_ref() else { continue };
+        let (mut mnx, mut mxx) = (f32::INFINITY, f32::NEG_INFINITY);
+        let (mut mnz, mut mxz) = (f32::INFINITY, f32::NEG_INFINITY);
+        for p in &mesh.positions {
+            mnx = mnx.min(p[0]); mxx = mxx.max(p[0]);
+            mnz = mnz.min(p[2]); mxz = mxz.max(p[2]);
+        }
+        let (wx, _, wz) = world_pos(i);
+        let (sw_xmin, sw_xmax) = (wx + mnx, wx + mxx);
+        let (sw_zmin, sw_zmax) = (wz + mnz, wz + mxz);
+
+        for (door_name, dx, dz) in &doors {
+            let (d_xmin, d_xmax) = (dx - half_door, dx + half_door);
+            // Door is thin along its facing axis (~4 cm slab + frame depth)
+            // but we don't know facing here; treat door as a 0.12 m strip
+            // centred on z (which matches the room wall thickness).
+            let (d_zmin, d_zmax) = (dz - 0.06, dz + 0.06);
+            let overlaps_x = sw_xmin < d_xmax - 0.005 && sw_xmax > d_xmin + 0.005;
+            let overlaps_z = sw_zmin < d_zmax - 0.005 && sw_zmax > d_zmin + 0.005;
+            assert!(
+                !(overlaps_x && overlaps_z),
+                "shaft_wall '{}' xz=[{:.2},{:.2}]→[{:.2},{:.2}] covers door '{}' at ({:.2},{:.2})",
+                n.name, sw_xmin, sw_zmin, sw_xmax, sw_zmax, door_name, dx, dz,
+            );
+        }
+    }
+}
+
+#[test]
 fn elevator_doorways_are_one_and_a_half_times_door_width() {
     // Doors that open onto an elevator cell are widened to 1.5 × the
     // standard interior door (so 0.9 × 1.5 = 1.35 m at default

--- a/crates/mogen-dsl/stdlib/stair_simple.mog
+++ b/crates/mogen-dsl/stdlib/stair_simple.mog
@@ -1,10 +1,10 @@
-// summary: Simple straight-flight staircase. Authored along +Z: bottom step at z=-depth/2 (y=0), top step at z=+depth/2 (y=$rise). `width`/`depth` are the floorplan footprint; `rise` is the vertical distance from one floor to the next; `steps` is the tread count (default 14 gives ~0.2 m per step for a 2.8 m rise). Each tread is a right-triangle approximation: a box rising from y=0 to its top surface, so the underside of the flight is closed. Tread depth fills `$depth / $steps` exactly so adjacent treads butt flush — any z gap would leak the floor below through the riser face.
+// summary: Simple straight-flight staircase. Authored along +Z: bottom step at z=-depth/2 (y=0), top step at z=+depth/2 (y=$rise). `width`/`depth` are the floorplan footprint; `rise` is the vertical distance from one floor to the next; `steps` is the tread count (default 14 gives ~0.2 m per step for a 2.8 m rise). Each tread is a single-rise box stacked at its true elevation, so the underside follows the stair as a stepped diagonal — when another flight is stacked directly above (switchback half-flights between storeys), the climber below keeps `rise − rise/steps` of headroom along the entire ascent instead of losing it at the top. Tread depth fills `$depth / $steps` exactly so adjacent treads butt flush — any z gap would leak the floor below through the riser face.
 module "stair_simple" (width=2.0, depth=3.0, rise=2.8, steps=14) {
   group "stair_simple" {
     for (var="i", from=0, to=$steps) {
       box "step_$i" (
-        pos=[0, $rise * ($i + 1) / $steps * 0.5, $depth * -0.5 + ($i + 0.5) * $depth / $steps],
-        size=[$width - 0.1, $rise * ($i + 1) / $steps, $depth / $steps]
+        pos=[0, $rise * ($i + 0.5) / $steps, $depth * -0.5 + ($i + 0.5) * $depth / $steps],
+        size=[$width - 0.1, $rise / $steps, $depth / $steps]
       )
     }
   }


### PR DESCRIPTION
## Summary

- **Switchback stairs were unclimbable**: `stair_simple` rendered each tread as a growing box from `y=0` to its top, making the under-side a flat plane at the flight base. When the next storey's half-flight stacked directly above (same x-half, same z-range), its under-side hung only `half_rise = 1.4 m` above the climber's head at the top of the flight below.
- **Fix**: each tread is now a single-rise block at its true elevation, so the under-side traces a stepped diagonal parallel to the treads. Headroom stays at `step_h − actual_rise ≈ 2.62 m` along the entire climb. The `emit_synthetic_stair` fallback gets the same treatment. New test locks the invariant.

## What's in the PR

The headline change is `fix(building): switchback stair under-side leaves clear headroom`. The PR also bundles three earlier local-only building/staircase commits that were already on `master` ahead of `origin/master`:

- `fix(building): drop 10% margin on door eligibility so stair entry slot fits`
- `fix(building): skip shaft walls on faces with an adjacent room`
- `test(building): lock in shaft_wall closure on faces with no adjacent room`

All four commits are related stair/shell work.

## Test plan

- [x] `cargo test -p mogen-dsl --lib lower::building` — 88 passed, including the new `stair_steps_have_constant_rise_not_growing_boxes` test. One pre-existing unrelated failure (`windows_on_each_side_never_overlap`) reproduces on `master` before this branch.
- [x] `cargo run --release --bin mogen -- build examples/buildings/three_storey_house.mog` builds clean (6.8k tris, 13ms).
- [ ] Visual check in Godot / Studio that a climber can now ascend a multi-storey switchback stairwell without hitting the under-stair above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)