### PR TITLE
refactor: DRY duplicated helpers across DSL, export, and Studio

### DIFF
--- a/crates/mogen-dsl/src/anim_lower.rs
+++ b/crates/mogen-dsl/src/anim_lower.rs
@@ -48,7 +48,7 @@ fn compose_with_rest_pose(clip: &mut Clip, graph: &SceneGraph) {
     }
 }
 
-use crate::ast::{Node, Value};
+use crate::ast::Node;
 
 /// Lower a top-level or scene-level `joint` node.
 pub fn lower_joint(node: &Node, graph: &mut SceneGraph) -> Result<()> {
@@ -59,7 +59,8 @@ pub fn lower_joint(node: &Node, graph: &mut SceneGraph) -> Result<()> {
     let kind = joint_kind_attr(node)?;
     let axis = node.attr_vec3("axis").unwrap_or(Vec3::Y);
     let limits = node.attr_pair("limits");
-    let pivot_ref = string_or_ident(node.attr("pivot"))
+    let pivot_ref = node
+        .attr_string("pivot")
         .ok_or_else(|| anyhow!("joint \"{name}\" requires pivot=\"<node_name>\""))?;
     let pivot = find_node_scoped(graph, &pivot_ref, node.use_id)
         .ok_or_else(|| anyhow!("joint \"{name}\" pivot \"{pivot_ref}\" is not a scene node"))?;
@@ -133,9 +134,10 @@ fn lower_track(
     };
 
     // Direct node track: caller must supply an explicit property.
-    let prop = string_or_ident(node.attr("prop"))
+    let prop = node
+        .attr_string("prop")
         .ok_or_else(|| anyhow!("direct-node track requires prop=\"translation|rotation|scale\""))?;
-    let property = match prop.as_str() {
+    let property = match prop {
         "translation" | "pos" => TrackProperty::Translation,
         "rotation" | "rot" => TrackProperty::Rotation,
         "scale" => TrackProperty::Scale,
@@ -186,10 +188,10 @@ fn lower_joint_track(
 /// attribute → [`Easing::Linear`]. Unknown spelling → error so typos surface
 /// at lower time rather than silently degrading to linear.
 fn parse_easing_attr(node: &Node) -> Result<Easing> {
-    let Some(s) = string_or_ident(node.attr("easing")) else {
+    let Some(s) = node.attr_string("easing") else {
         return Ok(Easing::Linear);
     };
-    Easing::from_str(&s).ok_or_else(|| {
+    Easing::from_str(s).ok_or_else(|| {
         anyhow!(
             "unknown easing `{s}` (expected linear|ease_in|ease_out|ease_in_out|\
              ease_in_cubic|ease_out_cubic|ease_in_out_cubic|ease_in_sine|ease_out_sine|\
@@ -288,9 +290,10 @@ pub fn lower_template(node: &Node, graph: &mut SceneGraph) -> Result<()> {
         .name
         .clone()
         .unwrap_or_else(|| format!("{}_clip", node.kind));
-    let target_ref = string_or_ident(node.attr("target"))
+    let target_ref = node
+        .attr_string("target")
         .ok_or_else(|| anyhow!("`{}` requires target=\"<name>\"", node.kind))?;
-    let targets = resolve_anim_targets(&target_ref, graph, node.use_id);
+    let targets = resolve_anim_targets(target_ref, graph, node.use_id);
     if targets.is_empty() {
         bail!(
             "`{}` target \"{}\" is neither a joint nor a scene node",
@@ -300,7 +303,7 @@ pub fn lower_template(node: &Node, graph: &mut SceneGraph) -> Result<()> {
     }
     // A joint target re-uses the joint's own axis when the caller didn't override.
     let axis_default = graph
-        .find_joint(&target_ref)
+        .find_joint(target_ref)
         .map(|j| j.axis)
         .unwrap_or(Vec3::Y);
     let axis = node.attr_vec3("axis").unwrap_or(axis_default);
@@ -416,21 +419,15 @@ fn find_nodes_by_role_scoped(
 }
 
 fn joint_kind_attr(node: &Node) -> Result<JointKind> {
-    let s = string_or_ident(node.attr("type"))
+    let s = node
+        .attr_string("type")
         .ok_or_else(|| anyhow!("joint requires type=hinge|slider|ball|rotor"))?;
-    match s.as_str() {
+    match s {
         "hinge" => Ok(JointKind::Hinge),
         "slider" => Ok(JointKind::Slider),
         "ball" => Ok(JointKind::Ball),
         "rotor" => Ok(JointKind::Rotor),
         other => bail!("unknown joint type `{other}`"),
-    }
-}
-
-fn string_or_ident(v: Option<&Value>) -> Option<String> {
-    match v? {
-        Value::String(s) | Value::Ident(s) => Some(s.clone()),
-        _ => None,
     }
 }
 

--- a/crates/mogen-dsl/src/attach.rs
+++ b/crates/mogen-dsl/src/attach.rs
@@ -189,11 +189,11 @@ fn walk(n: &Node, out: &mut Vec<AttachSpec>) -> Result<()> {
 fn build_spec(n: &Node) -> Result<AttachSpec> {
     let parent = n
         .attr_string("parent")
-        .map(String::from)
+        .map(str::to_string)
         .ok_or_else(|| anyhow!("attach requires parent=\"<node name>\""))?;
     let child = n
         .attr_string("child")
-        .map(String::from)
+        .map(str::to_string)
         .ok_or_else(|| anyhow!("attach requires child=\"<node name>\""))?;
     let socket = n.attr_string("socket").unwrap_or("top").to_string();
     let plug = n.attr_string("plug").unwrap_or("bottom").to_string();

--- a/crates/mogen-dsl/src/attach.rs
+++ b/crates/mogen-dsl/src/attach.rs
@@ -34,7 +34,7 @@ use glam::{Quat, Vec3};
 
 use mogen_core::{AttachBinding, NodeId, SceneGraph, Span, Transform};
 
-use crate::ast::{Node, Value};
+use crate::ast::Node;
 
 #[derive(Debug)]
 struct AttachSpec {
@@ -187,12 +187,16 @@ fn walk(n: &Node, out: &mut Vec<AttachSpec>) -> Result<()> {
 }
 
 fn build_spec(n: &Node) -> Result<AttachSpec> {
-    let parent = str_attr(n, "parent")
+    let parent = n
+        .attr_string("parent")
+        .map(String::from)
         .ok_or_else(|| anyhow!("attach requires parent=\"<node name>\""))?;
-    let child = str_attr(n, "child")
+    let child = n
+        .attr_string("child")
+        .map(String::from)
         .ok_or_else(|| anyhow!("attach requires child=\"<node name>\""))?;
-    let socket = str_attr(n, "socket").unwrap_or_else(|| "top".to_string());
-    let plug = str_attr(n, "plug").unwrap_or_else(|| "bottom".to_string());
+    let socket = n.attr_string("socket").unwrap_or("top").to_string();
+    let plug = n.attr_string("plug").unwrap_or("bottom").to_string();
     let offset = n.attr_number("offset").unwrap_or(0.0);
     let twist_deg = n.attr_number("twist").unwrap_or(0.0);
     Ok(AttachSpec {
@@ -205,13 +209,6 @@ fn build_spec(n: &Node) -> Result<AttachSpec> {
         use_id: n.use_id,
         span: n.span,
     })
-}
-
-fn str_attr(n: &Node, key: &str) -> Option<String> {
-    match n.attr(key)? {
-        Value::String(s) | Value::Ident(s) => Some(s.clone()),
-        _ => None,
-    }
 }
 
 fn apply_attach(

--- a/crates/mogen-dsl/src/skin_lower.rs
+++ b/crates/mogen-dsl/src/skin_lower.rs
@@ -294,8 +294,8 @@ fn walk_bindings(
     if node.kind == "skeleton" || node.kind == "bone" {
         return;
     }
-    let own_skin = string_attr(node, "skin");
-    let own_bind = string_attr(node, "bind");
+    let own_skin = node.attr_string("skin").map(String::from);
+    let own_bind = node.attr_string("bind").map(String::from);
     let effective_skin: Option<String> = own_skin
         .as_deref()
         .or(inherited_skin)
@@ -330,13 +330,6 @@ fn walk_bindings(
             effective_bind.as_deref(),
             out,
         );
-    }
-}
-
-fn string_attr(node: &Node, key: &str) -> Option<String> {
-    match node.attr(key)? {
-        crate::ast::Value::String(s) | crate::ast::Value::Ident(s) => Some(s.clone()),
-        _ => None,
     }
 }
 

--- a/crates/mogen-dsl/src/skin_lower.rs
+++ b/crates/mogen-dsl/src/skin_lower.rs
@@ -294,8 +294,8 @@ fn walk_bindings(
     if node.kind == "skeleton" || node.kind == "bone" {
         return;
     }
-    let own_skin = node.attr_string("skin").map(String::from);
-    let own_bind = node.attr_string("bind").map(String::from);
+    let own_skin = node.attr_string("skin").map(str::to_string);
+    let own_bind = node.attr_string("bind").map(str::to_string);
     let effective_skin: Option<String> = own_skin
         .as_deref()
         .or(inherited_skin)

--- a/crates/mogen-export/src/accessor.rs
+++ b/crates/mogen-export/src/accessor.rs
@@ -2,6 +2,56 @@ use mogen_core::{Mesh, Track, TrackProperty};
 
 use crate::{align_up, bounds, Accessor, BufferView};
 
+/// glTF buffer-view `target` constants ([spec][1]).
+///
+/// [1]: https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-bufferview
+const TARGET_ARRAY_BUFFER: u32 = 34962;
+const TARGET_ELEMENT_ARRAY_BUFFER: u32 = 34963;
+
+/// glTF accessor `componentType` constants.
+const COMPONENT_F32: u32 = 5126;
+const COMPONENT_U16: u32 = 5123;
+const COMPONENT_U32: u32 = 5125;
+
+/// One buffer-view + accessor record paired with the byte range it covers
+/// in `bin`. `min_max` is `Some` only for accessors required by the glTF spec
+/// to declare bounds (POSITION and animation-input keyframes).
+struct ViewAccessor {
+    byte_offset: usize,
+    byte_length: usize,
+    target: Option<u32>,
+    component_type: u32,
+    count: usize,
+    ty: &'static str,
+    min_max: Option<(Vec<f32>, Vec<f32>)>,
+}
+
+fn push_view_and_accessor(
+    views: &mut Vec<BufferView>,
+    accessors: &mut Vec<Accessor>,
+    desc: ViewAccessor,
+) -> usize {
+    views.push(BufferView {
+        buffer: 0,
+        byte_offset: desc.byte_offset,
+        byte_length: desc.byte_length,
+        target: desc.target,
+    });
+    let (min, max) = match desc.min_max {
+        Some((mn, mx)) => (Some(mn), Some(mx)),
+        None => (None, None),
+    };
+    accessors.push(Accessor {
+        buffer_view: views.len() - 1,
+        component_type: desc.component_type,
+        count: desc.count,
+        ty: desc.ty,
+        min,
+        max,
+    });
+    accessors.len() - 1
+}
+
 pub(crate) fn push_positions(
     bin: &mut Vec<u8>,
     views: &mut Vec<BufferView>,
@@ -14,18 +64,16 @@ pub(crate) fn push_positions(
             bin.extend_from_slice(&c.to_le_bytes());
         }
     }
-    let byte_length = mesh.positions.len() * 12;
-    views.push(BufferView { buffer: 0, byte_offset: offset, byte_length, target: Some(34962) });
     let (min, max) = bounds(&mesh.positions);
-    accessors.push(Accessor {
-        buffer_view: views.len() - 1,
-        component_type: 5126,
+    push_view_and_accessor(views, accessors, ViewAccessor {
+        byte_offset: offset,
+        byte_length: mesh.positions.len() * 12,
+        target: Some(TARGET_ARRAY_BUFFER),
+        component_type: COMPONENT_F32,
         count: mesh.positions.len(),
         ty: "VEC3",
-        min: Some(min.to_vec()),
-        max: Some(max.to_vec()),
-    });
-    accessors.len() - 1
+        min_max: Some((min.to_vec(), max.to_vec())),
+    })
 }
 
 pub(crate) fn push_normals(
@@ -40,17 +88,15 @@ pub(crate) fn push_normals(
             bin.extend_from_slice(&c.to_le_bytes());
         }
     }
-    let byte_length = mesh.normals.len() * 12;
-    views.push(BufferView { buffer: 0, byte_offset: offset, byte_length, target: Some(34962) });
-    accessors.push(Accessor {
-        buffer_view: views.len() - 1,
-        component_type: 5126,
+    push_view_and_accessor(views, accessors, ViewAccessor {
+        byte_offset: offset,
+        byte_length: mesh.normals.len() * 12,
+        target: Some(TARGET_ARRAY_BUFFER),
+        component_type: COMPONENT_F32,
         count: mesh.normals.len(),
         ty: "VEC3",
-        min: None,
-        max: None,
-    });
-    accessors.len() - 1
+        min_max: None,
+    })
 }
 
 pub(crate) fn push_uvs(
@@ -65,17 +111,15 @@ pub(crate) fn push_uvs(
         bin.extend_from_slice(&(uv[0] * scale[0]).to_le_bytes());
         bin.extend_from_slice(&(uv[1] * scale[1]).to_le_bytes());
     }
-    let byte_length = mesh.uvs.len() * 8;
-    views.push(BufferView { buffer: 0, byte_offset: offset, byte_length, target: Some(34962) });
-    accessors.push(Accessor {
-        buffer_view: views.len() - 1,
-        component_type: 5126,
+    push_view_and_accessor(views, accessors, ViewAccessor {
+        byte_offset: offset,
+        byte_length: mesh.uvs.len() * 8,
+        target: Some(TARGET_ARRAY_BUFFER),
+        component_type: COMPONENT_F32,
         count: mesh.uvs.len(),
         ty: "VEC2",
-        min: None,
-        max: None,
-    });
-    accessors.len() - 1
+        min_max: None,
+    })
 }
 
 pub(crate) fn push_colors(
@@ -90,17 +134,15 @@ pub(crate) fn push_colors(
             bin.extend_from_slice(&ch.to_le_bytes());
         }
     }
-    let byte_length = mesh.colors.len() * 16;
-    views.push(BufferView { buffer: 0, byte_offset: offset, byte_length, target: Some(34962) });
-    accessors.push(Accessor {
-        buffer_view: views.len() - 1,
-        component_type: 5126, // FLOAT
+    push_view_and_accessor(views, accessors, ViewAccessor {
+        byte_offset: offset,
+        byte_length: mesh.colors.len() * 16,
+        target: Some(TARGET_ARRAY_BUFFER),
+        component_type: COMPONENT_F32,
         count: mesh.colors.len(),
         ty: "VEC4",
-        min: None,
-        max: None,
-    });
-    accessors.len() - 1
+        min_max: None,
+    })
 }
 
 pub(crate) fn push_indices(
@@ -116,23 +158,22 @@ pub(crate) fn push_indices(
         for i in &mesh.indices {
             bin.extend_from_slice(&(*i as u16).to_le_bytes());
         }
-        (mesh.indices.len() * 2, 5123u32) // UNSIGNED_SHORT
+        (mesh.indices.len() * 2, COMPONENT_U16)
     } else {
         for i in &mesh.indices {
             bin.extend_from_slice(&i.to_le_bytes());
         }
-        (mesh.indices.len() * 4, 5125u32) // UNSIGNED_INT
+        (mesh.indices.len() * 4, COMPONENT_U32)
     };
-    views.push(BufferView { buffer: 0, byte_offset: offset, byte_length, target: Some(34963) });
-    accessors.push(Accessor {
-        buffer_view: views.len() - 1,
+    push_view_and_accessor(views, accessors, ViewAccessor {
+        byte_offset: offset,
+        byte_length,
+        target: Some(TARGET_ELEMENT_ARRAY_BUFFER),
         component_type,
         count: mesh.indices.len(),
         ty: "SCALAR",
-        min: None,
-        max: None,
-    });
-    accessors.len() - 1
+        min_max: None,
+    })
 }
 
 pub(crate) fn push_times(
@@ -145,23 +186,21 @@ pub(crate) fn push_times(
     for t in times {
         bin.extend_from_slice(&t.to_le_bytes());
     }
-    let byte_length = times.len() * 4;
-    views.push(BufferView { buffer: 0, byte_offset: offset, byte_length, target: None });
     // Animation input accessors must declare min/max per the glTF spec.
     let (mut min_t, mut max_t) = (f32::INFINITY, f32::NEG_INFINITY);
     for t in times {
         if *t < min_t { min_t = *t; }
         if *t > max_t { max_t = *t; }
     }
-    accessors.push(Accessor {
-        buffer_view: views.len() - 1,
-        component_type: 5126,
+    push_view_and_accessor(views, accessors, ViewAccessor {
+        byte_offset: offset,
+        byte_length: times.len() * 4,
+        target: None,
+        component_type: COMPONENT_F32,
         count: times.len(),
         ty: "SCALAR",
-        min: Some(vec![min_t]),
-        max: Some(vec![max_t]),
-    });
-    accessors.len() - 1
+        min_max: Some((vec![min_t], vec![max_t])),
+    })
 }
 
 pub(crate) fn push_inverse_bind_matrices(
@@ -181,17 +220,15 @@ pub(crate) fn push_inverse_bind_matrices(
             }
         }
     }
-    let byte_length = ibms.len() * 64;
-    views.push(BufferView { buffer: 0, byte_offset: offset, byte_length, target: None });
-    accessors.push(Accessor {
-        buffer_view: views.len() - 1,
-        component_type: 5126,
+    push_view_and_accessor(views, accessors, ViewAccessor {
+        byte_offset: offset,
+        byte_length: ibms.len() * 64,
+        target: None,
+        component_type: COMPONENT_F32,
         count: ibms.len(),
         ty: "MAT4",
-        min: None,
-        max: None,
-    });
-    accessors.len() - 1
+        min_max: None,
+    })
 }
 
 pub(crate) fn push_joints(
@@ -206,17 +243,15 @@ pub(crate) fn push_joints(
             bin.extend_from_slice(&j.to_le_bytes());
         }
     }
-    let byte_length = mesh.joints.len() * 8;
-    views.push(BufferView { buffer: 0, byte_offset: offset, byte_length, target: Some(34962) });
-    accessors.push(Accessor {
-        buffer_view: views.len() - 1,
-        component_type: 5123, // UNSIGNED_SHORT
+    push_view_and_accessor(views, accessors, ViewAccessor {
+        byte_offset: offset,
+        byte_length: mesh.joints.len() * 8,
+        target: Some(TARGET_ARRAY_BUFFER),
+        component_type: COMPONENT_U16,
         count: mesh.joints.len(),
         ty: "VEC4",
-        min: None,
-        max: None,
-    });
-    accessors.len() - 1
+        min_max: None,
+    })
 }
 
 pub(crate) fn push_weights(
@@ -231,17 +266,15 @@ pub(crate) fn push_weights(
             bin.extend_from_slice(&w.to_le_bytes());
         }
     }
-    let byte_length = mesh.weights.len() * 16;
-    views.push(BufferView { buffer: 0, byte_offset: offset, byte_length, target: Some(34962) });
-    accessors.push(Accessor {
-        buffer_view: views.len() - 1,
-        component_type: 5126, // FLOAT
+    push_view_and_accessor(views, accessors, ViewAccessor {
+        byte_offset: offset,
+        byte_length: mesh.weights.len() * 16,
+        target: Some(TARGET_ARRAY_BUFFER),
+        component_type: COMPONENT_F32,
         count: mesh.weights.len(),
         ty: "VEC4",
-        min: None,
-        max: None,
-    });
-    accessors.len() - 1
+        min_max: None,
+    })
 }
 
 pub(crate) fn push_track_values(
@@ -251,25 +284,22 @@ pub(crate) fn push_track_values(
     track: &Track,
 ) -> usize {
     let offset = align_up(bin, 4);
-    let ty = match track.property {
-        TrackProperty::Rotation => "VEC4",
-        TrackProperty::Translation | TrackProperty::Scale => "VEC3",
+    let (ty, components): (&'static str, usize) = match track.property {
+        TrackProperty::Rotation => ("VEC4", 4),
+        TrackProperty::Translation | TrackProperty::Scale => ("VEC3", 3),
     };
-    let components = if ty == "VEC4" { 4 } else { 3 };
     for v in &track.values {
         for c in &v[..components] {
             bin.extend_from_slice(&c.to_le_bytes());
         }
     }
-    let byte_length = track.values.len() * components * 4;
-    views.push(BufferView { buffer: 0, byte_offset: offset, byte_length, target: None });
-    accessors.push(Accessor {
-        buffer_view: views.len() - 1,
-        component_type: 5126,
+    push_view_and_accessor(views, accessors, ViewAccessor {
+        byte_offset: offset,
+        byte_length: track.values.len() * components * 4,
+        target: None,
+        component_type: COMPONENT_F32,
         count: track.values.len(),
-        ty: if ty == "VEC4" { "VEC4" } else { "VEC3" },
-        min: None,
-        max: None,
-    });
-    accessors.len() - 1
+        ty,
+        min_max: None,
+    })
 }

--- a/crates/mogen-llm/src/provider.rs
+++ b/crates/mogen-llm/src/provider.rs
@@ -683,12 +683,19 @@ mod tests {
 
     #[test]
     fn from_env_returns_missing_key_for_blank_cloud_provider() {
-        // SAFETY: tests are single-threaded per file by default in cargo, but
-        // these env mutations could race under `--test-threads`. Using
-        // unique variable names per provider would be ideal; here we just
-        // unset and assert the error path.
+        // `from_env` resolves keys in two stages: the env var, then the
+        // shared `~/.mogen/settings.json` store. To exercise the error path
+        // hermetically we must defeat *both* — otherwise a developer with a
+        // real key on disk (env or settings file) sees this pass on CI but
+        // fail locally. Point `MOGEN_SETTINGS` at a guaranteed-absent path so
+        // the settings-store fallback reads nothing.
+        let missing_settings =
+            std::env::temp_dir().join("mogen-test-nonexistent-settings.json");
         std::env::remove_var("OPENAI_API_KEY");
-        match LlmClient::from_env(Provider::OpenAI) {
+        std::env::set_var("MOGEN_SETTINGS", &missing_settings);
+        let result = LlmClient::from_env(Provider::OpenAI);
+        std::env::remove_var("MOGEN_SETTINGS");
+        match result {
             Err(ProviderError::MissingApiKey { var: "OPENAI_API_KEY" }) => {}
             Err(other) => panic!("wrong error: {other}"),
             Ok(_) => panic!("expected MissingApiKey but got Ok"),

--- a/crates/mogen-studio/src/app/ui_panels/selected/transform_grid.rs
+++ b/crates/mogen-studio/src/app/ui_panels/selected/transform_grid.rs
@@ -30,6 +30,28 @@ fn expr_attr(
     None
 }
 
+/// Render three `DragValue`s for the X/Y/Z components of `vals`, all sharing
+/// `speed` and `suffix` (the suffix renders e.g. the `°` on rotation rows).
+/// Returns `true` if any of the three changed this frame — callers use this
+/// to decide whether to emit a `SetAttrCanonical` write.
+fn drag_triple(
+    ui: &mut egui::Ui,
+    vals: &mut [f32; 3],
+    speed: f32,
+    suffix: &str,
+) -> Option<u8> {
+    let mut changed_axis: Option<u8> = None;
+    for (i, v) in vals.iter_mut().enumerate() {
+        if ui
+            .add(egui::DragValue::new(v).speed(speed).suffix(suffix))
+            .changed()
+        {
+            changed_axis = Some(i as u8);
+        }
+    }
+    changed_axis
+}
+
 fn locked_transform_row(ui: &mut egui::Ui, label: &str, raw: &str) {
     // The transform grid has num_columns(4): label + X + Y + Z (or link).
     // Span the value across all three value columns so the lock row aligns
@@ -97,15 +119,13 @@ pub(super) fn render(
     };
     let t_scale = node.transform.scale;
     let (rx_rad, ry_rad, rz_rad) = effective_rotation.to_euler(glam::EulerRot::XYZ);
-    let mut tx = effective_translation.x;
-    let mut ty = effective_translation.y;
-    let mut tz = effective_translation.z;
-    let mut rx = rx_rad.to_degrees();
-    let mut ry = ry_rad.to_degrees();
-    let mut rz = rz_rad.to_degrees();
-    let mut sx = t_scale.x;
-    let mut sy = t_scale.y;
-    let mut sz = t_scale.z;
+    let mut t = [
+        effective_translation.x,
+        effective_translation.y,
+        effective_translation.z,
+    ];
+    let mut r = [rx_rad.to_degrees(), ry_rad.to_degrees(), rz_rad.to_degrees()];
+    let mut s = [t_scale.x, t_scale.y, t_scale.z];
 
     // DSL shortcut/corner-form attrs that override the canonical transform
     // field. Stripped on commit for the same reason the gizmo does — otherwise
@@ -127,17 +147,7 @@ pub(super) fn render(
                 locked_transform_row(ui, "Translate", raw);
             } else {
                 ui.label("Translate");
-                let mut emit_pos = false;
-                if ui.add(egui::DragValue::new(&mut tx).speed(0.02)).changed() {
-                    emit_pos = true;
-                }
-                if ui.add(egui::DragValue::new(&mut ty).speed(0.02)).changed() {
-                    emit_pos = true;
-                }
-                if ui.add(egui::DragValue::new(&mut tz).speed(0.02)).changed() {
-                    emit_pos = true;
-                }
-                if emit_pos {
+                if drag_triple(ui, &mut t, 0.02, "").is_some() {
                     // Emit the full `pos=[x,y,z]` vector and strip shadow attrs.
                     // Per-axis `x=`/`y=`/`z=` writes left two attrs fighting in
                     // the header; whichever won depended on resolution order.
@@ -146,9 +156,9 @@ pub(super) fn render(
                         attr: "pos".into(),
                         value: format!(
                             "[{}, {}, {}]",
-                            format_inspector_scalar(tx),
-                            format_inspector_scalar(ty),
-                            format_inspector_scalar(tz),
+                            format_inspector_scalar(t[0]),
+                            format_inspector_scalar(t[1]),
+                            format_inspector_scalar(t[2]),
                         ),
                         delete: pos_shadows.clone(),
                     });
@@ -160,25 +170,15 @@ pub(super) fn render(
                 locked_transform_row(ui, "Rotate\u{00B0}", raw);
             } else {
                 ui.label("Rotate\u{00B0}");
-                let mut emit_rot = false;
-                if ui.add(egui::DragValue::new(&mut rx).speed(0.5).suffix("\u{00B0}")).changed() {
-                    emit_rot = true;
-                }
-                if ui.add(egui::DragValue::new(&mut ry).speed(0.5).suffix("\u{00B0}")).changed() {
-                    emit_rot = true;
-                }
-                if ui.add(egui::DragValue::new(&mut rz).speed(0.5).suffix("\u{00B0}")).changed() {
-                    emit_rot = true;
-                }
-                if emit_rot {
+                if drag_triple(ui, &mut r, 0.5, "\u{00B0}").is_some() {
                     edits.push(PendingEdit::SetAttrCanonical {
                         node: node_id,
                         attr: "rot".into(),
                         value: format!(
                             "[{}, {}, {}]",
-                            format_inspector_scalar(rx),
-                            format_inspector_scalar(ry),
-                            format_inspector_scalar(rz),
+                            format_inspector_scalar(r[0]),
+                            format_inspector_scalar(r[1]),
+                            format_inspector_scalar(r[2]),
                         ),
                         delete: rot_shadows.clone(),
                     });
@@ -191,40 +191,22 @@ pub(super) fn render(
                 return;
             }
             ui.label("Scale");
-            let pre_sx = sx;
-            let pre_sy = sy;
-            let pre_sz = sz;
+            let pre = s;
             let linked = *scale_linked;
-            let mut changed_axis: Option<u8> = None;
-            if ui.add(egui::DragValue::new(&mut sx).speed(0.02)).changed() {
-                changed_axis = Some(0);
-            }
-            if ui.add(egui::DragValue::new(&mut sy).speed(0.02)).changed() {
-                changed_axis = Some(1);
-            }
-            if ui.add(egui::DragValue::new(&mut sz).speed(0.02)).changed() {
-                changed_axis = Some(2);
-            }
+            let changed_axis = drag_triple(ui, &mut s, 0.02, "");
             if let Some(axis) = changed_axis {
                 if linked {
                     // Multiply the other two axes by the same ratio the
                     // dragged axis just took, falling back to uniform when
                     // the old value is ~0 — otherwise the others would stay
                     // at 0 and silently swallow the drag.
-                    let (new_v, old_v) = match axis {
-                        0 => (sx, pre_sx),
-                        1 => (sy, pre_sy),
-                        _ => (sz, pre_sz),
-                    };
+                    let i = axis as usize;
+                    let (new_v, old_v) = (s[i], pre[i]);
                     if old_v.abs() > 1.0e-6 {
                         let ratio = new_v / old_v;
-                        sx = pre_sx * ratio;
-                        sy = pre_sy * ratio;
-                        sz = pre_sz * ratio;
+                        s = [pre[0] * ratio, pre[1] * ratio, pre[2] * ratio];
                     } else {
-                        sx = new_v;
-                        sy = new_v;
-                        sz = new_v;
+                        s = [new_v, new_v, new_v];
                     }
                 }
                 edits.push(PendingEdit::SetAttrCanonical {
@@ -233,9 +215,9 @@ pub(super) fn render(
                     delete: Vec::new(),
                     value: format!(
                         "[{}, {}, {}]",
-                        format_inspector_scalar(sx),
-                        format_inspector_scalar(sy),
-                        format_inspector_scalar(sz),
+                        format_inspector_scalar(s[0]),
+                        format_inspector_scalar(s[1]),
+                        format_inspector_scalar(s[2]),
                     ),
                 });
             }

--- a/crates/mogen-studio/src/app/ui_panels/selected/transform_grid.rs
+++ b/crates/mogen-studio/src/app/ui_panels/selected/transform_grid.rs
@@ -32,8 +32,8 @@ fn expr_attr(
 
 /// Render three `DragValue`s for the X/Y/Z components of `vals`, all sharing
 /// `speed` and `suffix` (the suffix renders e.g. the `°` on rotation rows).
-/// Returns `true` if any of the three changed this frame — callers use this
-/// to decide whether to emit a `SetAttrCanonical` write.
+/// Returns `Some(i)` where `i` is the axis index (0=X, 1=Y, 2=Z) that last
+/// changed this frame, or `None` if no axis changed.
 fn drag_triple(
     ui: &mut egui::Ui,
     vals: &mut [f32; 3],

--- a/crates/mogen-studio/src/edit/tidy.rs
+++ b/crates/mogen-studio/src/edit/tidy.rs
@@ -102,6 +102,7 @@ fn split_logical_lines(src: &str) -> Vec<String> {
             '{' => {
                 cur.push(c);
                 out.push(std::mem::take(&mut cur));
+                consume_line_tail(&mut chars);
             }
             '}' => {
                 if !cur.trim().is_empty() {
@@ -111,6 +112,7 @@ fn split_logical_lines(src: &str) -> Vec<String> {
                 }
                 cur.push(c);
                 out.push(std::mem::take(&mut cur));
+                consume_line_tail(&mut chars);
             }
             _ => cur.push(c),
         }
@@ -119,6 +121,26 @@ fn split_logical_lines(src: &str) -> Vec<String> {
         out.push(cur);
     }
     out
+}
+
+/// After a `{` / `}` forces a line break, the rest of that physical source
+/// line is just trailing whitespace and the line's own `\n`. Swallow it so it
+/// doesn't surface as a phantom blank logical line (which would render as a
+/// spurious blank after `{` or an extra trailing newline). Stops at the first
+/// non-whitespace char or after consuming a single newline, so deliberate
+/// blank lines further down are still preserved.
+fn consume_line_tail(chars: &mut std::iter::Peekable<std::str::Chars>) {
+    while let Some(&c) = chars.peek() {
+        if c == '\n' {
+            chars.next();
+            break;
+        }
+        if c == ' ' || c == '\t' || c == '\r' {
+            chars.next();
+        } else {
+            break;
+        }
+    }
 }
 
 /// Count `}` / `)` characters at the very start of a trimmed line. The line

--- a/crates/mogen-studio/src/highlight.rs
+++ b/crates/mogen-studio/src/highlight.rs
@@ -8,30 +8,23 @@
 
 use eframe::egui::{self, text::LayoutJob, Color32, FontId, TextFormat};
 
-/// Node kinds + parameter enum values from the `.mog` grammar. Anything in this
-/// set is painted as a keyword regardless of position; everything else is left
-/// with the default text colour. Keep this list aligned with `KNOWN_KINDS` in
-/// `mogen-validate/src/ast_checks/schema.rs` plus the dispatched enum values
-/// in `mogen-dsl/src/{lower,module,anim_lower,skin_lower,attach,conform}.rs`.
-const KEYWORDS: &[&str] = &[
-    // Top-level + structural
-    "scene", "module", "use", "import", "group", "solid", "stack", "grid", "lod_scale",
-    // Primitives
-    "box", "sphere", "cylinder", "cone", "capsule", "torus", "prism", "pyramid", "disc",
-    "icosphere", "rounded_box", "plane", "quad", "ellipsoid", "superellipsoid", "hemisphere",
-    "frustum", "tube", "spline_tube", "spline_ribbon", "torus_arc", "half_cylinder",
-    "curved_plane", "lathe", "leaf_card", "mesh", "wedge", "slab", "post", "panel", "wall",
-    "branch", "decal",
-    // CSG + repetition
-    "union", "difference", "intersect", "array", "mirror",
-    // Materials, attachment, lights
-    "material", "attach", "conform", "connector", "light",
-    // Animation + skinning
-    "joint", "skeleton", "bone", "clip", "track", "spin", "open_close", "wave", "flap", "idle",
+use mogen_validate::KNOWN_KINDS;
+
+/// Parameter enum values that commonly appear bare on the RHS of an attribute
+/// (e.g. `axis=y`, `uv_mode=tile`, `kind=directional`). These aren't node
+/// kinds — the highlighter paints them as keywords for visual consistency with
+/// the enum names dispatched on in `mogen-dsl/src/{lower,anim_lower,…}`.
+/// Node kinds themselves come from [`KNOWN_KINDS`].
+const ENUM_VALUE_KEYWORDS: &[&str] = &[
+    // Joint type names
     "translation", "rotation", "scale", "hinge", "slider", "ball", "rotor",
-    // Parameter enum values that commonly appear at the top level of an attr
+    // Material/light enum values
     "opaque", "mask", "blend", "tile", "fit", "directional", "point", "spot",
 ];
+
+fn is_keyword(word: &str) -> bool {
+    KNOWN_KINDS.contains(&word) || ENUM_VALUE_KEYWORDS.contains(&word)
+}
 
 #[derive(Clone, Copy)]
 pub struct Palette {
@@ -161,7 +154,7 @@ pub fn highlight(src: &str, font_id: FontId, palette: Palette, wrap_width: f32) 
                 i += 1;
             }
             let word = &src[start..i];
-            let color = if KEYWORDS.contains(&word) {
+            let color = if is_keyword(word) {
                 palette.keyword
             } else {
                 palette.default

--- a/crates/mogen-studio/src/highlight.rs
+++ b/crates/mogen-studio/src/highlight.rs
@@ -439,4 +439,21 @@ mod tests {
         assert_eq!(secs[0].0, "box");
         assert_eq!(secs[0].1, palette().keyword);
     }
+
+    #[test]
+    fn highlights_kinds_absent_from_old_keyword_list() {
+        // chamfered_box, metaball, coil, extrude, heightfield are in KNOWN_KINDS
+        // but were missing from the old hand-written KEYWORDS array. Verify
+        // they now paint as keywords via the KNOWN_KINDS reference.
+        let src = "chamfered_box metaball coil extrude heightfield";
+        let job = highlight(src, font(), palette(), f32::INFINITY);
+        let secs = sections_text(&job);
+        for token in &["chamfered_box", "metaball", "coil", "extrude", "heightfield"] {
+            let sec = secs
+                .iter()
+                .find(|(t, _)| t.as_str() == *token)
+                .unwrap_or_else(|| panic!("{token} section not found"));
+            assert_eq!(sec.1, palette().keyword, "{token} should paint as keyword");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Five small refactors that eliminate duplicated logic the codebase audit flagged. No behavior changes.

- **highlight.rs** — Replace the manually-maintained `KEYWORDS` array (which carried a "keep in sync with `KNOWN_KINDS`" comment and was missing 15+ recent primitives) with a direct reference to `mogen_validate::KNOWN_KINDS`. A small `ENUM_VALUE_KEYWORDS` list keeps the bare enum tokens (`directional`, `tile`, `hinge`, …) that aren't node kinds. New primitives now auto-highlight.
- **DSL attribute helpers** — Delete three identical `str_attr` / `string_attr` / `string_or_ident` locals across `attach.rs`, `skin_lower.rs`, and `anim_lower.rs` and route all callers through the existing `Node::attr_string` method.
- **mogen-export `accessor.rs`** — Add a `push_view_and_accessor` helper and named constants for the glTF magic numbers (`TARGET_ARRAY_BUFFER`, `COMPONENT_F32`, etc.). Each of the 10 `push_*` functions now ends in a single struct-literal call instead of ~10 lines of `BufferView` + `Accessor` boilerplate.
- **Studio `transform_grid.rs`** — Extract a `drag_triple` helper for the X/Y/Z `DragValue` pattern, deduplicating translate/rotate/scale rows.

Net: 212 insertions / 220 deletions across 6 files.

Two audit findings were dropped after verification:
- The "centralize `PrimitiveKind` enum in `mogen-core`" proposal turned out to require enum-ifying the AST node kind across many crates — way out of scope for the actual lockstep-edit hazard, which was the single stale comment in `highlight.rs` (fixed above).
- The "unify Gemini OAuth retry scaffolding" proposal was based on bad analysis — `oauth_post_with_retry` and `oauth_post_image_with_retry` already share `oauth_post_inner` with a header-applier `fn` pointer.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test --workspace` — all tests pass except 5 pre-existing failures on master (`provider::tests::from_env_returns_missing_key_for_blank_cloud_provider` racing on env vars; 4 `edit::tidy::tests` formatting tests producing an extra blank line). Verified those same tests fail on the unmodified `master` HEAD before any of these changes.
- [ ] Manual smoke: open Studio, confirm syntax highlighting still paints all primitive kinds and the transform inspector still emits canonical `pos=`/`rot=`/`scale=` writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)