### PR TITLE
feat(cli): add `mogen mcp` subcommand exposing the CLI as an MCP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +940,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1081,12 @@ name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "earcutr"
@@ -1395,6 +1447,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1476,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1458,6 +1536,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1914,6 +1993,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,6 +2103,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2380,6 +2489,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,7 +2602,12 @@ dependencies = [
  "mogen-render",
  "mogen-update",
  "mogen-validate",
+ "rmcp",
+ "schemars 0.8.22",
+ "serde",
  "serde_json",
+ "tokio",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3321,6 +3444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3742,6 +3871,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3869,6 +4018,41 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -4003,6 +4187,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 1.2.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4187,6 +4421,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4231,6 +4476,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -4565,6 +4819,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4667,8 +4930,21 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4678,6 +4954,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls 0.23.39",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -4795,6 +5084,12 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
  "tracing-core",
 ]
 
@@ -5430,7 +5725,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core",
+ "windows-core 0.52.0",
  "windows-targets 0.52.6",
 ]
 
@@ -5444,10 +5739,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crates/mogen/Cargo.toml
+++ b/crates/mogen/Cargo.toml
@@ -24,3 +24,12 @@ clap = { workspace = true }
 image = { workspace = true }
 serde_json = { workspace = true }
 indicatif = "0.17"
+# MCP server (`mogen mcp` subcommand). `default` pulls in macros + the
+# stdio-capable server scaffolding; `transport-io` adds the actual stdio
+# transport. Tokio is only used by the MCP path — every other subcommand
+# stays sync.
+rmcp = { version = "1", features = ["transport-io"] }
+schemars = "0.8"
+serde = { workspace = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "process", "sync"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }

--- a/crates/mogen/src/cli/cmd.rs
+++ b/crates/mogen/src/cli/cmd.rs
@@ -452,6 +452,16 @@ pub(crate) enum Cmd {
         #[arg(long)]
         plan: PathBuf,
     },
