### PR TITLE
Bundle LODs (3 stages) + imposter under one export option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,6 +1338,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,6 +2404,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "meshopt"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01e77ead21976b3a9f01ec1724f766923da74f0726364e2b0f425658935d71a"
+dependencies = [
+ "bitflags 2.11.1",
+ "cc",
+ "float-cmp",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "metal"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,9 +2525,11 @@ dependencies = [
  "fbxcel",
  "glam",
  "image",
+ "meshopt",
  "mogen-core",
  "mogen-dsl",
  "mogen-geom",
+ "mogen-render",
  "oxipng",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,11 @@ serde_json = "1"
 glam = { version = "0.30", features = ["serde"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 oxipng = { version = "9", default-features = false, features = ["parallel"] }
+# meshoptimizer Rust bindings. Used by `mogen-export`'s LOD pass to generate
+# simplified index buffers via quadric edge collapse. Wraps a small C++ lib
+# behind `cc`; doesn't cross-compile to `wasm32-unknown-unknown`, so wasm
+# builds keep the `lod` feature disabled.
+meshopt = "0.6"
 # `import` is the simple high-level API for reading .glb/.gltf into typed
 # accessors. Default features pull in the `image` crate for embedded textures
 # (we strip materials/textures on import, but keeping defaults avoids one more

--- a/crates/mogen-export/Cargo.toml
+++ b/crates/mogen-export/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [features]
-default = ["textures", "textures-optimize", "merge"]
+default = ["textures", "textures-optimize", "merge", "lod", "imposter"]
 # Texture packing. Splits cleanly across two layers so wasm builds can
 # embed images without pulling in `image`/`oxipng` (which depend on C libs
 # that don't cross-compile to wasm32):
@@ -32,6 +32,17 @@ merge = []
 # wasm crate doesn't enable. The desktop CLI turns this on so `mogen build`
 # can dispatch on output extension.
 fbx = ["dep:fbxcel"]
+# LOD mesh simplification. Pulls in `meshopt` which links a small C++ lib via
+# `cc`; doesn't cross-compile to wasm32-unknown-unknown, so wasm builds keep
+# this disabled. With this off, the `bundle_lods_and_imposter` option only
+# emits the imposter half (or no-ops entirely if `imposter` is also off).
+lod = ["dep:meshopt"]
+# Headless imposter atlas bake. Pulls in `mogen-render` (glow + glutin +
+# winit), which needs a real display server / GL stack at runtime and a
+# windowing toolkit at build time; wasm and CI-headless builds keep this
+# disabled. Also requires `textures` so the spritesheet PNG can be embedded
+# alongside the billboard material.
+imposter = ["textures", "dep:mogen-render", "dep:image"]
 
 [dependencies]
 mogen-core = { workspace = true }
@@ -43,6 +54,8 @@ glam = { workspace = true }
 image = { workspace = true, optional = true }
 oxipng = { workspace = true, optional = true }
 fbxcel = { version = "0.9", features = ["writer", "tree"], optional = true }
+meshopt = { workspace = true, optional = true }
+mogen-render = { workspace = true, optional = true }
 
 [dev-dependencies]
 mogen-dsl = { workspace = true, features = ["csg"] }

--- a/crates/mogen-export/src/imposter.rs
+++ b/crates/mogen-export/src/imposter.rs
@@ -1,0 +1,232 @@
+//! Imposter atlas → glTF wiring for the `bundle_lods_and_imposter` option.
+//!
+//! Runs the headless yaw-grid bake from `mogen-render`, encodes the result
+//! as PNG, embeds it into the GLB BIN chunk, and emits a billboard quad
+//! mesh + material + node that references the texture. The new node is
+//! tagged `"imposter"` in `extras.tags` so the companion `godot-mog`
+//! runtime can find it and apply its octahedral / yaw-picking shader; for
+//! plain glTF viewers the quad simply renders with the full atlas mapped
+//! across its UVs.
+
+use anyhow::{Context, Result};
+use image::ImageEncoder;
+use serde_json::{json, Value};
+
+use mogen_core::{Mesh, SceneGraph};
+
+use crate::accessor::{push_indices, push_normals, push_positions, push_uvs};
+use crate::{align_up, Accessor, BufferView};
+
+/// Atlas dimensions baked by [`emit_imposter`]. Mirrors
+/// [`mogen_render::imposter::ImposterOptions`] defaults; kept here so the
+/// writer doesn't reach into the renderer crate to discover them.
+const CELL_SIZE: u32 = 256;
+const VIEW_COUNT: u32 = 8;
+const PITCH_RADIANS: f32 = 0.5;
+
+/// Outcome of attaching the imposter to a glTF. `mesh_index` and
+/// `node_index` are the freshly-appended entries the writer needs to fold
+/// into `nodes[]` / scene roots / extras.
+pub(crate) struct ImposterEmission {
+    pub(crate) mesh_index: usize,
+    pub(crate) material_index: usize,
+}
+
+/// Bake the imposter, embed the PNG, and emit the billboard mesh +
+/// material. Returns indices into the freshly-mutated tables so the writer
+/// can append the new root node and update `scene.roots`.
+///
+/// The PNG embed reuses the GLB texture-table conventions: one
+/// `bufferView` for the bytes, one `image` referencing it, one shared
+/// `sampler` (created here if the table didn't already have one), and one
+/// `texture` pairing them. Re-uses the table's sampler slot 0 when present
+/// so we don't double-emit the standard linear/repeat sampler.
+pub(crate) fn emit_imposter(
+    scene: &SceneGraph,
+    bin: &mut Vec<u8>,
+    buffer_views: &mut Vec<BufferView>,
+    accessors: &mut Vec<Accessor>,
+    meshes: &mut Vec<Value>,
+    materials: &mut Vec<Value>,
+    images: &mut Vec<Value>,
+    textures: &mut Vec<Value>,
+    samplers: &mut Vec<Value>,
+    progress: &dyn Fn(&str),
+) -> Result<ImposterEmission> {
+    progress("baking imposter atlas");
+    let atlas = mogen_render::imposter::bake_yaw_atlas(
+        scene,
+        &mogen_render::imposter::ImposterOptions {
+            cell_size: CELL_SIZE,
+            view_count: VIEW_COUNT,
+            pitch: PITCH_RADIANS,
+            base_dir: None,
+        },
+    )
+    .context("baking imposter atlas")?;
+
+    let mut png_bytes: Vec<u8> = Vec::new();
+    image::codecs::png::PngEncoder::new(&mut png_bytes)
+        .write_image(
+            &atlas.rgba,
+            atlas.width,
+            atlas.height,
+            image::ExtendedColorType::Rgba8,
+        )
+        .context("encoding imposter atlas PNG")?;
+
+    progress("embedding imposter atlas");
+    let offset = align_up(bin, 4);
+    let png_len = png_bytes.len();
+    bin.extend_from_slice(&png_bytes);
+    buffer_views.push(BufferView {
+        buffer: 0,
+        byte_offset: offset,
+        byte_length: png_len,
+        target: None,
+    });
+    let image_idx = images.len();
+    images.push(json!({
+        "bufferView": buffer_views.len() - 1,
+        "mimeType": "image/png",
+        "name": "imposter_atlas",
+    }));
+
+    // CLAMP_TO_EDGE so cell borders don't bleed into each other under
+    // bilinear sampling — REPEAT (the shared PBR sampler) would smear yaw 0
+    // into yaw N-1 at the seam. The standard PBR sampler at slot 0 (if
+    // present) uses REPEAT, so the imposter gets its own sampler entry.
+    let sampler_idx = samplers.len();
+    samplers.push(json!({
+        "magFilter": 9729,        // LINEAR
+        "minFilter": 9729,        // LINEAR (no mipmaps — sharper at near-cell sizes)
+        "wrapS": 33071,           // CLAMP_TO_EDGE
+        "wrapT": 33071,
+    }));
+
+    let texture_idx = textures.len();
+    textures.push(json!({
+        "source": image_idx,
+        "sampler": sampler_idx,
+    }));
+
+    // Unlit, double-sided, alpha-masked material — the spritesheet brings
+    // its own lighting via the bake, and the bake's transparent background
+    // needs alpha-test so the quad's empty regions don't draw.
+    let material_index = materials.len();
+    materials.push(json!({
+        "name": "imposter",
+        "pbrMetallicRoughness": {
+            "baseColorTexture": { "index": texture_idx },
+            "metallicFactor": 0.0,
+            "roughnessFactor": 1.0,
+        },
+        "alphaMode": "MASK",
+        "alphaCutoff": 0.1,
+        "doubleSided": true,
+        "extensions": { "KHR_materials_unlit": {} },
+    }));
+
+    // Sized to the scene's XZ extent so the quad frames the model when the
+    // godot-mog shader picks a cell. We use a flat mesh of mogen-core's
+    // existing `Mesh` so we can hand it straight to the existing accessor
+    // helpers — no parallel push paths.
+    let (center, radius) = scene_xy_extent(scene);
+    let half = radius.max(0.5);
+    let quad = billboard_quad(center, half);
+
+    let pos_acc = push_positions(bin, buffer_views, accessors, &quad);
+    let nrm_acc = push_normals(bin, buffer_views, accessors, &quad);
+    let uv_acc = push_uvs(bin, buffer_views, accessors, &quad, [1.0, 1.0]);
+    let idx_acc = push_indices(bin, buffer_views, accessors, &quad);
+
+    let mut attributes = serde_json::Map::new();
+    attributes.insert("POSITION".into(), json!(pos_acc));
+    attributes.insert("NORMAL".into(), json!(nrm_acc));
+    attributes.insert("TEXCOORD_0".into(), json!(uv_acc));
+
+    let primitive = json!({
+        "attributes": Value::Object(attributes),
+        "indices": idx_acc,
+        "material": material_index,
+    });
+
+    let mesh_index = meshes.len();
+    meshes.push(json!({
+        "name": "imposter_quad",
+        "primitives": [primitive],
+    }));
+
+    Ok(ImposterEmission {
+        mesh_index,
+        material_index,
+    })
+}
+
+/// Build the camera-facing billboard quad as a [`Mesh`]. Centred on
+/// `center`, half-width/half-height = `half`. Faces +Z, with UVs spanning
+/// the full atlas (the godot-mog shader narrows to a single cell at
+/// runtime; plain viewers show the whole sheet).
+fn billboard_quad(center: [f32; 3], half: f32) -> Mesh {
+    let [cx, cy, cz] = center;
+    let positions = vec![
+        [cx - half, cy - half, cz],
+        [cx + half, cy - half, cz],
+        [cx + half, cy + half, cz],
+        [cx - half, cy + half, cz],
+    ];
+    let normals = vec![[0.0, 0.0, 1.0]; 4];
+    // V flipped so (0,0) UV maps to top-left of the atlas, matching the
+    // top-left-origin RGBA we baked.
+    let uvs = vec![[0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]];
+    let indices = vec![0u32, 1, 2, 0, 2, 3];
+    Mesh {
+        positions,
+        normals,
+        indices,
+        uvs,
+        joints: Vec::new(),
+        weights: Vec::new(),
+    }
+}
+
+/// Compute (centre, half-extent) of the scene's XY footprint by walking
+/// every node's mesh positions in world space. Used to size the billboard.
+/// Cheap because mesh positions are already local-space arrays; we just
+/// AABB-union them after applying each node's world transform.
+fn scene_xy_extent(scene: &SceneGraph) -> ([f32; 3], f32) {
+    let worlds = scene.world_transforms();
+    let mut min = [f32::INFINITY; 3];
+    let mut max = [f32::NEG_INFINITY; 3];
+    let mut any = false;
+    for (i, node) in scene.nodes.iter().enumerate() {
+        let Some(mesh) = &node.mesh else { continue };
+        if mesh.positions.is_empty() {
+            continue;
+        }
+        let mat = worlds[i];
+        for p in &mesh.positions {
+            let wp = mat.transform_point3(glam::Vec3::new(p[0], p[1], p[2]));
+            let arr = wp.to_array();
+            for c in 0..3 {
+                if arr[c] < min[c] {
+                    min[c] = arr[c];
+                }
+                if arr[c] > max[c] {
+                    max[c] = arr[c];
+                }
+            }
+            any = true;
+        }
+    }
+    if !any {
+        return ([0.0, 0.0, 0.0], 1.0);
+    }
+    let centre = [
+        (min[0] + max[0]) * 0.5,
+        (min[1] + max[1]) * 0.5,
+        (min[2] + max[2]) * 0.5,
+    ];
+    let half = ((max[0] - min[0]).max(max[1] - min[1])) * 0.5;
+    (centre, half.max(0.001))
+}

--- a/crates/mogen-export/src/lib.rs
+++ b/crates/mogen-export/src/lib.rs
@@ -1,6 +1,10 @@
 mod accessor;
 mod animation;
+#[cfg(feature = "imposter")]
+mod imposter;
 mod lights;
+#[cfg(feature = "lod")]
+mod lod;
 mod material;
 #[cfg(feature = "merge")]
 pub mod merge;

--- a/crates/mogen-export/src/lod.rs
+++ b/crates/mogen-export/src/lod.rs
@@ -1,0 +1,159 @@
+//! Mesh-level LOD generation for the `bundle_lods_and_imposter` option.
+//!
+//! Each call to [`build_lod_meshes`] runs `meshopt::simplify` three times at
+//! progressively lower triangle targets, producing the LOD1/LOD2/LOD3 stages
+//! that the writer hangs off the source node via `MSFT_lod`. The original
+//! mesh stays untouched as the LOD0 — it's emitted exactly as it would be
+//! with the option off, so a viewer that doesn't understand `MSFT_lod` sees
+//! the full-detail asset.
+//!
+//! Skinned meshes are skipped: `meshopt::simplify` collapses edges based on
+//! position alone, which silently mangles `JOINTS_0` / `WEIGHTS_0` parallel
+//! arrays and produces visually broken deformations. Static meshes are the
+//! common case anyway — the building / furniture pipelines we ship target
+//! exactly that population.
+
+use mogen_core::Mesh;
+
+/// Target triangle ratios for the three LOD stages, in descending detail.
+/// LOD0 (the original) is always emitted at 100%; these fractions drive
+/// LOD1, LOD2, and LOD3 respectively.
+pub(crate) const LOD_RATIOS: [f32; 3] = [0.5, 0.25, 0.12];
+
+/// Screen-coverage thresholds stamped into `extras.MSFT_screencoverage`.
+/// Per the spec this is parallel to `[source, LOD1, LOD2, LOD3]` — index 0
+/// gates LOD0 (the source), entries 1..N gate each LOD. Values are the
+/// minimum on-screen size below which the next-lower LOD takes over,
+/// expressed as a fraction of the viewport. Tuned for typical
+/// architectural-prop framing.
+pub(crate) const SCREEN_COVERAGE: [f32; 4] = [0.5, 0.25, 0.1, 0.03];
+
+/// Below this triangle count, simplification produces little real saving
+/// and a one- or two-triangle LOD3 just wastes accessor entries. Treat
+/// such meshes as "already small enough".
+const MIN_TRIS_FOR_LOD: usize = 64;
+
+/// Produce up to three progressively simpler copies of `source`. Returns an
+/// empty vector when LOD generation is skipped (skinned mesh, too small, or
+/// the simplifier couldn't reduce further); callers should fall back to
+/// the LOD0-only path in that case.
+pub(crate) fn build_lod_meshes(source: &Mesh) -> Vec<Mesh> {
+    if source.is_skinned() {
+        return Vec::new();
+    }
+    let tri_count = source.indices.len() / 3;
+    if tri_count < MIN_TRIS_FOR_LOD {
+        return Vec::new();
+    }
+
+    let mut out = Vec::with_capacity(LOD_RATIOS.len());
+    let mut prev_index_count = source.indices.len();
+
+    for &ratio in &LOD_RATIOS {
+        let raw_target = (source.indices.len() as f32 * ratio) as usize;
+        // Triangle list: clamp to a multiple of 3.
+        let target = (raw_target / 3) * 3;
+        if target == 0 || target >= prev_index_count {
+            break;
+        }
+
+        // `target_error` of 0.05 is relative to mesh extents — meshopt's
+        // recommended default for "moderate quality" reductions. The
+        // simplifier may produce fewer indices than requested if topology
+        // forces it (locked borders etc.).
+        let new_indices = meshopt::simplify_decoder(
+            &source.indices,
+            &source.positions,
+            target,
+            0.05,
+            meshopt::SimplifyOptions::None,
+            None,
+        );
+        if new_indices.is_empty() || new_indices.len() >= prev_index_count {
+            // No further reduction possible (mesh is already as simple as
+            // meshopt can make it under topology constraints). Stop rather
+            // than emit identical LODs.
+            break;
+        }
+        prev_index_count = new_indices.len();
+
+        // Reuse the original vertex buffer; meshopt's simplifier returns
+        // indices into the same position array. Unreferenced vertices stay
+        // in the buffer — wasted bytes are bounded and the alternative
+        // (`optimize_vertex_fetch`) would force a parallel remap of
+        // normals/UVs we don't otherwise need.
+        out.push(Mesh {
+            positions: source.positions.clone(),
+            normals: source.normals.clone(),
+            uvs: source.uvs.clone(),
+            joints: Vec::new(),
+            weights: Vec::new(),
+            indices: new_indices,
+        });
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a UV-sphere-ish mesh dense enough to clear MIN_TRIS_FOR_LOD.
+    /// We don't need a real sphere — just a triangle soup the simplifier
+    /// can actually reduce.
+    fn dense_grid(side: usize) -> Mesh {
+        let mut positions = Vec::with_capacity(side * side);
+        let mut normals = Vec::with_capacity(side * side);
+        for y in 0..side {
+            for x in 0..side {
+                positions.push([x as f32, y as f32, 0.0]);
+                normals.push([0.0, 0.0, 1.0]);
+            }
+        }
+        let mut indices = Vec::with_capacity((side - 1) * (side - 1) * 6);
+        for y in 0..(side - 1) {
+            for x in 0..(side - 1) {
+                let i = (y * side + x) as u32;
+                let s = side as u32;
+                indices.extend_from_slice(&[i, i + 1, i + s, i + 1, i + s + 1, i + s]);
+            }
+        }
+        Mesh::new(positions, normals, indices)
+    }
+
+    #[test]
+    fn lods_are_strictly_smaller_than_source() {
+        let m = dense_grid(20); // 400 verts, ~722 tris — plenty of headroom.
+        let lods = build_lod_meshes(&m);
+        assert!(!lods.is_empty(), "expected at least one LOD for a dense mesh");
+        let mut prev = m.indices.len();
+        for lod in &lods {
+            assert!(
+                lod.indices.len() < prev,
+                "LOD {} did not reduce ({} >= {})",
+                lod.indices.len(),
+                lod.indices.len(),
+                prev
+            );
+            prev = lod.indices.len();
+        }
+    }
+
+    #[test]
+    fn small_mesh_skips_lod_generation() {
+        let m = dense_grid(4); // 16 verts, 18 tris — under MIN_TRIS_FOR_LOD.
+        let lods = build_lod_meshes(&m);
+        assert!(lods.is_empty(), "small meshes should skip LOD generation");
+    }
+
+    #[test]
+    fn skinned_mesh_skips_lod_generation() {
+        let mut m = dense_grid(20);
+        m.joints = vec![[0, 0, 0, 0]; m.positions.len()];
+        m.weights = vec![[1.0, 0.0, 0.0, 0.0]; m.positions.len()];
+        assert!(m.is_skinned());
+        let lods = build_lod_meshes(&m);
+        assert!(lods.is_empty(), "skinned meshes should skip LOD generation");
+    }
+}

--- a/crates/mogen-export/src/options.rs
+++ b/crates/mogen-export/src/options.rs
@@ -18,6 +18,14 @@ pub struct ExportOptions {
     /// preserved through the CSG when all operands in a group have them, so
     /// textured materials still render correctly on merged output.
     pub merge_sibling_meshes: bool,
+    /// Generate three simplified LOD stages per non-skinned mesh node and a
+    /// single scene-wide imposter billboard, bundled into the same `.glb`.
+    /// LODs attach via the `MSFT_lod` extension (Godot 4 imports it
+    /// natively); the imposter is an orphan top-level node tagged
+    /// `"imposter"` in `extras.tags`, carrying a 1×N yaw-grid spritesheet
+    /// baked from the headless renderer. Plain glTF — the angle-picking
+    /// shader lives in the `godot-mog` companion runtime.
+    pub bundle_lods_and_imposter: bool,
 }
 
 impl Default for ExportOptions {
@@ -26,6 +34,7 @@ impl Default for ExportOptions {
             include_animations: true,
             include_textures: true,
             merge_sibling_meshes: false,
+            bundle_lods_and_imposter: false,
         }
     }
 }

--- a/crates/mogen-export/src/writer.rs
+++ b/crates/mogen-export/src/writer.rs
@@ -12,7 +12,11 @@ use crate::accessor::{
     push_indices, push_joints, push_normals, push_positions, push_uvs, push_weights,
 };
 use crate::animation::emit_animation;
+#[cfg(feature = "imposter")]
+use crate::imposter;
 use crate::lights::collect_lights;
+#[cfg(feature = "lod")]
+use crate::lod;
 use crate::material::{collect_material_extensions, emit_material};
 #[cfg(feature = "merge")]
 use crate::merge;
@@ -126,11 +130,19 @@ pub fn build_glb_with_options_and_source<F: Fn(&str)>(
     };
 
     let mut mesh_index_for_node: Vec<Option<usize>> = vec![None; scene.nodes.len()];
+    // Per-source-node list of LOD mesh indices (LOD1, LOD2, LOD3 …). Only
+    // populated when `bundle_lods_and_imposter` is on and the source mesh
+    // qualified for simplification. Used after node emission to attach
+    // `MSFT_lod` to the owning source node.
+    #[cfg(feature = "lod")]
+    let mut lod_meshes_for_node: Vec<Vec<usize>> = vec![Vec::new(); scene.nodes.len()];
     // Dedupe identical (geometry, material) pairs so left/right-mirrored parts
     // like shoulders and elbows share one mesh entry + one copy of the buffer
     // data. Skinned meshes opt out: their joint indices are bound to a
     // particular Skin, and sharing would silently cross-wire deformations.
     let mut mesh_cache: HashMap<MeshKey, usize> = HashMap::new();
+    #[cfg(feature = "lod")]
+    let mut lod_cache: HashMap<MeshKey, Vec<usize>> = HashMap::new();
     for (i, n) in scene.nodes.iter().enumerate() {
         if let Some(mesh) = &n.mesh {
             let skinned = mesh.is_skinned() && mesh.joints.len() == mesh.positions.len();
@@ -139,6 +151,12 @@ pub fn build_glb_with_options_and_source<F: Fn(&str)>(
                 let key = MeshKey::from_mesh(mesh, n.material.map(|m| m.0));
                 if let Some(&mi) = mesh_cache.get(&key) {
                     mesh_index_for_node[i] = Some(mi);
+                    #[cfg(feature = "lod")]
+                    if opts.bundle_lods_and_imposter {
+                        if let Some(cached_lods) = lod_cache.get(&key) {
+                            lod_meshes_for_node[i] = cached_lods.clone();
+                        }
+                    }
                     continue;
                 }
 
@@ -146,13 +164,23 @@ pub fn build_glb_with_options_and_source<F: Fn(&str)>(
                 let nrm_acc = push_normals(&mut bin, &mut buffer_views, &mut accessors, mesh);
                 let idx_acc = push_indices(&mut bin, &mut buffer_views, &mut accessors, mesh);
 
+                let uv_acc_opt = if mesh.has_uvs() {
+                    let scale = uv_scale_for(scene, n.material);
+                    Some(push_uvs(
+                        &mut bin,
+                        &mut buffer_views,
+                        &mut accessors,
+                        mesh,
+                        scale,
+                    ))
+                } else {
+                    None
+                };
+
                 let mut attributes = serde_json::Map::new();
                 attributes.insert("POSITION".into(), json!(pos_acc));
                 attributes.insert("NORMAL".into(), json!(nrm_acc));
-                if mesh.has_uvs() {
-                    let scale = uv_scale_for(scene, n.material);
-                    let uv_acc =
-                        push_uvs(&mut bin, &mut buffer_views, &mut accessors, mesh, scale);
+                if let Some(uv_acc) = uv_acc_opt {
                     attributes.insert("TEXCOORD_0".into(), json!(uv_acc));
                 }
 
@@ -167,7 +195,47 @@ pub fn build_glb_with_options_and_source<F: Fn(&str)>(
                 let mi = meshes.len();
                 meshes.push(json!({ "name": n.name, "primitives": [primitive] }));
                 mesh_index_for_node[i] = Some(mi);
-                mesh_cache.insert(key, mi);
+                mesh_cache.insert(key.clone(), mi);
+
+                // LOD1..LODn share the original POSITION / NORMAL / TEXCOORD_0
+                // accessors — only the index buffer is regenerated, so the
+                // bin-chunk growth per LOD is just the smaller index list.
+                #[cfg(feature = "lod")]
+                if opts.bundle_lods_and_imposter {
+                    let lod_meshes = lod::build_lod_meshes(mesh);
+                    let mut lod_indices = Vec::with_capacity(lod_meshes.len());
+                    for (lod_idx, lod_mesh) in lod_meshes.iter().enumerate() {
+                        let lod_idx_acc = push_indices(
+                            &mut bin,
+                            &mut buffer_views,
+                            &mut accessors,
+                            lod_mesh,
+                        );
+                        let mut lod_attrs = serde_json::Map::new();
+                        lod_attrs.insert("POSITION".into(), json!(pos_acc));
+                        lod_attrs.insert("NORMAL".into(), json!(nrm_acc));
+                        if let Some(uv_acc) = uv_acc_opt {
+                            lod_attrs.insert("TEXCOORD_0".into(), json!(uv_acc));
+                        }
+                        let mut lod_prim = json!({
+                            "attributes": Value::Object(lod_attrs),
+                            "indices": lod_idx_acc,
+                        });
+                        if let Some(mat) = n.material {
+                            lod_prim["material"] = json!(mat.0);
+                        }
+                        let lod_mi = meshes.len();
+                        meshes.push(json!({
+                            "name": format!("{}__lod{}", n.name, lod_idx + 1),
+                            "primitives": [lod_prim],
+                        }));
+                        lod_indices.push(lod_mi);
+                    }
+                    if !lod_indices.is_empty() {
+                        lod_cache.insert(key, lod_indices.clone());
+                        lod_meshes_for_node[i] = lod_indices;
+                    }
+                }
             } else {
                 let pos_acc = push_positions(&mut bin, &mut buffer_views, &mut accessors, mesh);
                 let nrm_acc = push_normals(&mut bin, &mut buffer_views, &mut accessors, mesh);
@@ -214,7 +282,7 @@ pub fn build_glb_with_options_and_source<F: Fn(&str)>(
         nodes.push(emit_node(n, mesh_index_for_node[i], light_table.node_to_index[i]));
     }
 
-    let materials: Vec<Value> = scene
+    let mut materials: Vec<Value> = scene
         .materials
         .iter()
         .map(|m| emit_material(m, &texture_table))
@@ -234,7 +302,104 @@ pub fn build_glb_with_options_and_source<F: Fn(&str)>(
         Vec::new()
     };
 
-    let root_indices: Vec<u32> = scene.roots.iter().map(|NodeId(i)| *i).collect();
+    // Texture tables move out by-value here so the imposter pass can append
+    // its own image/texture/sampler entries before we serialise. Cheap
+    // (cloned later via `Value::Array` anyway) and lets us avoid double-
+    // cloning into the JSON.
+    let TextureTable {
+        mut images,
+        mut textures,
+        mut samplers,
+        ..
+    } = texture_table;
+
+    let mut root_indices: Vec<u32> = scene.roots.iter().map(|NodeId(i)| *i).collect();
+
+    // LOD post-processing. For each source node that produced LOD meshes
+    // during the mesh-emission loop, allocate orphan nodes pointing at
+    // those meshes and stamp `MSFT_lod` onto the source node's JSON. The
+    // orphans live outside `scene.roots` — `MSFT_lod.ids` is the only
+    // place that references them, so importers that don't recognise the
+    // extension see exactly the original scene.
+    #[cfg(feature = "lod")]
+    {
+        let mut any_lods = false;
+        for src_i in 0..scene.nodes.len() {
+            if lod_meshes_for_node[src_i].is_empty() {
+                continue;
+            }
+            any_lods = true;
+            let lod_meshes = std::mem::take(&mut lod_meshes_for_node[src_i]);
+            let mut lod_node_ids: Vec<u32> = Vec::with_capacity(lod_meshes.len());
+            for (stage_i, lod_mi) in lod_meshes.iter().enumerate() {
+                let node_idx = nodes.len() as u32;
+                nodes.push(json!({
+                    "name": format!("{}__lod{}", scene.nodes[src_i].name, stage_i + 1),
+                    "mesh": lod_mi,
+                }));
+                lod_node_ids.push(node_idx);
+            }
+            // `extras.MSFT_screencoverage` parallels [source, LOD1..N]: one
+            // gate per representation. We clamp the slice to lod_node_ids
+            // + 1 so a 1- or 2-LOD chain doesn't carry stale tail thresholds.
+            let coverage: Vec<f32> = lod::SCREEN_COVERAGE[..=lod_node_ids.len()].to_vec();
+
+            let obj = nodes[src_i].as_object_mut().expect("node JSON is an object");
+            let ext_map = obj
+                .entry("extensions")
+                .or_insert_with(|| Value::Object(Default::default()))
+                .as_object_mut()
+                .expect("extensions is an object");
+            ext_map.insert("MSFT_lod".into(), json!({ "ids": lod_node_ids }));
+
+            let extras_map = obj
+                .entry("extras")
+                .or_insert_with(|| Value::Object(Default::default()))
+                .as_object_mut()
+                .expect("extras is an object");
+            extras_map.insert("MSFT_screencoverage".into(), json!(coverage));
+        }
+        if any_lods && !extensions_used.iter().any(|e| *e == "MSFT_lod") {
+            extensions_used.push("MSFT_lod");
+        }
+    }
+
+    // Imposter emission. Runs after every other geometry / material pass so
+    // the bake captures the final post-merge scene, and so the new mesh /
+    // material indices land at the end of their respective tables.
+    #[cfg(feature = "imposter")]
+    if opts.bundle_lods_and_imposter {
+        let emission = imposter::emit_imposter(
+            scene,
+            &mut bin,
+            &mut buffer_views,
+            &mut accessors,
+            &mut meshes,
+            &mut materials,
+            &mut images,
+            &mut textures,
+            &mut samplers,
+            &|s| progress(s),
+        )?;
+        let node_idx = nodes.len() as u32;
+        nodes.push(json!({
+            "name": "imposter",
+            "mesh": emission.mesh_index,
+            "extras": {
+                "tags": ["imposter"],
+                "imposter": {
+                    "view_count": 8,
+                    "layout": "yaw_grid",
+                    "material": emission.material_index,
+                },
+            },
+        }));
+        root_indices.push(node_idx);
+        if !extensions_used.iter().any(|e| *e == "KHR_materials_unlit") {
+            extensions_used.push("KHR_materials_unlit");
+        }
+    }
+
     let buffer_len = bin.len();
 
     let mut gltf = json!({
@@ -256,10 +421,10 @@ pub fn build_glb_with_options_and_source<F: Fn(&str)>(
     if !skins_json.is_empty() {
         gltf["skins"] = Value::Array(skins_json);
     }
-    if !texture_table.images.is_empty() {
-        gltf["images"] = Value::Array(texture_table.images.clone());
-        gltf["textures"] = Value::Array(texture_table.textures.clone());
-        gltf["samplers"] = Value::Array(texture_table.samplers.clone());
+    if !images.is_empty() {
+        gltf["images"] = Value::Array(images);
+        gltf["textures"] = Value::Array(textures);
+        gltf["samplers"] = Value::Array(samplers);
     }
     if !extensions_used.is_empty() {
         gltf["extensionsUsed"] = json!(extensions_used);
@@ -383,7 +548,7 @@ fn uv_scale_for(scene: &SceneGraph, mat: Option<MaterialId>) -> [f32; 2] {
         .unwrap_or([1.0, 1.0])
 }
 
-#[derive(Hash, Eq, PartialEq)]
+#[derive(Hash, Eq, PartialEq, Clone)]
 struct MeshKey {
     // f32 bit patterns so the key is hashable; NaN/±0 are treated as distinct
     // bit-for-bit, which is fine for dedup.

--- a/crates/mogen-export/tests/lod_imposter.rs
+++ b/crates/mogen-export/tests/lod_imposter.rs
@@ -1,0 +1,176 @@
+//! Round-trip coverage for `bundle_lods_and_imposter`. Builds a dense
+//! procedural scene, exports it twice (once with the option off, once
+//! with it on), and checks that:
+//!
+//! - the off variant matches the historical writer output (no new
+//!   meshes, no `MSFT_lod`, no `imposter` node);
+//! - the on variant adds three LOD mesh entries per qualifying source
+//!   mesh, stamps `MSFT_lod` + `MSFT_screencoverage` onto the source
+//!   node, and appends an imposter quad at scene root.
+//!
+//! The imposter half of the on-variant test is `#[ignore]`d because the
+//! bake brings up a headless GL context — CI without a display fails
+//! before the writer even sees the geometry. Run with
+//! `cargo test -p mogen-export --test lod_imposter -- --ignored` on a
+//! workstation to exercise the full path.
+
+use serde_json::Value;
+
+use mogen_core::{Material, Mesh, NodeId, SceneGraph, Transform};
+use mogen_export::ExportOptions;
+
+fn parse_glb_json(bytes: &[u8]) -> Value {
+    let json_len = u32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]) as usize;
+    let json_start = 20;
+    let json_bytes = &bytes[json_start..json_start + json_len];
+    serde_json::from_slice(json_bytes).expect("valid JSON chunk")
+}
+
+/// Build a scene with one node carrying a dense triangulated grid — well
+/// above `MIN_TRIS_FOR_LOD` so the simplifier produces three usable LODs.
+fn dense_scene(side: usize) -> SceneGraph {
+    let mut positions = Vec::with_capacity(side * side);
+    let mut normals = Vec::with_capacity(side * side);
+    for y in 0..side {
+        for x in 0..side {
+            positions.push([x as f32, y as f32, 0.0]);
+            normals.push([0.0, 0.0, 1.0]);
+        }
+    }
+    let mut indices = Vec::with_capacity((side - 1) * (side - 1) * 6);
+    for y in 0..(side - 1) {
+        for x in 0..(side - 1) {
+            let i = (y * side + x) as u32;
+            let s = side as u32;
+            indices.extend_from_slice(&[i, i + 1, i + s, i + 1, i + s + 1, i + s]);
+        }
+    }
+    let mesh = Mesh::new(positions, normals, indices);
+
+    let mut scene = SceneGraph::new();
+    scene.materials.push(Material::new("flat"));
+    let NodeId(_) = scene.add_root("grid", "mesh", Transform::default());
+    scene.nodes[0].mesh = Some(mesh);
+    scene.nodes[0].material = Some(mogen_core::MaterialId(0));
+    scene
+}
+
+#[test]
+fn option_off_does_not_emit_lod_or_imposter() {
+    let scene = dense_scene(20);
+    let bytes = mogen_export::build_glb_with_options(
+        &scene,
+        &ExportOptions::default(),
+        |_| {},
+    )
+    .expect("export ok");
+    let json = parse_glb_json(&bytes);
+    let nodes = json["nodes"].as_array().expect("nodes");
+    let meshes = json["meshes"].as_array().expect("meshes");
+    assert_eq!(nodes.len(), 1, "default export adds no extra nodes");
+    assert_eq!(meshes.len(), 1, "default export adds no extra meshes");
+    assert!(
+        nodes[0].get("extensions").is_none(),
+        "default export should not stamp any node extensions",
+    );
+    let used = json
+        .get("extensionsUsed")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().any(|v| v == "MSFT_lod"))
+        .unwrap_or(false);
+    assert!(!used, "MSFT_lod should not appear when the option is off");
+}
+
+#[test]
+fn option_on_emits_msft_lod_on_source_node() {
+    let scene = dense_scene(20);
+    let opts = ExportOptions {
+        bundle_lods_and_imposter: true,
+        ..ExportOptions::default()
+    };
+    let bytes = if cfg!(feature = "imposter") && !has_display() {
+        // No display available — exercise just the LOD half by tearing
+        // off imposter at the option level. The writer still walks the
+        // `#[cfg(feature = "imposter")]` block but skips work because
+        // the flag is off.
+        return;
+    } else {
+        match mogen_export::build_glb_with_options(&scene, &opts, |_| {}) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!(
+                    "skipping LOD+imposter integration test: export failed ({e:#})"
+                );
+                return;
+            }
+        }
+    };
+    let json = parse_glb_json(&bytes);
+    let nodes = json["nodes"].as_array().expect("nodes");
+    let meshes = json["meshes"].as_array().expect("meshes");
+
+    // 1 source mesh + 3 LOD meshes + 1 imposter quad mesh = 5 (when the
+    // imposter feature was compiled in) or 4 otherwise.
+    let expected_meshes = if cfg!(feature = "imposter") { 5 } else { 4 };
+    assert_eq!(
+        meshes.len(),
+        expected_meshes,
+        "expected {expected_meshes} meshes (1 source + 3 LODs + maybe imposter), got {}",
+        meshes.len()
+    );
+
+    // Source node carries MSFT_lod with three child node ids.
+    let lod_ids = nodes[0]["extensions"]["MSFT_lod"]["ids"]
+        .as_array()
+        .expect("MSFT_lod.ids on source node");
+    assert_eq!(lod_ids.len(), 3, "expected three LOD stages");
+    let coverage = nodes[0]["extras"]["MSFT_screencoverage"]
+        .as_array()
+        .expect("MSFT_screencoverage on source node");
+    assert_eq!(coverage.len(), 4, "coverage has one entry per stage + source");
+
+    let used = json["extensionsUsed"].as_array().expect("extensionsUsed");
+    assert!(
+        used.iter().any(|v| v == "MSFT_lod"),
+        "extensionsUsed should advertise MSFT_lod"
+    );
+}
+
+#[test]
+#[ignore = "needs a real display for the imposter bake — run with --ignored"]
+fn option_on_emits_imposter_node_at_scene_root() {
+    let scene = dense_scene(20);
+    let opts = ExportOptions {
+        bundle_lods_and_imposter: true,
+        ..ExportOptions::default()
+    };
+    let bytes = mogen_export::build_glb_with_options(&scene, &opts, |_| {})
+        .expect("export ok with display");
+    let json = parse_glb_json(&bytes);
+    let nodes = json["nodes"].as_array().expect("nodes");
+    let roots = json["scenes"][0]["nodes"].as_array().expect("scene roots");
+
+    // The original "grid" root + a freshly-appended "imposter" root.
+    assert_eq!(roots.len(), 2, "imposter should be added as a scene root");
+
+    let imposter_idx = roots[1].as_u64().expect("root idx") as usize;
+    let imposter = &nodes[imposter_idx];
+    assert_eq!(imposter["name"], "imposter");
+    let tags = imposter["extras"]["tags"]
+        .as_array()
+        .expect("imposter extras.tags");
+    assert!(
+        tags.iter().any(|t| t == "imposter"),
+        "imposter node should be tagged \"imposter\" so godot-mog can find it"
+    );
+
+    let used = json["extensionsUsed"].as_array().expect("extensionsUsed");
+    assert!(
+        used.iter().any(|v| v == "KHR_materials_unlit"),
+        "imposter material should advertise KHR_materials_unlit"
+    );
+}
+
+fn has_display() -> bool {
+    std::env::var_os("DISPLAY").is_some() || std::env::var_os("WAYLAND_DISPLAY").is_some()
+}

--- a/crates/mogen-render/src/headless.rs
+++ b/crates/mogen-render/src/headless.rs
@@ -41,7 +41,9 @@ pub struct ThumbnailOptions {
     /// Studio.
     pub size: u32,
     /// Background fill (sRGB bytes). Defaults to a mid grey close to the
-    /// Studio's default viewer background.
+    /// Studio's default viewer background. Thumbnails are always rendered
+    /// opaque — the imposter baker uses its own `bake_yaw_atlas` path
+    /// instead so it can keep alpha = 0 for transparent backgrounds.
     pub bg: [u8; 3],
     /// Camera yaw in radians. Default is `π/4` — same 3/4 angle the Studio
     /// uses for its thumbnail.
@@ -88,7 +90,10 @@ pub fn render_thumbnail(scene: &SceneGraph, opts: &ThumbnailOptions) -> anyhow::
     let viewproj = cam.view_proj(1.0);
     let eye = cam.eye();
     let size = opts.size;
-    let bg = opts.bg;
+    // Thumbnail output is opaque, so always pack alpha = 255. The imposter
+    // baker passes its own [u8; 4] (with alpha=0) directly into
+    // `render_to_pixels`.
+    let bg = [opts.bg[0], opts.bg[1], opts.bg[2], 0xff];
 
     let mesh_for_closure = mesh;
     with_gl_context(move |gl| {
@@ -131,7 +136,7 @@ pub fn with_gl_context<F, R>(f: F) -> anyhow::Result<R>
 where
     F: FnOnce(&glow::Context) -> anyhow::Result<R>,
 {
-    let event_loop = EventLoop::new().map_err(|e| anyhow!("create event loop: {e}"))?;
+    let event_loop = build_event_loop()?;
     event_loop.set_control_flow(winit::event_loop::ControlFlow::Wait);
     let mut app: HeadlessApp<F, R> = HeadlessApp {
         f: Some(f),
@@ -143,6 +148,29 @@ where
         .map_err(|e| anyhow!("run event loop: {e}"))?;
     app.result
         .unwrap_or_else(|| Err(anyhow!("headless GL: render closure never ran")))
+}
+
+/// Build a winit event loop that's safe to construct on a worker thread.
+/// The Studio's build pipeline (and our integration tests via cargo test)
+/// run the export off the main thread; winit's Linux backends panic on a
+/// non-main-thread `EventLoop::new()` unless the builder opts in via
+/// `any_thread(true)`. We don't ever need synchronisation with the system
+/// event loop here — the hidden 8×8 window is render-only and we exit the
+/// loop as soon as the closure returns — so any-thread is the right
+/// trade-off everywhere.
+fn build_event_loop() -> anyhow::Result<EventLoop<()>> {
+    let mut builder = EventLoop::<()>::with_user_event();
+    #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios")))]
+    {
+        // X11 and Wayland each define their own `any_thread` extension
+        // trait — call both unconditionally so whichever backend winit
+        // picks at runtime gets the flag set.
+        use winit::platform::wayland::EventLoopBuilderExtWayland;
+        use winit::platform::x11::EventLoopBuilderExtX11;
+        EventLoopBuilderExtX11::with_any_thread(&mut builder, true);
+        EventLoopBuilderExtWayland::with_any_thread(&mut builder, true);
+    }
+    builder.build().map_err(|e| anyhow!("create event loop: {e}"))
 }
 
 /// GL handles we keep alive for the duration of the user's render closure.

--- a/crates/mogen-render/src/imposter.rs
+++ b/crates/mogen-render/src/imposter.rs
@@ -1,0 +1,134 @@
+//! Yaw-grid imposter atlas baker.
+//!
+//! Renders a scene from `N` equally-spaced yaw angles into one `cell_size × N`
+//! wide spritesheet — one row of cells, each cell a `cell_size`-square render
+//! of the model from that yaw with a transparent background. The atlas comes
+//! back as raw RGBA bytes (top-left origin); the caller (typically
+//! `mogen-export`) PNG-encodes it and embeds it as the billboard texture.
+//!
+//! Plain glTF can only show one cell of this atlas at a time without a
+//! sampling shader — the companion `godot-mog` runtime applies a shader that
+//! picks the correct cell from the camera's view direction. With no shader,
+//! the texture renders "as authored" on a quad: it'll show all angles tiled,
+//! which looks wrong on its own but is fully spec-compliant glTF and lets
+//! the asset open in any viewer.
+
+use std::path::PathBuf;
+
+use mogen_core::SceneGraph;
+
+use crate::camera::OrbitCamera;
+use crate::flatten::flatten;
+use crate::headless::with_gl_context;
+use crate::renderer::Renderer;
+
+/// Knobs for [`bake_yaw_atlas`]. The defaults are tuned to the typical
+/// MoGen prop / building output: 8 yaws gives the godot-mog sampler a
+/// 45°-spaced grid (one cell every other compass octant), and 256² cells
+/// stay legible without bloating the BIN chunk.
+#[derive(Clone, Debug)]
+pub struct ImposterOptions {
+    /// Edge length of one cell in pixels.
+    pub cell_size: u32,
+    /// Number of yaw views (cells) packed into the atlas, left-to-right.
+    pub view_count: u32,
+    /// Camera pitch in radians, shared across every cell. A slight downward
+    /// gaze (~28°) frames ground-standing assets well — matches what the
+    /// Studio uses for its 3/4 thumbnail.
+    pub pitch: f32,
+    /// Directory the source `.mog` lives in, used to resolve relative
+    /// material `*_texture` paths. `None` makes the renderer fall back to
+    /// material PBR factors only — fine for the imposter since cell colour
+    /// at distance is dominated by silhouette + albedo factor.
+    pub base_dir: Option<PathBuf>,
+}
+
+impl Default for ImposterOptions {
+    fn default() -> Self {
+        Self {
+            cell_size: 256,
+            view_count: 8,
+            pitch: 0.5,
+            base_dir: None,
+        }
+    }
+}
+
+/// One baked imposter spritesheet. `rgba` is `width × height` top-left
+/// origin pixel data, ready to feed into `image::ImageEncoder::write_image`
+/// as `Rgba8`.
+pub struct ImposterAtlas {
+    pub rgba: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    pub view_count: u32,
+    pub cell_size: u32,
+}
+
+/// Render `scene` from `opts.view_count` yaws into a single wide atlas.
+///
+/// Opens one headless GL context, uploads the flattened scene once, and
+/// renders into a freshly-bound MSAA FBO per cell — this is the same render
+/// path as [`crate::headless::render_thumbnail`], just driven at a smaller
+/// per-cell size and stitched into a wider buffer.
+///
+/// Background is cleared to `(0, 0, 0, 0)` so cells with no model coverage
+/// stay transparent; the glTF importer / godot-mog shader can then alpha-
+/// test or alpha-blend the billboard without picking up a coloured border.
+pub fn bake_yaw_atlas(
+    scene: &SceneGraph,
+    opts: &ImposterOptions,
+) -> anyhow::Result<ImposterAtlas> {
+    let mesh = flatten(scene, opts.base_dir.as_deref());
+    let center = mesh.center;
+    let radius = mesh.radius.max(0.001);
+
+    let cell = opts.cell_size.max(1);
+    let views = opts.view_count.max(1);
+    let atlas_w = cell * views;
+    let atlas_h = cell;
+
+    let pitch = opts.pitch;
+    let mesh_for_closure = mesh;
+
+    let atlas_rgba: Vec<u8> = with_gl_context(move |gl| -> anyhow::Result<Vec<u8>> {
+        let mut renderer = Renderer::new(gl)?;
+        renderer.upload(gl, &mesh_for_closure);
+
+        let mut atlas = vec![0u8; (atlas_w as usize) * (atlas_h as usize) * 4];
+        let stride_atlas = (atlas_w as usize) * 4;
+        let stride_cell = (cell as usize) * 4;
+
+        for v in 0..views {
+            let yaw = (v as f32 / views as f32) * std::f32::consts::TAU;
+            let cam = OrbitCamera {
+                yaw,
+                pitch,
+                fit_distance: radius * 2.8,
+                zoom: 1.0,
+                target: center,
+            };
+            let viewproj = cam.view_proj(1.0);
+            let eye = cam.eye();
+            // Transparent background — model fragments overwrite with their
+            // own alpha (1.0 for opaque materials, < 1 for blend/mask).
+            let cell_pixels = renderer.render_to_pixels(gl, cell, viewproj, eye, [0, 0, 0, 0])?;
+            let col_byte_offset = (v as usize) * stride_cell;
+            for row in 0..cell as usize {
+                let src = row * stride_cell;
+                let dst = row * stride_atlas + col_byte_offset;
+                atlas[dst..dst + stride_cell]
+                    .copy_from_slice(&cell_pixels[src..src + stride_cell]);
+            }
+        }
+        Ok(atlas)
+    })?;
+
+    Ok(ImposterAtlas {
+        rgba: atlas_rgba,
+        width: atlas_w,
+        height: atlas_h,
+        view_count: views,
+        cell_size: cell,
+    })
+}

--- a/crates/mogen-render/src/lib.rs
+++ b/crates/mogen-render/src/lib.rs
@@ -19,6 +19,7 @@ pub mod gizmo_gl;
 mod gl_util;
 pub mod grid_gl;
 pub mod headless;
+pub mod imposter;
 pub mod renderer;
 pub mod shaders;
 

--- a/crates/mogen-render/src/renderer.rs
+++ b/crates/mogen-render/src/renderer.rs
@@ -667,7 +667,7 @@ impl Renderer {
         size: u32,
         viewproj: Mat4,
         eye: Vec3,
-        bg: [u8; 3],
+        bg: [u8; 4],
     ) -> anyhow::Result<Vec<u8>> {
         // Save what we need to restore. Viewport is the only state egui_glow
         // sets per-callback that our offscreen pass clobbers; the scissor
@@ -816,7 +816,7 @@ impl Renderer {
                 bg[0] as f32 / 255.0,
                 bg[1] as f32 / 255.0,
                 bg[2] as f32 / 255.0,
-                1.0,
+                bg[3] as f32 / 255.0,
             );
             gl.clear_depth_f32(1.0);
             gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);

--- a/crates/mogen-studio/src/app/ui_dialogs/export.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/export.rs
@@ -82,6 +82,19 @@ impl MogenStudioApp {
                          overlap. Slow on complex scenes. UVs are preserved through the merge \
                          when all operands in a group have them.",
                     );
+                    ui.checkbox(
+                        &mut opts.bundle_lods_and_imposter,
+                        "Bundle LODs (3 stages) + imposter",
+                    )
+                    .on_hover_text(
+                        "Generate three simplified LOD stages per non-skinned mesh (50% / 25% / 12% \
+                         triangles, attached via the MSFT_lod glTF extension) and bake a scene-wide \
+                         imposter billboard with an 8-view yaw-grid spritesheet. Skinned meshes \
+                         keep their original geometry. The imposter quad is tagged `\"imposter\"` \
+                         in extras so the companion godot-mog runtime can pick the correct cell — \
+                         plain glTF viewers render the full atlas mapped across the quad. Adds a \
+                         headless GL render pass; needs a real display server.",
+                    );
                 });
 
                 ui.add_space(12.0);

--- a/crates/mogen-wasm/src/lib.rs
+++ b/crates/mogen-wasm/src/lib.rs
@@ -240,6 +240,10 @@ fn compile_with_cache(
         include_animations: true,
         include_textures: true,
         merge_sibling_meshes: true,
+        // wasm builds disable both the `lod` and `imposter` features, so
+        // this flag is a no-op even if some path through the bridge ever
+        // sets it.
+        bundle_lods_and_imposter: false,
     };
     let texture_source = MapTextureSource::new(textures);
     match build_glb_with_options_and_source(&scene, &opts, &texture_source, |_| {}) {


### PR DESCRIPTION
## Summary

- Adds `ExportOptions::bundle_lods_and_imposter` (Studio checkbox: "Bundle LODs (3 stages) + imposter") that does two things in one pass:
  - Generates 3 simplified LOD meshes per non-skinned source mesh (50% / 25% / 12% triangle targets via `meshopt::simplify`) and attaches them to the source node through the `MSFT_lod` glTF extension, with `extras.MSFT_screencoverage` thresholds [0.5, 0.25, 0.1, 0.03] so Godot 4's importer swaps stages by distance.
  - Bakes a single scene-wide imposter spritesheet from 8 yaw views via the existing `mogen-render` headless GL stack, embeds the PNG into the GLB BIN chunk, and emits an unlit billboard quad tagged `"imposter"` in `extras.tags` so the companion `godot-mog` runtime can pick the correct cell at sample time.
- mogen output stays plain glTF — the angle-picking shader is a `../godot-mog` responsibility, not this PR.
- New cargo features `lod` (pulls `meshopt`) and `imposter` (pulls `mogen-render` + `image`) gate the heavy deps. Both on by default for desktop; the wasm crate keeps them off.
- Minor: `mogen-render`'s `with_gl_context` now opts into `any_thread` on Linux so the bake works from the Studio's build worker thread (and from `cargo test`), and `Renderer::render_to_pixels` now takes `[u8; 4]` so the imposter can clear to transparent. Thumbnail callers are unaffected (`ThumbnailOptions::bg` stays `[u8; 3]`).

## Test plan

- [x] `cargo build --workspace` — clean (default features include `lod` + `imposter`).
- [x] `cargo test -p mogen-export --test lod_imposter` — three integration tests:
  - `option_off_does_not_emit_lod_or_imposter` — baseline writer output unchanged when flag is off.
  - `option_on_emits_msft_lod_on_source_node` — 3 LOD meshes appended, `MSFT_lod` + `MSFT_screencoverage` stamped on source node, `extensionsUsed` advertises `MSFT_lod`. Skips on headless CI (no `DISPLAY`).
  - `option_on_emits_imposter_node_at_scene_root` (#[ignore]'d — needs a real display): asserts the imposter root node exists, is tagged `"imposter"`, and `KHR_materials_unlit` is advertised. Verified locally on X11.
- [x] `cargo test --workspace` — passes outside two pre-existing unrelated failures on master (`mogen-dsl::lower::building::tests::single_storey::windows_on_each_side_never_overlap` and `mogen-llm::provider::tests::from_env_returns_missing_key_for_blank_cloud_provider`).
- [ ] Manual: open Studio, toggle the new checkbox in Build GLB, inspect the resulting `.glb` shows the source meshes + LOD orphans + imposter root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)