### PR TITLE
Add LOD and imposter preview to Studio viewport

### DIFF
--- a/crates/mogen-export/src/imposter.rs
+++ b/crates/mogen-export/src/imposter.rs
@@ -14,6 +14,8 @@ use serde_json::{json, Value};
 
 use mogen_core::{Mesh, SceneGraph};
 
+pub use mogen_render::imposter::ImposterAtlas;
+
 use crate::accessor::{push_indices, push_normals, push_positions, push_uvs};
 use crate::{align_up, Accessor, BufferView};
 
@@ -41,6 +43,25 @@ pub(crate) struct ImposterEmission {
 /// `sampler` (created here if the table didn't already have one), and one
 /// `texture` pairing them. Re-uses the table's sampler slot 0 when present
 /// so we don't double-emit the standard linear/repeat sampler.
+/// Bake the scene-wide imposter spritesheet exactly as
+/// `bundle_lods_and_imposter` would embed it — same cell size, view count,
+/// and pitch — without writing a GLB. Studio's imposter preview shows the
+/// returned atlas so the user sees the precise artifact the export bundles.
+/// Requires a working display server (headless GL bake), same as the export
+/// path.
+pub fn bake_scene_imposter(scene: &SceneGraph) -> Result<ImposterAtlas> {
+    mogen_render::imposter::bake_yaw_atlas(
+        scene,
+        &mogen_render::imposter::ImposterOptions {
+            cell_size: CELL_SIZE,
+            view_count: VIEW_COUNT,
+            pitch: PITCH_RADIANS,
+            base_dir: None,
+        },
+    )
+    .context("baking imposter atlas")
+}
+
 pub(crate) fn emit_imposter(
     scene: &SceneGraph,
     bin: &mut Vec<u8>,

--- a/crates/mogen-export/src/lib.rs
+++ b/crates/mogen-export/src/lib.rs
@@ -17,6 +17,12 @@ mod writer;
 pub mod fbx;
 
 pub use options::ExportOptions;
+
+#[cfg(feature = "lod")]
+pub use lod::{scene_with_lod, LOD_STAGE_COUNT};
+
+#[cfg(feature = "imposter")]
+pub use imposter::{bake_scene_imposter, ImposterAtlas};
 pub use texture::{FsTextureSource, MapTextureSource, TextureSource};
 pub use writer::{
     build_glb_with_options, build_glb_with_options_and_source, write_glb, write_glb_with_options,

--- a/crates/mogen-export/src/lod.rs
+++ b/crates/mogen-export/src/lod.rs
@@ -13,12 +13,17 @@
 //! common case anyway — the building / furniture pipelines we ship target
 //! exactly that population.
 
-use mogen_core::Mesh;
+use mogen_core::{Mesh, SceneGraph};
 
 /// Target triangle ratios for the three LOD stages, in descending detail.
 /// LOD0 (the original) is always emitted at 100%; these fractions drive
 /// LOD1, LOD2, and LOD3 respectively.
 pub(crate) const LOD_RATIOS: [f32; 3] = [0.5, 0.25, 0.12];
+
+/// Number of simplified LOD stages the `bundle_lods_and_imposter` export
+/// attaches per mesh (LOD1..LOD3 — LOD0 is the untouched original). Exposed
+/// so Studio's LOD preview can offer exactly the stages the export bundles.
+pub const LOD_STAGE_COUNT: usize = LOD_RATIOS.len();
 
 /// Screen-coverage thresholds stamped into `extras.MSFT_screencoverage`.
 /// Per the spec this is parallel to `[source, LOD1, LOD2, LOD3]` — index 0
@@ -95,6 +100,32 @@ pub(crate) fn build_lod_meshes(source: &Mesh) -> Vec<Mesh> {
     out
 }
 
+/// Clone `scene`, swapping every mesh for its `stage`-th simplified LOD so
+/// the result is exactly the geometry a `bundle_lods_and_imposter` export
+/// would ship at that detail level. `stage` is 1-based: `1` → LOD1 (≈50%
+/// tris), `2` → LOD2 (≈25%), `3` → LOD3 (≈12%). A node whose mesh is
+/// skinned, too small, or can't be simplified that far keeps its original
+/// geometry — the same per-mesh fallback the GLB writer applies, so the
+/// preview never shows geometry the export wouldn't.
+///
+/// `stage == 0` (or out of range) returns a plain clone (full detail). Used
+/// by Studio's viewport LOD preview; the export path itself attaches all
+/// stages via `MSFT_lod` rather than collapsing to one.
+pub fn scene_with_lod(scene: &SceneGraph, stage: usize) -> SceneGraph {
+    let mut out = scene.clone();
+    if stage == 0 || stage > LOD_STAGE_COUNT {
+        return out;
+    }
+    for node in &mut out.nodes {
+        let Some(mesh) = &node.mesh else { continue };
+        let lods = build_lod_meshes(mesh);
+        if let Some(reduced) = lods.into_iter().nth(stage - 1) {
+            node.mesh = Some(reduced);
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,6 +176,39 @@ mod tests {
         let m = dense_grid(4); // 16 verts, 18 tris — under MIN_TRIS_FOR_LOD.
         let lods = build_lod_meshes(&m);
         assert!(lods.is_empty(), "small meshes should skip LOD generation");
+    }
+
+    #[test]
+    fn scene_with_lod_swaps_dense_meshes_and_keeps_small_ones() {
+        use mogen_core::{SceneGraph, Transform};
+        let mut scene = SceneGraph::new();
+        let big = scene.add_root("big", "box", Transform::default());
+        scene.set_mesh(big, dense_grid(20));
+        let small = scene.add_root("small", "box", Transform::default());
+        scene.set_mesh(small, dense_grid(4));
+
+        let src_big = scene.nodes[big.0 as usize].mesh.clone().unwrap();
+        let src_small = scene.nodes[small.0 as usize].mesh.clone().unwrap();
+
+        let lod1 = scene_with_lod(&scene, 1);
+        let out_big = lod1.nodes[big.0 as usize].mesh.as_ref().unwrap();
+        let out_small = lod1.nodes[small.0 as usize].mesh.as_ref().unwrap();
+        assert!(
+            out_big.indices.len() < src_big.indices.len(),
+            "dense mesh should be simplified at LOD1"
+        );
+        assert_eq!(
+            out_small.indices.len(),
+            src_small.indices.len(),
+            "sub-threshold mesh should keep its original geometry"
+        );
+
+        // Stage 0 / out of range = untouched full-detail clone.
+        let full = scene_with_lod(&scene, 0);
+        assert_eq!(
+            full.nodes[big.0 as usize].mesh.as_ref().unwrap().indices.len(),
+            src_big.indices.len()
+        );
     }
 
     #[test]

--- a/crates/mogen-studio/Cargo.toml
+++ b/crates/mogen-studio/Cargo.toml
@@ -39,7 +39,7 @@ path-guid = "7C1A3B5D-9E4F-4C82-AF1B-2D3E4F5061A0"
 mogen-core = { workspace = true }
 mogen-dsl = { workspace = true, features = ["csg"] }
 mogen-validate = { workspace = true, features = ["csg"] }
-mogen-export = { workspace = true, features = ["textures", "merge"] }
+mogen-export = { workspace = true, features = ["textures", "merge", "lod", "imposter"] }
 mogen-llm = { workspace = true }
 mogen-moghub-client = { workspace = true, features = ["oauth"] }
 mogen-update = { workspace = true }

--- a/crates/mogen-studio/src/app.rs
+++ b/crates/mogen-studio/src/app.rs
@@ -31,6 +31,7 @@ mod moghub_open;
 mod multi_caret;
 mod oauth_ui;
 mod onboarding;
+mod preview;
 mod pricing;
 mod publish_textures;
 mod spotlight;
@@ -242,6 +243,19 @@ pub struct MogenStudioApp {
     /// "writing glb", …). Read every frame to drive the modal status line.
     /// Shared because the worker thread updates it mid-build.
     build_stage: Arc<Mutex<String>>,
+
+    /// Viewport LOD-detail preview. `Full` shows compiled geometry untouched;
+    /// the LOD stages render the simplified geometry a
+    /// `bundle_lods_and_imposter` build would ship. Transient (not persisted)
+    /// — it's a preview, not a project setting.
+    preview_lod: preview::PreviewLod,
+    /// Imposter-preview modal: open flag, in-flight bake channel, the loaded
+    /// atlas texture, and the last bake error (mutually exclusive with a
+    /// loaded preview).
+    show_imposter: bool,
+    imposter_rx: Option<Receiver<Result<preview::ImposterBake, String>>>,
+    imposter_preview: Option<preview::ImposterPreview>,
+    imposter_err: Option<String>,
 
     viewer: Viewer,
 
@@ -542,6 +556,11 @@ impl MogenStudioApp {
             export_opts_draft: ExportOptions::default(),
             build_rx: None,
             build_stage: Arc::new(Mutex::new(String::new())),
+            preview_lod: preview::PreviewLod::default(),
+            show_imposter: false,
+            imposter_rx: None,
+            imposter_preview: None,
+            imposter_err: None,
             oauth_login_rx: None,
             oauth_login_provider: None,
             oauth_status_message: None,
@@ -851,6 +870,7 @@ impl eframe::App for MogenStudioApp {
         self.poll_meta_generate();
         self.poll_ask();
         self.poll_build();
+        self.poll_imposter_preview(ctx);
         self.poll_oauth_login();
         self.poll_update();
         self.poll_generate(ctx);
@@ -1044,6 +1064,7 @@ impl eframe::App for MogenStudioApp {
         self.ui_quit_confirm(ctx);
         self.ui_close_confirm(ctx);
         self.ui_export_dialog(ctx);
+        self.ui_imposter_preview(ctx);
         self.ui_external_conflict(ctx);
         self.ui_about(ctx);
         self.community_window(ctx);
@@ -1073,6 +1094,7 @@ impl eframe::App for MogenStudioApp {
             || self.any_ask_in_flight()
             || self.any_meta_generate_in_flight()
             || self.build_rx.is_some()
+            || self.imposter_rx.is_some()
             || self.update_in_flight()
         {
             ctx.request_repaint_after(std::time::Duration::from_millis(120));

--- a/crates/mogen-studio/src/app/compile.rs
+++ b/crates/mogen-studio/src/app/compile.rs
@@ -19,7 +19,10 @@ impl MogenStudioApp {
             match &r.scene {
                 Some(scene) if matches!(r.stage, Stage::Ok) => {
                     let fit = self.files[i].first_render;
-                    self.viewer.set_scene(scene.clone(), base_dir, fit);
+                    // Hand the viewer the LOD-preview scene when one is
+                    // active; `last_result` keeps the full-detail geometry.
+                    let viewer_scene = self.viewer_scene(scene);
+                    self.viewer.set_scene(viewer_scene, base_dir, fit);
                     self.files[i].first_render = false;
                 }
                 _ => self.viewer.clear(),

--- a/crates/mogen-studio/src/app/preview.rs
+++ b/crates/mogen-studio/src/app/preview.rs
@@ -1,0 +1,196 @@
+//! LOD / imposter preview support.
+//!
+//! Both previews reuse `mogen-export`'s own pipeline so the viewport shows
+//! the exact artifacts a `bundle_lods_and_imposter` build would ship:
+//!
+//! - **LOD**: [`MogenStudioApp::viewer_scene`] swaps each mesh for its
+//!   simplified stage via `mogen_export::scene_with_lod` before the scene
+//!   reaches the viewer. `last_result.scene` is left untouched so the
+//!   inspector, summary, and export still operate on full-detail geometry.
+//! - **Imposter**: a worker thread bakes the spritesheet with
+//!   `mogen_export::bake_scene_imposter` (the same headless yaw-grid bake the
+//!   export embeds) and the result is shown as an image in a modal.
+
+use std::sync::Arc;
+
+use eframe::egui;
+use mogen_core::SceneGraph;
+
+use crate::pipeline::Stage;
+
+use super::MogenStudioApp;
+
+/// Viewport LOD-detail preview level. `Full` renders the compiled geometry
+/// untouched; the LOD stages render exactly what the export bundles at that
+/// stage (same simplifier, same per-mesh skip/fallback rules).
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub enum PreviewLod {
+    #[default]
+    Full,
+    Lod1,
+    Lod2,
+    Lod3,
+}
+
+pub const PREVIEW_LODS: [PreviewLod; 4] = [
+    PreviewLod::Full,
+    PreviewLod::Lod1,
+    PreviewLod::Lod2,
+    PreviewLod::Lod3,
+];
+
+impl PreviewLod {
+    /// 1-based LOD stage for `mogen_export::scene_with_lod`; `Full` → 0.
+    pub fn stage(self) -> usize {
+        match self {
+            PreviewLod::Full => 0,
+            PreviewLod::Lod1 => 1,
+            PreviewLod::Lod2 => 2,
+            PreviewLod::Lod3 => 3,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            PreviewLod::Full => "Full detail (LOD0)",
+            PreviewLod::Lod1 => "LOD1 (≈50% triangles)",
+            PreviewLod::Lod2 => "LOD2 (≈25% triangles)",
+            PreviewLod::Lod3 => "LOD3 (≈12% triangles)",
+        }
+    }
+
+    /// Compact label for the floating viewport bar.
+    pub fn short(self) -> &'static str {
+        match self {
+            PreviewLod::Full => "Full",
+            PreviewLod::Lod1 => "LOD1",
+            PreviewLod::Lod2 => "LOD2",
+            PreviewLod::Lod3 => "LOD3",
+        }
+    }
+}
+
+/// Raw bake handed back from the worker thread. RGBA is the spritesheet
+/// straight from `mogen_export::bake_scene_imposter` (top-left origin), ready
+/// for `egui::ColorImage::from_rgba_unmultiplied`.
+pub struct ImposterBake {
+    pub rgba: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    pub view_count: u32,
+    pub cell_size: u32,
+}
+
+/// GPU-uploaded imposter atlas plus the bake parameters, shown by the
+/// imposter-preview modal.
+pub struct ImposterPreview {
+    pub texture: egui::TextureHandle,
+    pub width: u32,
+    pub height: u32,
+    pub view_count: u32,
+    pub cell_size: u32,
+}
+
+impl MogenStudioApp {
+    /// The scene the viewer should display for `scene`, honouring the active
+    /// LOD preview. Full detail (the common case) just clones the shared
+    /// `Arc` — no geometry work. A LOD stage runs the export simplifier on a
+    /// detached copy so `last_result.scene` (inspector / export source of
+    /// truth) keeps its original geometry.
+    pub(super) fn viewer_scene(&self, scene: &Arc<SceneGraph>) -> Arc<SceneGraph> {
+        let stage = self.preview_lod.stage();
+        if stage == 0 {
+            return scene.clone();
+        }
+        Arc::new(mogen_export::scene_with_lod(scene, stage))
+    }
+
+    /// Switch the viewport LOD preview and re-feed the active scene so the
+    /// change lands immediately. Recompiling (rather than poking the viewer
+    /// directly) keeps the LOD swap on the one code path that hands scenes to
+    /// the viewer, so animation/selection state stays consistent.
+    pub(super) fn set_preview_lod(&mut self, lod: PreviewLod) {
+        if self.preview_lod == lod {
+            return;
+        }
+        self.preview_lod = lod;
+        self.compile_active();
+    }
+
+    /// Bake the scene-wide imposter spritesheet off-thread. No-op (with a
+    /// status message) when the active scene hasn't compiled cleanly — the
+    /// bake needs real geometry, exactly like the export path.
+    pub(super) fn start_imposter_preview(&mut self, ctx: &egui::Context) {
+        self.show_imposter = true;
+        if self.imposter_rx.is_some() {
+            return;
+        }
+        self.compile_active();
+        let i = self.active;
+        let scene = match &self.files[i].last_result {
+            Some(r) if r.stage == Stage::Ok => r
+                .scene
+                .as_ref()
+                .map(|s| (**s).clone()),
+            _ => None,
+        };
+        let Some(scene) = scene else {
+            self.imposter_preview = None;
+            self.imposter_err =
+                Some("fix scene errors first — the imposter bake needs valid geometry".into());
+            return;
+        };
+        self.imposter_err = None;
+        self.imposter_preview = None;
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.imposter_rx = Some(rx);
+        let ctx = ctx.clone();
+        std::thread::spawn(move || {
+            let msg = match mogen_export::bake_scene_imposter(&scene) {
+                Ok(atlas) => Ok(ImposterBake {
+                    rgba: atlas.rgba,
+                    width: atlas.width,
+                    height: atlas.height,
+                    view_count: atlas.view_count,
+                    cell_size: atlas.cell_size,
+                }),
+                Err(e) => Err(format!("{e:#}")),
+            };
+            let _ = tx.send(msg);
+            ctx.request_repaint();
+        });
+    }
+
+    /// Drain a finished imposter bake and upload it as an egui texture.
+    pub(super) fn poll_imposter_preview(&mut self, ctx: &egui::Context) {
+        let msg = match self.imposter_rx.as_ref() {
+            Some(rx) => match rx.try_recv() {
+                Ok(m) => m,
+                Err(_) => return,
+            },
+            None => return,
+        };
+        self.imposter_rx = None;
+        match msg {
+            Ok(bake) => {
+                let img = egui::ColorImage::from_rgba_unmultiplied(
+                    [bake.width as usize, bake.height as usize],
+                    &bake.rgba,
+                );
+                let texture = ctx.load_texture(
+                    "mogen-imposter-preview",
+                    img,
+                    egui::TextureOptions::LINEAR,
+                );
+                self.imposter_preview = Some(ImposterPreview {
+                    texture,
+                    width: bake.width,
+                    height: bake.height,
+                    view_count: bake.view_count,
+                    cell_size: bake.cell_size,
+                });
+            }
+            Err(e) => self.imposter_err = Some(e),
+        }
+    }
+}

--- a/crates/mogen-studio/src/app/ui_dialogs.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs.rs
@@ -9,6 +9,7 @@
 //! - `new_prompt` — New from Prompt (text + optional reference image)
 //! - `external` — on-disk-conflict resolver
 //! - `export` — Build GLB
+//! - `imposter` — baked imposter-atlas preview
 //! - `video` — Render MP4 options + capture-progress scrim
 
 mod about;
@@ -16,6 +17,7 @@ mod ask;
 pub(super) mod community;
 mod export;
 mod external;
+mod imposter;
 mod new_prompt;
 mod prefs;
 mod quit;

--- a/crates/mogen-studio/src/app/ui_dialogs/export.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/export.rs
@@ -18,6 +18,7 @@ impl MogenStudioApp {
         let mut do_build = false;
         let mut do_cancel = false;
         let mut do_close = false;
+        let mut do_preview_imposter = false;
         let mut save_then_export = false;
         let i = self.active;
         let file_has_path = self.files[i].path.is_some();
@@ -97,6 +98,26 @@ impl MogenStudioApp {
                     );
                 });
 
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    if ui
+                        .button("Preview imposter…")
+                        .on_hover_text(
+                            "Bake and show the imposter spritesheet this option \
+                             embeds, without writing a GLB",
+                        )
+                        .clicked()
+                    {
+                        do_preview_imposter = true;
+                    }
+                    ui.label(
+                        egui::RichText::new(
+                            "LOD stages: use the ◇ picker on the viewport bar.",
+                        )
+                        .weak(),
+                    );
+                });
+
                 ui.add_space(12.0);
 
                 if in_flight {
@@ -158,6 +179,9 @@ impl MogenStudioApp {
         if do_cancel {
             self.cancel_build();
             return;
+        }
+        if do_preview_imposter {
+            self.start_imposter_preview(ctx);
         }
         if do_build {
             let ctx_clone = ctx.clone();

--- a/crates/mogen-studio/src/app/ui_dialogs/imposter.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/imposter.rs
@@ -1,0 +1,98 @@
+use eframe::egui;
+
+use crate::app::MogenStudioApp;
+
+impl MogenStudioApp {
+    /// Imposter-preview modal. Shows the baked yaw-grid spritesheet the
+    /// `bundle_lods_and_imposter` export embeds — same cell size, view count,
+    /// and pitch — so the user can judge the billboard before shipping it.
+    pub(in crate::app) fn ui_imposter_preview(&mut self, ctx: &egui::Context) {
+        if !self.show_imposter {
+            return;
+        }
+        let in_flight = self.imposter_rx.is_some();
+        let mut open = true;
+        let mut rebake = false;
+
+        egui::Window::new("Imposter preview")
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(false)
+            .default_width(600.0)
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .show(ctx, |ui| {
+                ui.label(
+                    "Scene-wide imposter billboard baked exactly as the \
+                     `bundle_lods_and_imposter` export embeds it.",
+                );
+                ui.add_space(8.0);
+
+                if in_flight {
+                    ui.horizontal(|ui| {
+                        ui.spinner();
+                        ui.label("baking imposter atlas…");
+                    });
+                } else if let Some(err) = &self.imposter_err {
+                    ui.colored_label(
+                        egui::Color32::LIGHT_RED,
+                        format!("imposter bake failed: {err}"),
+                    );
+                } else if let Some(p) = &self.imposter_preview {
+                    // Scale the wide atlas down to fit the modal while
+                    // keeping aspect; never upscale past 1:1.
+                    let max_w = 560.0_f32;
+                    let scale = (max_w / p.width as f32).min(1.0);
+                    let size = egui::vec2(
+                        p.width as f32 * scale,
+                        p.height as f32 * scale,
+                    );
+                    egui::Frame::none()
+                        .fill(egui::Color32::from_gray(40))
+                        .inner_margin(egui::Margin::same(4.0))
+                        .show(ui, |ui| {
+                            ui.add(
+                                egui::Image::new(&p.texture)
+                                    .fit_to_exact_size(size),
+                            );
+                        });
+                    ui.add_space(6.0);
+                    ui.label(format!(
+                        "{} views · {}² px cells · {}×{} atlas",
+                        p.view_count, p.cell_size, p.width, p.height
+                    ));
+                    ui.label(
+                        egui::RichText::new(
+                            "The companion godot-mog runtime picks the cell \
+                             matching the camera yaw. Plain glTF viewers map \
+                             the whole sheet across the quad (every angle \
+                             tiled) — that's expected, not a bake error.",
+                        )
+                        .weak(),
+                    );
+                } else {
+                    ui.label("(no imposter baked yet)");
+                }
+
+                ui.add_space(12.0);
+                ui.horizontal(|ui| {
+                    if ui
+                        .add_enabled(!in_flight, egui::Button::new("Re-bake"))
+                        .on_hover_text("Bake the imposter again from the current scene")
+                        .clicked()
+                    {
+                        rebake = true;
+                    }
+                    if ui.button("Close").clicked() {
+                        self.show_imposter = false;
+                    }
+                });
+            });
+
+        if !open {
+            self.show_imposter = false;
+        }
+        if rebake {
+            self.start_imposter_preview(ctx);
+        }
+    }
+}

--- a/crates/mogen-studio/src/app/ui_menu.rs
+++ b/crates/mogen-studio/src/app/ui_menu.rs
@@ -348,6 +348,8 @@ impl MogenStudioApp {
             });
 
             let mut chosen_theme: Option<Theme> = None;
+            let mut chosen_lod: Option<crate::app::preview::PreviewLod> = None;
+            let mut do_imposter_preview = false;
             ui.menu_button("View", |ui| {
                 if shortcut_menu_item(
                     ui,
@@ -407,6 +409,38 @@ impl MogenStudioApp {
                     let _ = self.settings.save();
                 }
                 ui.separator();
+                ui.menu_button("LOD Preview", |ui| {
+                    use crate::app::preview::PREVIEW_LODS;
+                    let cur = self.preview_lod;
+                    for l in PREVIEW_LODS {
+                        let selected = l == cur;
+                        if ui
+                            .selectable_label(selected, l.label())
+                            .clicked()
+                            && !selected
+                        {
+                            chosen_lod = Some(l);
+                            ui.close_menu();
+                        }
+                    }
+                    ui.separator();
+                    if ui
+                        .button("Imposter atlas…")
+                        .on_hover_text(
+                            "Bake and show the scene-wide imposter spritesheet the \
+                             `bundle_lods_and_imposter` export embeds",
+                        )
+                        .clicked()
+                    {
+                        do_imposter_preview = true;
+                        ui.close_menu();
+                    }
+                })
+                .response
+                .on_hover_text(
+                    "Render the simplified LOD geometry / imposter the export bundles",
+                );
+                ui.separator();
                 ui.menu_button("Theme", |ui| {
                     let current = self.settings.theme();
                     for t in THEMES {
@@ -453,6 +487,13 @@ impl MogenStudioApp {
                 self.settings.set_theme(t);
                 apply_theme(ui.ctx(), t);
                 let _ = self.settings.save();
+            }
+            if let Some(l) = chosen_lod {
+                self.set_preview_lod(l);
+            }
+            if do_imposter_preview {
+                let ctx = ui.ctx().clone();
+                self.start_imposter_preview(&ctx);
             }
 
             ui.menu_button("Community", |ui| {

--- a/crates/mogen-studio/src/app/ui_panels/overlay.rs
+++ b/crates/mogen-studio/src/app/ui_panels/overlay.rs
@@ -157,6 +157,59 @@ impl MogenStudioApp {
                                 }
                             });
                             ui.separator();
+                            // LOD-detail preview picker. Renders exactly the
+                            // simplified geometry a `bundle_lods_and_imposter`
+                            // build would ship at each stage; "Imposter…"
+                            // bakes the spritesheet the export embeds. Not
+                            // persisted — it's a transient preview, and
+                            // disabled in cinema mode like the other editor
+                            // controls.
+                            ui.add_enabled_ui(!cinema_on, |ui| {
+                                use crate::app::preview::{PreviewLod, PREVIEW_LODS};
+                                let cur_lod = self.preview_lod;
+                                let mut chosen_lod: Option<PreviewLod> = None;
+                                let mut bake_imposter = false;
+                                let label = format!("◇ {}", cur_lod.short());
+                                ui.menu_button(label, |ui| {
+                                    ui.label(egui::RichText::new("LOD preview").strong());
+                                    ui.separator();
+                                    for l in PREVIEW_LODS {
+                                        let selected = l == cur_lod;
+                                        if ui
+                                            .selectable_label(selected, l.label())
+                                            .clicked()
+                                            && !selected
+                                        {
+                                            chosen_lod = Some(l);
+                                            ui.close_menu();
+                                        }
+                                    }
+                                    ui.separator();
+                                    if ui
+                                        .button("Imposter…")
+                                        .on_hover_text(
+                                            "Bake and show the scene-wide imposter \
+                                             billboard spritesheet the export embeds",
+                                        )
+                                        .clicked()
+                                    {
+                                        bake_imposter = true;
+                                        ui.close_menu();
+                                    }
+                                })
+                                .response
+                                .on_hover_text(
+                                    "Preview the LOD stages / imposter the \
+                                     `bundle_lods_and_imposter` export bundles",
+                                );
+                                if let Some(l) = chosen_lod {
+                                    self.set_preview_lod(l);
+                                }
+                                if bake_imposter {
+                                    self.start_imposter_preview(ctx);
+                                }
+                            });
+                            ui.separator();
                             // Environment-lighting preset picker. Drives the
                             // analytic sky probe and the fallback key/fill
                             // rig the shader uses when the scene declares no

--- a/crates/mogen-studio/src/app/ui_panels/summary.rs
+++ b/crates/mogen-studio/src/app/ui_panels/summary.rs
@@ -144,6 +144,26 @@ impl MogenStudioApp {
             ui.label(format!("joints: {joints}"));
         }
 
+        // LOD-preview note. The counts above are always full-detail (they
+        // come from `last_result`, which the LOD preview never touches), so
+        // flag when the viewport is showing simplified geometry instead.
+        if self.preview_lod != crate::app::preview::PreviewLod::Full {
+            ui.add_space(4.0);
+            ui.colored_label(
+                egui::Color32::from_rgb(240, 200, 140),
+                format!(
+                    "previewing {} — viewport geometry is simplified; \
+                     counts above are full-detail",
+                    self.preview_lod.short()
+                ),
+            )
+            .on_hover_text(
+                "The LOD preview renders the geometry a \
+                 `bundle_lods_and_imposter` build would ship at this stage. \
+                 Switch back to Full on the viewport ◇ picker.",
+            );
+        }
+
         // Polygon count slider — multiplies primitive default segment/ring
         // counts at lower-time. Reads the live value out of source so it
         // stays in sync if the user edits the directive in the text editor.


### PR DESCRIPTION
## Summary

Adds interactive LOD (level-of-detail) preview and imposter spritesheet baking to MoGen Studio's viewport, allowing users to see exactly what geometry and billboards the `bundle_lods_and_imposter` export option would ship before building.

## Key Changes

- **New preview module** (`crates/mogen-studio/src/app/preview.rs`): Core LOD preview logic and imposter baking orchestration
  - `PreviewLod` enum with Full/LOD1/LOD2/LOD3 stages matching export stages
  - `viewer_scene()` method that swaps meshes for simplified LOD geometry on demand
  - `start_imposter_preview()` spawns off-thread bake using `mogen_export::bake_scene_imposter`
  - `poll_imposter_preview()` drains completed bakes and uploads textures to egui

- **Imposter preview modal** (`crates/mogen-studio/src/app/ui_dialogs/imposter.rs`): Shows baked spritesheet with view count, cell size, and atlas dimensions; includes re-bake button

- **UI integration**: 
  - Viewport overlay menu (◇ picker) for LOD stage selection and imposter baking
  - View menu with LOD Preview submenu
  - Export dialog "Preview imposter…" button for quick baking without writing GLB
  - Summary panel warning when viewport is showing simplified geometry

- **Export API exposure** (`crates/mogen-export/src/lib.rs` and `imposter.rs`):
  - Public `bake_scene_imposter()` function wrapping `mogen_render::imposter::bake_yaw_atlas`
  - Re-export of `ImposterAtlas` from `mogen_render`
  - Public `scene_with_lod()` and `LOD_STAGE_COUNT` from LOD module

- **LOD scene transformation** (`crates/mogen-export/src/lod.rs`):
  - New `scene_with_lod()` function that clones a scene and swaps each mesh for its simplified LOD stage
  - Respects per-mesh fallback rules (skinned, too small, or unsimplifiable meshes keep original geometry)
  - Stage 0 returns untouched full-detail clone

- **App state management** (`crates/mogen-studio/src/app.rs`):
  - `preview_lod` field tracking current viewport LOD stage
  - `show_imposter`, `imposter_rx`, `imposter_preview`, `imposter_err` fields for modal state and bake channel
  - `poll_imposter_preview()` called each frame to drain completed bakes

- **Compile integration** (`crates/mogen-studio/src/app/compile.rs`): `viewer_scene()` called when feeding scenes to the 3D viewer so LOD preview is always active

## Implementation Details

- LOD preview is **transient** (not persisted) — it's a viewport preview, not a project setting
- Disabled in cinema mode like other editor controls
- Imposter baking runs off-thread with `std::thread::spawn` and `mpsc` channel for non-blocking UI
- Full-detail counts in summary panel always come from `last_result` (unmodified source), with a warning label when viewport shows simplified geometry
- Reuses exact same simplification pipeline and per-mesh fallback rules as the export path, so preview is pixel-accurate to what ships

https://claude.ai/code/session_01EeMAScmyk2Vm8nfq7uGKGU