+    /// Run `mogen` as an MCP (Model Context Protocol) server over stdio.
+    /// Every other CLI subcommand — `build`, `check`, `generate`,
+    /// `moghub publish`, etc. — is exposed as a tool the connected LLM
+    /// client can invoke. Each tool call spawns the same binary in
+    /// normal CLI mode and captures stdout/stderr, so behaviour is
+    /// identical to invoking the command from a terminal. Designed to
+    /// be launched by an MCP client (e.g. Claude Desktop / a custom
+    /// client) — it speaks JSON-RPC on stdin/stdout, so don't run it
+    /// interactively.
+    Mcp,
     /// Run a suite of prompts through `generate` and report success rate and
     /// mean token cost. Does not write GLBs.
     Bench {

--- a/crates/mogen/src/commands/mcp.rs
+++ b/crates/mogen/src/commands/mcp.rs
@@ -1,0 +1,923 @@
+//! `mogen mcp` — expose every CLI subcommand to an MCP-speaking LLM
+//! client over stdio.
+//!
+//! Each tool wrapper builds an argv vector and re-invokes the same
+//! `mogen` binary as a subprocess. Going via subprocess (rather than
+//! calling the command functions in-process) buys us three things:
+//!
+//! * Several commands call `std::process::exit(1)` on validation errors
+//!   (`check`, `auth`, `moghub`). Running them in-process would kill the
+//!   MCP server itself.
+//! * Many commands `println!` results to stdout. In stdio MCP mode our
+//!   own stdout is reserved for JSON-RPC, so any stray print would
+//!   corrupt the protocol. The child writes its stdout into a pipe we
+//!   capture.
+//! * Future CLI changes (new flags, new subcommands) need no MCP-side
+//!   refactor — the args are forwarded verbatim.
+//!
+//! Tool names mirror the CLI subcommand names with hyphens replaced by
+//! underscores (clap auto-renames `DumpScene` to `dump-scene` on the
+//! CLI; we call the tool `dump_scene`). Moghub tools are namespaced
+//! with a `moghub_` prefix.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use rmcp::{
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{CallToolResult, Content, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router,
+    transport::stdio,
+    ErrorData as McpError, ServerHandler, ServiceExt,
+};
+use serde::Deserialize;
+use tokio::process::Command;
+use tracing_subscriber::EnvFilter;
+
+/// Entry point for `mogen mcp`. Builds a current-thread tokio runtime
+/// (no need for a thread pool — every tool dispatches to a child
+/// process), wires the MCP server to stdio, and blocks until the
+/// client disconnects.
+pub(crate) fn run() -> Result<()> {
+    // Logs MUST go to stderr — stdout is the JSON-RPC transport. If
+    // `RUST_LOG` is unset, default to `warn` so a noisy environment
+    // can't accidentally pollute the protocol via tracing macros
+    // someone else writes.
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async {
+        let service = MogenMcp::new().serve(stdio()).await?;
+        service.waiting().await?;
+        Ok::<_, anyhow::Error>(())
+    })?;
+    Ok(())
+}
+
+// --- subprocess plumbing ----------------------------------------------------
+
+/// Spawn the running `mogen` binary with `args`, capture stdout +
+/// stderr, and return them as MCP tool content.
+///
+/// On non-zero exit we still return a successful `CallToolResult` but
+/// mark it as an error result and bundle stderr in the message so the
+/// calling LLM gets the diagnostics back instead of an opaque
+/// "execution failed". On spawn failure (binary missing, OS error) we
+/// return a hard `McpError`.
+async fn run_mogen(args: Vec<String>) -> Result<CallToolResult, McpError> {
+    let exe = std::env::current_exe()
+        .map_err(|e| McpError::internal_error(format!("locating mogen binary: {e}"), None))?;
+    let output = Command::new(&exe)
+        .args(&args)
+        .output()
+        .await
+        .map_err(|e| McpError::internal_error(format!("spawning mogen: {e}"), None))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let mut parts = Vec::with_capacity(2);
+    if !stdout.is_empty() {
+        parts.push(Content::text(stdout));
+    }
+    if !stderr.is_empty() {
+        parts.push(Content::text(format!("[stderr]\n{stderr}")));
+    }
+    if parts.is_empty() {
+        parts.push(Content::text(""));
+    }
+    if output.status.success() {
+        Ok(CallToolResult::success(parts))
+    } else {
+        // Surface a structured error result. Per the MCP spec, tool
+        // errors that should still be returned to the LLM (rather than
+        // failing the RPC) go through `CallToolResult` with
+        // `is_error=true`.
+        Ok(CallToolResult::error(parts))
+    }
+}
+
+/// Helpers for assembling CLI args. The clap surface mostly uses
+/// `--kebab-case` long flags and stringly-typed enums — these match.
+fn push_opt<T: ToString>(args: &mut Vec<String>, name: &str, value: Option<T>) {
+    if let Some(v) = value {
+        args.push(name.to_string());
+        args.push(v.to_string());
+    }
+}
+
+fn push_flag(args: &mut Vec<String>, name: &str, value: bool) {
+    if value {
+        args.push(name.to_string());
+    }
+}
+
+fn push_path_opt(args: &mut Vec<String>, name: &str, value: Option<PathBuf>) {
+    if let Some(v) = value {
+        args.push(name.to_string());
+        args.push(v.to_string_lossy().into_owned());
+    }
+}
+
+// --- shared parameter structs -----------------------------------------------
+
+/// Subset of generation/modify/animate/repair flags that map 1:1 onto
+/// the CLI. Each is optional — only `prompt` (or `input`) is required
+/// per tool. Mirrors the clap definitions in `cli/cmd.rs` but stripped
+/// to the JSON-shaped subset (no path-vs-string distinction, no
+/// `value_enum` enums — strings are validated by the child).
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct LlmCommon {
+    /// LLM provider. One of `auto`, `gemini`, `gemini-oauth`,
+    /// `antigravity`, `openai`, `anthropic`, `ollama`, `claude-code`,
+    /// `fireworks`, `zai`. Defaults to `auto`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider: Option<String>,
+    /// Model name. Provider default applies when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    /// Cap on server-side reasoning: `low`, `medium`, `high`, `xhigh`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    thinking: Option<String>,
+    /// Visual style hint. One of `ps1`, `n64`, `low-poly`,
+    /// `high-detail`, `arcade`, `voxel`, `cel-shaded`,
+    /// `stylized-fantasy`, `cyberpunk`, `pixel-art`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    style: Option<String>,
+    /// Override the provider's API key env var.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    api_key: Option<String>,
+    /// Sampling temperature; provider default applies when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    /// Abort if total prompt+response tokens exceed this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    budget_tokens: Option<u32>,
+    /// Cap on repair iterations after the first attempt. Defaults to 2.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_repair_iters: Option<u32>,
+    /// Seed embedded in the DSL header. Random when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    seed: Option<u64>,
+    /// `cachedContents/...` resource for the system instruction.
+    /// Gemini only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    cached_content: Option<String>,
+    /// Disable the automatic system-instruction cache.
+    #[serde(default)]
+    no_cache: bool,
+    /// Print the generated DSL but skip compilation and file writes.
+    #[serde(default)]
+    dry_run: bool,
+}
+
+impl LlmCommon {
+    fn push(self, args: &mut Vec<String>) {
+        push_opt(args, "--provider", self.provider);
+        push_opt(args, "--model", self.model);
+        push_opt(args, "--thinking", self.thinking);
+        push_opt(args, "--style", self.style);
+        push_opt(args, "--api-key", self.api_key);
+        push_opt(args, "--temperature", self.temperature);
+        push_opt(args, "--budget-tokens", self.budget_tokens);
+        push_opt(args, "--max-repair-iters", self.max_repair_iters);
+        push_opt(args, "--seed", self.seed);
+        push_opt(args, "--cached-content", self.cached_content);
+        push_flag(args, "--no-cache", self.no_cache);
+        push_flag(args, "--dry-run", self.dry_run);
+    }
+}
+
+// --- per-tool parameter structs ---------------------------------------------
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct BuildArgs {
+    /// Path to the `.mog` source.
+    input: PathBuf,
+    /// Output path. Defaults to `<input>.glb` (or `.fbx` when
+    /// `format` is `fbx`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    out: Option<PathBuf>,
+    /// Output container: `glb` (default) or `fbx`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    format: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct InputOnly {
+    /// Path to the `.mog` (for parse/dump-scene/check) or `.glb`
+    /// (for inspect) input.
+    input: PathBuf,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct CheckArgs {
+    /// Path to the `.mog` source.
+    input: PathBuf,
+    /// Emit diagnostics as line-delimited JSON instead of human-formatted text.
+    #[serde(default)]
+    json: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct DumpSceneArgs {
+    /// Path to the `.mog` source.
+    input: PathBuf,
+    /// Emit the lowered scene graph as JSON.
+    #[serde(default)]
+    json: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ThumbnailArgs {
+    /// Path to the `.mog` source.
+    input: PathBuf,
+    /// Output PNG path. Defaults to `<input>.png`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    out: Option<PathBuf>,
+    /// Square edge length in pixels. Defaults to 512.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    size: Option<u32>,
+    /// Camera yaw in radians. Default π/4.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    yaw: Option<f32>,
+    /// Camera pitch in radians. Default 0.5 rad.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pitch: Option<f32>,
+    /// Background fill, 6-digit hex (`#2a2d33`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    bg: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct GenerateArgs {
+    /// Natural-language asset description, e.g. "a wooden stool".
+    prompt: String,
+    /// Output GLB path. Ignored in dry-run mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    out: Option<PathBuf>,
+    /// Where to stash the intermediate `.mog`. Defaults to the sibling
+    /// of `out` with a `.mog` extension.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    dsl_out: Option<PathBuf>,
+    /// Run the Architect agent first — generate a Markdown plan from
+    /// the prompt, then feed it into the Coder pass. Costs one extra
+    /// LLM round-trip.
+    #[serde(default)]
+    plan: bool,
+    /// Visual auto-refinement iteration count (0–10).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    auto_refine: Option<u32>,
+    #[serde(flatten)]
+    common: LlmCommon,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ModifyArgs {
+    /// Existing `.mog` to modify.
+    input: PathBuf,
+    /// Natural-language description of the change.
+    prompt: String,
+    /// Output GLB path. Defaults to `<input>.glb`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    out: Option<PathBuf>,
+    /// Where to write the modified DSL. Defaults to overwriting `input`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    dsl_out: Option<PathBuf>,
+    /// Run the Architect agent first.
+    #[serde(default)]
+    plan: bool,
+    /// Visual auto-refinement iteration count (0–10).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    auto_refine: Option<u32>,
+    /// Force a full DSL rewrite instead of SEARCH/REPLACE edit blocks.
+    #[serde(default)]
+    rewrite: bool,
+    #[serde(flatten)]
+    common: LlmCommon,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct AnimateArgs {
+    /// Existing `.mog` whose animations should be edited.
+    input: PathBuf,
+    /// Natural-language description of the animation.
+    prompt: String,
+    /// Output GLB path. Defaults to `<input>.glb`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    out: Option<PathBuf>,
+    /// Where to write the updated DSL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    dsl_out: Option<PathBuf>,
+    #[serde(flatten)]
+    common: LlmCommon,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct RepairArgs {
+    /// Existing `.mog` to repair.
+    input: PathBuf,
+    /// Output GLB path. Defaults to `<input>.glb`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    out: Option<PathBuf>,
+    /// Where to write the repaired DSL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    dsl_out: Option<PathBuf>,
+    /// Stop after rewriting the `.mog`; don't run build.
+    #[serde(default)]
+    no_build: bool,
+    #[serde(flatten)]
+    common: LlmCommon,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct TexturesArgs {
+    /// Input `.mog` to augment.
+    input: PathBuf,
+    /// Where to write the modified `.mog`. Defaults to in-place.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    out: Option<PathBuf>,
+    /// GLB output path. Defaults to `<input>.glb`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    glb: Option<PathBuf>,
+    /// PNG output directory, relative to the `.mog`. Defaults to
+    /// `textures/<mog-stem>/`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    textures_dir: Option<PathBuf>,
+    /// Style hint appended to each image prompt. Defaults to
+    /// `photorealistic`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    style: Option<String>,
+    /// Gemini image model name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    /// Regenerate even if the slot is already declared or its PNG
+    /// already exists.
+    #[serde(default)]
+    force: bool,
+    /// Print the plan and skip API calls / file writes.
+    #[serde(default)]
+    dry_run: bool,
+    /// Stop after rewriting the `.mog`; don't run build.
+    #[serde(default)]
+    no_build: bool,
+    /// Override `GEMINI_API_KEY`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    api_key: Option<String>,
+    /// Use Z.ai's `glm-image` endpoint for albedo generation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    zai_api_key: Option<String>,
+    /// Skip every derived PBR map (normal / metallic-roughness / AO).
+    #[serde(default)]
+    no_pbr: bool,
+    /// Skip the derived normal map.
+    #[serde(default)]
+    no_normal: bool,
+    /// Skip the derived metallic-roughness map.
+    #[serde(default)]
+    no_metallic_roughness: bool,
+    /// Skip the derived ambient-occlusion map.
+    #[serde(default)]
+    no_occlusion: bool,
+    /// Cap on the longer side of every generated albedo. `0` keeps
+    /// the model's native resolution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    texture_size: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct UpdateArgs {
+    /// Install the update without prompting.
+    #[serde(default)]
+    yes: bool,
+    /// Print the latest release tag and exit without downloading.
+    #[serde(default)]
+    check: bool,
+    /// Reinstall the latest release even if already at it.
+    #[serde(default)]
+    force: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct BenchArgs {
+    /// One-prompt-per-line file. Defaults to `benches/prompts.txt`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    prompts: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    thinking: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_repair_iters: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    budget_tokens: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    api_key: Option<String>,
+    #[serde(default)]
+    no_cache: bool,
+}
+
+// --- moghub parameter structs -----------------------------------------------
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ServerOnly {
+    /// MoGHub server base URL. Defaults to the canonical instance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    server: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct MoghubDiscoverArgs {
+    /// Free-text search.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    query: Option<String>,
+    /// Filter by kind: `scene`, `model`, `module`, or `all`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    kind: Option<String>,
+    /// Filter by tag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tag: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    limit: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    offset: Option<u32>,
+    /// Emit the raw API response as JSON.
+    #[serde(default)]
+    json: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    server: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct MoghubRefArgs {
+    /// Model reference: `<user>/<slug>` or `@<user>/<slug>`.
+    reference: String,
+    #[serde(default)]
+    json: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    server: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct MoghubDownloadArgs {
+    /// Model reference: `<user>/<slug>` or `@<user>/<slug>`.
+    reference: String,
+    /// Specific version. Defaults to latest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    version: Option<i32>,
+    /// Destination directory. Defaults to `<slug>-v<version>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    out: Option<PathBuf>,
+    /// Only fetch the entry `.mog`; skip imports and thumbnail.
+    #[serde(default)]
+    entry_only: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    server: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct MoghubRefOnly {
+    reference: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    server: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct MoghubCommentArgs {
+    reference: String,
+    /// BBCode comment body.
+    body: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    server: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct MoghubNotificationsArgs {
+    /// Mark every notification as read instead of just listing.
+    #[serde(default)]
+    mark_read: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    server: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct MoghubPublishArgs {
+    input: PathBuf,
+    /// Override `meta(name=…)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    /// Override `meta(description=…)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    /// Comma-separated tags. Overrides `meta(tags=[…])`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tags: Option<String>,
+    /// SPDX-style license id. Defaults to `CC0-1.0`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    license: Option<String>,
+    /// `public`, `unlisted`, or `private`. Defaults to `public`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    visibility: Option<String>,
+    /// Version changelog message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+    /// PNG to attach as the thumbnail. Auto-rendered when omitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    thumbnail: Option<PathBuf>,
+    /// Override the published filename.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    filename: Option<String>,
+    /// Publish as a registry-importable module.
+    #[serde(default)]
+    module: bool,
+    /// Publish as a scene.
+    #[serde(default)]
+    scene: bool,
+    /// Force a new model even if `meta()` carries a prior stamp.
+    #[serde(default)]
+    new: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    server: Option<String>,
+}
+
+// --- the server -------------------------------------------------------------
+
+#[derive(Clone)]
+pub(crate) struct MogenMcp {
+    // Read by the `#[tool_handler]` macro's generated dispatch — the
+    // compiler can't see the indirection so it flags this as dead.
+    #[allow(dead_code)]
+    tool_router: ToolRouter<MogenMcp>,
+}
+
+#[tool_router]
+impl MogenMcp {
+    pub(crate) fn new() -> Self {
+        Self { tool_router: Self::tool_router() }
+    }
+
+    // -- pipeline ----------------------------------------------------------
+
+    #[tool(description = "Compile a .mog DSL file to a binary scene container (GLB or FBX). \
+        The output extension picks the format unless `format` is set explicitly.")]
+    async fn build(
+        &self,
+        Parameters(p): Parameters<BuildArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["build".to_string(), p.input.to_string_lossy().into_owned()];
+        push_path_opt(&mut args, "--out", p.out);
+        push_opt(&mut args, "--format", p.format);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Parse a .mog file and print the AST.")]
+    async fn parse(
+        &self,
+        Parameters(p): Parameters<InputOnly>,
+    ) -> Result<CallToolResult, McpError> {
+        run_mogen(vec!["parse".to_string(), p.input.to_string_lossy().into_owned()]).await
+    }
+
+    #[tool(description = "Validate a .mog file (semantic + reference checks). Returns \
+        diagnostics; tool result is marked as error iff any diagnostic is a hard error.")]
+    async fn check(
+        &self,
+        Parameters(p): Parameters<CheckArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["check".to_string(), p.input.to_string_lossy().into_owned()];
+        push_flag(&mut args, "--json", p.json);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Lower a .mog file to a SceneGraph and dump it as JSON or pretty Debug.")]
+    async fn dump_scene(
+        &self,
+        Parameters(p): Parameters<DumpSceneArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["dump-scene".to_string(), p.input.to_string_lossy().into_owned()];
+        push_flag(&mut args, "--json", p.json);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Read a .glb file and print its structure (chunks, accessors, meshes, \
+        materials, animations, skins).")]
+    async fn inspect(
+        &self,
+        Parameters(p): Parameters<InputOnly>,
+    ) -> Result<CallToolResult, McpError> {
+        run_mogen(vec!["inspect".to_string(), p.input.to_string_lossy().into_owned()]).await
+    }
+
+    #[tool(description = "Render a PNG preview of a .mog via the headless GL pipeline. Suitable \
+        to feed back into moghub_publish as a thumbnail.")]
+    async fn thumbnail(
+        &self,
+        Parameters(p): Parameters<ThumbnailArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["thumbnail".to_string(), p.input.to_string_lossy().into_owned()];
+        push_path_opt(&mut args, "--out", p.out);
+        push_opt(&mut args, "--size", p.size);
+        push_opt(&mut args, "--yaw", p.yaw);
+        push_opt(&mut args, "--pitch", p.pitch);
+        push_opt(&mut args, "--bg", p.bg);
+        run_mogen(args).await
+    }
+
+    // -- LLM-driven ---------------------------------------------------------
+
+    #[tool(description = "Generate a .mog from a natural-language prompt via the configured LLM \
+        provider, validate, and compile to GLB. Uses mogen's own LLM credentials.")]
+    async fn generate(
+        &self,
+        Parameters(p): Parameters<GenerateArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["generate".to_string(), p.prompt];
+        push_path_opt(&mut args, "--out", p.out);
+        push_path_opt(&mut args, "--dsl-out", p.dsl_out);
+        push_flag(&mut args, "--plan", p.plan);
+        push_opt(&mut args, "--auto-refine", p.auto_refine);
+        p.common.push(&mut args);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Modify an existing .mog with a natural-language prompt, validate, and \
+        recompile. Default mode emits SEARCH/REPLACE edit blocks; set `rewrite=true` to force a \
+        full rewrite.")]
+    async fn modify(
+        &self,
+        Parameters(p): Parameters<ModifyArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["modify".to_string(), p.input.to_string_lossy().into_owned(), p.prompt];
+        push_path_opt(&mut args, "--out", p.out);
+        push_path_opt(&mut args, "--dsl-out", p.dsl_out);
+        push_flag(&mut args, "--plan", p.plan);
+        push_opt(&mut args, "--auto-refine", p.auto_refine);
+        push_flag(&mut args, "--rewrite", p.rewrite);
+        p.common.push(&mut args);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Add or edit animations on an existing .mog via the LLM. Restricted to \
+        animation declarations (joint, clip/track, spin, open_close, wave, flap, idle).")]
+    async fn animate(
+        &self,
+        Parameters(p): Parameters<AnimateArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["animate".to_string(), p.input.to_string_lossy().into_owned(), p.prompt];
+        push_path_opt(&mut args, "--out", p.out);
+        push_path_opt(&mut args, "--dsl-out", p.dsl_out);
+        p.common.push(&mut args);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Repair validation errors in an existing .mog via the LLM. Runs the \
+        validator first, feeds each diagnostic back to the model, and re-validates. No-op if the \
+        file already validates.")]
+    async fn repair(
+        &self,
+        Parameters(p): Parameters<RepairArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["repair".to_string(), p.input.to_string_lossy().into_owned()];
+        push_path_opt(&mut args, "--out", p.out);
+        push_path_opt(&mut args, "--dsl-out", p.dsl_out);
+        push_flag(&mut args, "--no-build", p.no_build);
+        p.common.push(&mut args);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Generate PBR textures for every material in a .mog (LLM-drawn albedo \
+        + locally-derived normal / metallic-roughness / occlusion). Gemini-only. PNGs are \
+        written next to the .mog and the matching texture attrs spliced into the source.")]
+    async fn textures(
+        &self,
+        Parameters(p): Parameters<TexturesArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["textures".to_string(), p.input.to_string_lossy().into_owned()];
+        push_path_opt(&mut args, "--out", p.out);
+        push_path_opt(&mut args, "--glb", p.glb);
+        push_path_opt(&mut args, "--textures-dir", p.textures_dir);
+        push_opt(&mut args, "--style", p.style);
+        push_opt(&mut args, "--model", p.model);
+        push_flag(&mut args, "--force", p.force);
+        push_flag(&mut args, "--dry-run", p.dry_run);
+        push_flag(&mut args, "--no-build", p.no_build);
+        push_opt(&mut args, "--api-key", p.api_key);
+        push_opt(&mut args, "--zai-api-key", p.zai_api_key);
+        push_flag(&mut args, "--no-pbr", p.no_pbr);
+        push_flag(&mut args, "--no-normal", p.no_normal);
+        push_flag(&mut args, "--no-metallic-roughness", p.no_metallic_roughness);
+        push_flag(&mut args, "--no-occlusion", p.no_occlusion);
+        push_opt(&mut args, "--texture-size", p.texture_size);
+        run_mogen(args).await
+    }
+
+    // -- ops / bench --------------------------------------------------------
+
+    #[tool(description = "Download the latest release from GitHub and replace the running mogen \
+        binary in place. Without `yes=true`, only checks and prints what it would do.")]
+    async fn update(
+        &self,
+        Parameters(p): Parameters<UpdateArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["update".to_string()];
+        push_flag(&mut args, "--yes", p.yes);
+        push_flag(&mut args, "--check", p.check);
+        push_flag(&mut args, "--force", p.force);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Run a suite of prompts through `generate` and report success rate and \
+        mean token cost. Does not write GLBs.")]
+    async fn bench(
+        &self,
+        Parameters(p): Parameters<BenchArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["bench".to_string()];
+        push_path_opt(&mut args, "--prompts", p.prompts);
+        push_opt(&mut args, "--provider", p.provider);
+        push_opt(&mut args, "--model", p.model);
+        push_opt(&mut args, "--thinking", p.thinking);
+        push_opt(&mut args, "--max-repair-iters", p.max_repair_iters);
+        push_opt(&mut args, "--budget-tokens", p.budget_tokens);
+        push_opt(&mut args, "--api-key", p.api_key);
+        push_flag(&mut args, "--no-cache", p.no_cache);
+        run_mogen(args).await
+    }
+
+    // -- moghub -------------------------------------------------------------
+
+    #[tool(description = "Print the signed-in MoGHub user's handle and id. Fails if no session.")]
+    async fn moghub_whoami(
+        &self,
+        Parameters(p): Parameters<ServerOnly>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["moghub".to_string(), "whoami".to_string()];
+        push_opt(&mut args, "--server", p.server);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Browse the public MoGHub discover feed.")]
+    async fn moghub_discover(
+        &self,
+        Parameters(p): Parameters<MoghubDiscoverArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["moghub".to_string(), "discover".to_string()];
+        push_opt(&mut args, "--query", p.query);
+        push_opt(&mut args, "--kind", p.kind);
+        push_opt(&mut args, "--tag", p.tag);
+        push_opt(&mut args, "--limit", p.limit);
+        push_opt(&mut args, "--offset", p.offset);
+        push_flag(&mut args, "--json", p.json);
+        push_opt(&mut args, "--server", p.server);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Print full detail for a MoGHub model. Reference is `<user>/<slug>` \
+        or `@<user>/<slug>`.")]
+    async fn moghub_info(
+        &self,
+        Parameters(p): Parameters<MoghubRefArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["moghub".to_string(), "info".to_string(), p.reference];
+        push_flag(&mut args, "--json", p.json);
+        push_opt(&mut args, "--server", p.server);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Download a MoGHub model's `.mog` files into a directory. Defaults to \
+        the latest version.")]
+    async fn moghub_download(
+        &self,
+        Parameters(p): Parameters<MoghubDownloadArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["moghub".to_string(), "download".to_string(), p.reference];
+        push_opt(&mut args, "--version", p.version);
+        push_path_opt(&mut args, "--out", p.out);
+        push_flag(&mut args, "--entry-only", p.entry_only);
+        push_opt(&mut args, "--server", p.server);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "List comments on a MoGHub model.")]
+    async fn moghub_comments(
+        &self,
+        Parameters(p): Parameters<MoghubRefOnly>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["moghub".to_string(), "comments".to_string(), p.reference];
+        push_opt(&mut args, "--server", p.server);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Post a comment on a MoGHub model. Body accepts BBCode.")]
+    async fn moghub_comment(
+        &self,
+        Parameters(p): Parameters<MoghubCommentArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec![
+            "moghub".to_string(),
+            "comment".to_string(),
+            p.reference,
+            p.body,
+        ];
+        push_opt(&mut args, "--server", p.server);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Like a MoGHub model. Idempotent.")]
+    async fn moghub_like(
+        &self,
+        Parameters(p): Parameters<MoghubRefOnly>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["moghub".to_string(), "like".to_string(), p.reference];
+        push_opt(&mut args, "--server", p.server);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Remove a previously-set like on a MoGHub model.")]
+    async fn moghub_unlike(
+        &self,
+        Parameters(p): Parameters<MoghubRefOnly>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["moghub".to_string(), "unlike".to_string(), p.reference];
+        push_opt(&mut args, "--server", p.server);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "List the signed-in user's MoGHub notifications.")]
+    async fn moghub_notifications(
+        &self,
+        Parameters(p): Parameters<MoghubNotificationsArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec!["moghub".to_string(), "notifications".to_string()];
+        push_flag(&mut args, "--mark-read", p.mark_read);
+        push_opt(&mut args, "--server", p.server);
+        run_mogen(args).await
+    }
+
+    #[tool(description = "Publish a `.mog` to MoGHub. Bundles every locally imported `.mog` \
+        plus referenced PNG/JPG/JPEG/WebP textures. Re-publishing a file with a prior MoGHub \
+        stamp appends a version unless `new=true`.")]
+    async fn moghub_publish(
+        &self,
+        Parameters(p): Parameters<MoghubPublishArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut args = vec![
+            "moghub".to_string(),
+            "publish".to_string(),
+            p.input.to_string_lossy().into_owned(),
+        ];
+        push_opt(&mut args, "--title", p.title);
+        push_opt(&mut args, "--description", p.description);
+        push_opt(&mut args, "--tags", p.tags);
+        push_opt(&mut args, "--license", p.license);
+        push_opt(&mut args, "--visibility", p.visibility);
+        push_opt(&mut args, "--message", p.message);
+        push_path_opt(&mut args, "--thumbnail", p.thumbnail);
+        push_opt(&mut args, "--filename", p.filename);
+        push_flag(&mut args, "--module", p.module);
+        push_flag(&mut args, "--scene", p.scene);
+        push_flag(&mut args, "--new", p.new);
+        push_opt(&mut args, "--server", p.server);
+        run_mogen(args).await
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for MogenMcp {
+    fn get_info(&self) -> ServerInfo {
+        let mut info = ServerInfo::default();
+        info.protocol_version = ProtocolVersion::V_2024_11_05;
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        // `Implementation::from_build_env()` reads `CARGO_*` env vars at
+        // the rmcp crate's compile site, so it reports "rmcp" — build
+        // one ourselves so clients see "mogen" instead.
+        info.server_info = Implementation::from_build_env();
+        info.server_info.name = env!("CARGO_PKG_NAME").to_string();
+        info.server_info.version = env!("CARGO_PKG_VERSION").to_string();
+        info.server_info = info
+            .server_info
+            .with_title("MoGen")
+            .with_description(
+                "Procedural 3D model generator. Compiles `.mog` DSL to glTF/FBX and \
+                drives an LLM-backed generation pipeline.",
+            );
+        info.instructions = Some(
+            "MoGen MCP server. Exposes every `mogen` CLI subcommand as a tool. \
+            Use `build` / `check` / `parse` / `dump_scene` / `inspect` / `thumbnail` for \
+            deterministic compile + introspection of `.mog` files; `generate` / `modify` / \
+            `animate` / `repair` / `textures` to drive mogen's own LLM pipeline; \
+            `moghub_*` for community browse + publish; `update` / `bench` for ops. \
+            Every tool spawns the same `mogen` binary as a subprocess and returns its \
+            stdout + stderr. Paths are relative to the server's working directory."
+                .to_string(),
+        );
+        info
+    }
+}

--- a/crates/mogen/src/commands/mod.rs
+++ b/crates/mogen/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod bench;
 pub(crate) mod build;
 pub(crate) mod generate;
 pub(crate) mod inspect;
+pub(crate) mod mcp;
 pub(crate) mod modify;
 pub(crate) mod moghub;
 pub(crate) mod moghub_publish;

--- a/crates/mogen/src/main.rs
+++ b/crates/mogen/src/main.rs
@@ -16,6 +16,7 @@ use commands::bench::bench;
 use commands::build::build;
 use commands::generate::{generate, GenerateArgs};
 use commands::inspect::{check, dump_scene, inspect, parse_cmd};
+use commands::mcp::run as run_mcp_server;
 use commands::modify::{modify, ModifyArgs};
 use commands::repair::{repair, RepairArgs};
 use commands::textures::textures_cmd;
@@ -260,6 +261,7 @@ fn main() -> ExitCode {
             force,
         }),
         Cmd::ApplyUpdate { plan } => apply_update(plan),
+        Cmd::Mcp => run_mcp_server(),
         Cmd::Bench {
             prompts,
             provider,


### PR DESCRIPTION
## Summary

Adds `mogen mcp`, a stdio Model Context Protocol server that exposes every existing CLI subcommand as an MCP tool. Designed to be launched by an MCP client (Claude Desktop, a custom client, etc.); a separate client implementation will follow.

Built on the official `rmcp` 1.7 SDK with `schemars`-derived JSON input schemas. **23 tools** total:

- **Pipeline**: `build`, `parse`, `check`, `dump_scene`, `inspect`, `thumbnail`
- **LLM-driven**: `generate`, `modify`, `animate`, `repair`, `textures`
- **Ops**: `update`, `bench`
- **MoGHub**: `moghub_whoami`, `moghub_discover`, `moghub_info`, `moghub_download`, `moghub_comments`, `moghub_comment`, `moghub_like`, `moghub_unlike`, `moghub_notifications`, `moghub_publish`

## Why this design

Each tool call **spawns the same `mogen` binary as a child process** and captures its stdout + stderr, rather than calling command functions in-process. Three reasons:

1. Several commands call `std::process::exit(1)` on validation errors (`check`, `auth`, `moghub`). In-process invocation would kill the MCP server itself.
2. Many commands `println!` to stdout. In stdio MCP mode our stdout is the JSON-RPC transport — any stray print would corrupt the protocol. The child writes into a pipe we capture.
3. Future CLI changes (new flags, new subcommands) need no MCP-side refactor — the args forward verbatim.

Tracing is forced to stderr (`with_writer(std::io::stderr)`) so nothing leaks onto stdout. Default log filter is `warn` when `RUST_LOG` is unset, for the same reason.

On non-zero child exit, the tool returns a `CallToolResult` with `isError=true` and stderr in the content — so the calling LLM gets the diagnostic, not an opaque RPC failure.

## Test plan

- [x] `cargo build -p mogen` — clean.
- [x] `cargo test -p mogen` — 2 unit + 17 golden tests, all pass.
- [x] Smoke test via hand-rolled JSON-RPC client: `initialize` → `notifications/initialized` → `tools/list` returns all 23 tools with correct schemas → `tools/call` for `check` on a passing `.mog` returns success with the expected `ok: ... (7 nodes, 2 materials)` summary.
- [x] Error paths: `check` on `tests/broken/clip_bad.mog` returns `isError=true` with JSON diagnostics; `build` on a missing path returns `isError=true` with the OS error from stderr.
- [x] `serverInfo` reports `name: "mogen"`, `title: "MoGen"`, `version: 0.1.5` (not `rmcp` — `Implementation::from_build_env()` reads `CARGO_*` env vars at the rmcp crate's compile site, so we build the struct ourselves).
- [ ] Wire up a real MCP client (forthcoming, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)