### PR TITLE
feat(blob): true SDF + surface-nets organic-mass primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,6 +1336,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fast-surface-nets"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aef9e8d9e33f51d8120a2e997a819f18239ad7c2735e353ade79208a9a1c442"
+dependencies = [
+ "glam 0.29.3",
+ "ndshape",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1645,12 @@ dependencies = [
  "log",
  "xml-rs",
 ]
+
+[[package]]
+name = "glam"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
 
 [[package]]
 name = "glam"
@@ -2655,7 +2671,7 @@ dependencies = [
 name = "mogen-anim"
 version = "0.1.7"
 dependencies = [
- "glam",
+ "glam 0.30.10",
  "mogen-core",
 ]
 
@@ -2663,7 +2679,7 @@ dependencies = [
 name = "mogen-core"
 version = "0.1.7"
 dependencies = [
- "glam",
+ "glam 0.30.10",
  "serde",
 ]
 
@@ -2672,7 +2688,7 @@ name = "mogen-dsl"
 version = "0.1.7"
 dependencies = [
  "anyhow",
- "glam",
+ "glam 0.30.10",
  "mogen-anim",
  "mogen-core",
  "mogen-geom",
@@ -2687,7 +2703,7 @@ version = "0.1.7"
 dependencies = [
  "anyhow",
  "fbxcel",
- "glam",
+ "glam 0.30.10",
  "image",
  "meshopt",
  "mogen-core",
@@ -2705,7 +2721,8 @@ version = "0.1.7"
 dependencies = [
  "anyhow",
  "earcutr",
- "glam",
+ "fast-surface-nets",
+ "glam 0.30.10",
  "gltf",
  "manifold-csg",
  "mogen-core",
@@ -2717,7 +2734,7 @@ version = "0.1.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "glam",
+ "glam 0.30.10",
  "image",
  "mogen-core",
  "mogen-dsl",
@@ -2766,7 +2783,7 @@ name = "mogen-render"
 version = "0.1.7"
 dependencies = [
  "anyhow",
- "glam",
+ "glam 0.30.10",
  "glow 0.14.2",
  "glutin",
  "glutin-winit",
@@ -2789,7 +2806,7 @@ dependencies = [
  "eframe",
  "egui",
  "egui_glow",
- "glam",
+ "glam 0.30.10",
  "glow 0.14.2",
  "image",
  "mogen-core",
@@ -2920,6 +2937,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "ndshape"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975bce586ad637e27f6dc26ee907c07050686a588695bfd64b7873a9d48a700c"
+dependencies = [
+ "static_assertions",
 ]
 
 [[package]]

--- a/crates/mogen-dsl/src/lower.rs
+++ b/crates/mogen-dsl/src/lower.rs
@@ -1,4 +1,5 @@
 mod anim;
+mod blob;
 mod branch;
 mod building;
 pub(crate) mod connector;

--- a/crates/mogen-dsl/src/lower/blob.rs
+++ b/crates/mogen-dsl/src/lower/blob.rs
@@ -1,0 +1,168 @@
+//! Lowering for the `blob` container — true SDF + surface-nets meshing.
+//!
+//! Distinct from both `metaball` (sphere-cluster, vertex-fillet) and
+//! `union(smooth=k)` (mesh CSG + vertex pull): blob walks every child as an
+//! implicit primitive, evaluates the smooth-blended field on a voxel grid,
+//! and extracts the zero-isosurface with `fast-surface-nets`. This is what
+//! makes smooth eye sockets / nostrils / blended chin masses on a skull
+//! actually look organic instead of staircased.
+//!
+//! Children supported (`SdfPrim`): `sphere`, `ellipsoid`, `box`,
+//! `rounded_box`, `capsule`, `cylinder`, `torus`. Each accepts the same
+//! `pos` / `rot` / `scale` / size attrs the mesh primitives do, plus an
+//! optional `op="subtract"` to carve a smooth cavity rather than add mass.
+
+use anyhow::{anyhow, bail, Result};
+use glam::Vec3;
+
+use mogen_core::{NodeId, SceneGraph};
+use mogen_geom::{blob_to_mesh, BlobChild, SdfOp, SdfPrim};
+
+use crate::ast::{Node, Value};
+
+use super::connector::{add_aabb_connectors_if_missing, add_connector};
+use super::helpers::{apply_subdivide, inherit_material_from_ancestor, resolve_size3, transform_from_attrs};
+use super::lod::scaled_count;
+
+pub(super) fn lower_blob(
+    node: &Node,
+    parent: Option<NodeId>,
+    graph: &mut SceneGraph,
+) -> Result<NodeId> {
+    let transform = transform_from_attrs(node);
+    let name = node.name.clone().unwrap_or_else(|| node.kind.clone());
+
+    let id = match parent {
+        None => graph.add_root(&name, &node.kind, transform),
+        Some(p) => graph.add_child(p, &name, &node.kind, transform),
+    };
+    graph.set_source_span(id, node.span);
+    graph.nodes[id.0 as usize].use_id = node.use_id;
+    graph.nodes[id.0 as usize].origin = node.origin.clone();
+
+    super::node::apply_metadata(node, id, graph)?;
+
+    // Material inheritance: blob's own mat= wins; otherwise first additive
+    // child's mat=; otherwise ancestor chain. Matches `lower_csg`.
+    if graph.nodes[id.0 as usize].material.is_none() {
+        if let Some(first_operand) = node
+            .children
+            .iter()
+            .find(|c| !matches!(c.kind.as_str(), "material" | "connector"))
+        {
+            let mat_name = match first_operand.attr("mat") {
+                Some(Value::String(s)) | Some(Value::Ident(s)) => Some(s.clone()),
+                _ => None,
+            };
+            if let Some(name) = mat_name {
+                if let Some(mid) =
+                    graph.find_material_scoped(&name, first_operand.origin.as_deref())
+                {
+                    graph.set_material(id, mid);
+                }
+            }
+        }
+    }
+    inherit_material_from_ancestor(id, graph);
+
+    // Collect SDF children.
+    let mut children: Vec<BlobChild> = Vec::new();
+    for c in &node.children {
+        match c.kind.as_str() {
+            "material" | "connector" => continue,
+            _ => children.push(parse_blob_child(c)?),
+        }
+    }
+    if children.is_empty() {
+        bail!(
+            "`blob` requires at least one implicit-field primitive child (sphere, ellipsoid, box, rounded_box, capsule, cylinder, torus)"
+        );
+    }
+    // At least one Add child is required — a blob of only subtracts has
+    // nothing to carve into and produces an empty mesh.
+    if !children.iter().any(|c| matches!(c.op, SdfOp::Add)) {
+        bail!(
+            "`blob` requires at least one additive child; every child has `op=subtract`"
+        );
+    }
+
+    let blend = node.attr_number("blend").unwrap_or(0.1).max(0.0);
+    // Voxel grid resolution is dimensional (count per axis), so it scales
+    // linearly with LOD just like primitive `segments=`. The hard upper cap
+    // (256) stays — `scaled_count` only enforces the floor — so a global
+    // `lod_scale=2.0` on a hero asset can't blow up the voxel budget.
+    let raw_resolution = node.attr_number("resolution").map(|n| n as u32).unwrap_or(96);
+    let resolution = scaled_count(raw_resolution, 16).min(256);
+
+    let mut mesh = blob_to_mesh(&children, blend, resolution);
+    if mesh.indices.is_empty() {
+        bail!(
+            "`blob` produced no surface — check that additive children overlap and `resolution` is large enough"
+        );
+    }
+    mesh = apply_subdivide(node, mesh)?;
+
+    graph.set_mesh(id, mesh);
+
+    for c in &node.children {
+        if c.kind == "connector" {
+            add_connector(c, id, graph)?;
+        }
+    }
+    add_aabb_connectors_if_missing(id, graph);
+    Ok(id)
+}
+
+fn parse_blob_child(node: &Node) -> Result<BlobChild> {
+    let op = match node.attr_string("op") {
+        Some("subtract") | Some("sub") | Some("carve") => SdfOp::Subtract,
+        Some("add") | None => SdfOp::Add,
+        Some(other) => {
+            bail!("blob child `op=` must be \"add\" or \"subtract\" (got: \"{other}\")")
+        }
+    };
+    let prim = parse_sdf_prim(node)?;
+    let xform = transform_from_attrs(node).to_mat4();
+    Ok(BlobChild::new(prim, op, xform))
+}
+
+fn parse_sdf_prim(node: &Node) -> Result<SdfPrim> {
+    match node.kind.as_str() {
+        "sphere" => {
+            let r = node.attr_number("radius").unwrap_or(0.5).max(0.0);
+            Ok(SdfPrim::Sphere { radius: r })
+        }
+        "ellipsoid" => {
+            let s = resolve_size3(node, Vec3::ONE);
+            Ok(SdfPrim::Ellipsoid { half: s * 0.5 })
+        }
+        "box" => {
+            let s = resolve_size3(node, Vec3::ONE);
+            Ok(SdfPrim::Box { half: s * 0.5 })
+        }
+        "rounded_box" => {
+            let s = resolve_size3(node, Vec3::ONE);
+            let r = node.attr_number("radius").unwrap_or(0.1).max(0.0);
+            Ok(SdfPrim::RoundedBox { half: s * 0.5, radius: r })
+        }
+        "capsule" => {
+            let r = node.attr_number("radius").unwrap_or(0.3).max(0.0);
+            let h = node.attr_number("height").unwrap_or(1.0).max(0.0);
+            Ok(SdfPrim::Capsule { radius: r, height: h })
+        }
+        "cylinder" => {
+            let r = node.attr_number("radius").unwrap_or(0.5).max(0.0);
+            let h = node.attr_number("height").unwrap_or(1.0).max(0.0);
+            Ok(SdfPrim::Cylinder { radius: r, height: h })
+        }
+        "torus" => {
+            let major = node.attr_number("major").unwrap_or(0.5).max(0.0);
+            let minor = node.attr_number("minor").unwrap_or(0.15).max(0.0);
+            Ok(SdfPrim::Torus { major, minor })
+        }
+        other => Err(anyhow!(
+            "blob child kind `{other}` is not implicit-field-supported (allowed: sphere, ellipsoid, box, rounded_box, capsule, cylinder, torus)"
+        )),
+    }
+}
+

--- a/crates/mogen-dsl/src/lower/csg.rs
+++ b/crates/mogen-dsl/src/lower/csg.rs
@@ -9,7 +9,7 @@ use crate::ast::{Node, Value};
 
 use super::connector::{add_aabb_connectors_if_missing, add_connector};
 use super::deform::apply_deform;
-use super::helpers::{inherit_material_from_ancestor, transform_from_attrs};
+use super::helpers::{apply_subdivide, inherit_material_from_ancestor, transform_from_attrs};
 use super::node::apply_metadata;
 use super::primitive::primitive_mesh;
 
@@ -109,7 +109,9 @@ pub(super) fn lower_csg(
         _ => unreachable!(),
     };
 
-    graph.set_mesh(id, clean_csg_output(&combined));
+    let cleaned = clean_csg_output(&combined);
+    let cleaned = apply_subdivide(node, cleaned)?;
+    graph.set_mesh(id, cleaned);
 
     // Attach connectors declared directly on the CSG node.
     for c in &node.children {

--- a/crates/mogen-dsl/src/lower/helpers.rs
+++ b/crates/mogen-dsl/src/lower/helpers.rs
@@ -1,7 +1,45 @@
+use anyhow::{bail, Result};
 use glam::{Quat, Vec3};
 use mogen_core::{Aabb, Mesh, NodeId, SceneGraph, Transform};
+use mogen_geom::loop_subdivide;
 
 use crate::ast::{Node, Value};
+
+use super::lod::scaled_subdivisions;
+
+/// Cap applied to `subdivide=N` on every mesh-producing node. 3 keeps the
+/// post-pass at most 64× the input triangles — enough headroom that a
+/// surface-nets `blob` output (~5–15k tris at default resolution) stays
+/// under a million tris even at the cap.
+pub(super) const SUBDIVIDE_CAP: u32 = 3;
+
+/// Apply Loop subdivision to `mesh` per `node`'s `subdivide=N` attr
+/// (clamped to [0, SUBDIVIDE_CAP]). Returns the mesh unchanged if the attr
+/// is absent or zero. Called from the three mesh-producing lowering
+/// paths (`primitive_mesh` for leaves, `lower_csg` for boolean ops, and
+/// `lower_blob` for implicit-field containers) so any mesh-producing kind
+/// honours the same `subdivide=` knob with the same cap.
+///
+/// LOD scaling: Loop subdivision is exponential (4× tris per level), so it
+/// gets the same `log2(scale)` additive offset that `icosphere`'s
+/// `subdivisions=` does. A global `lod_scale=0.5` drops `subdivide=1` to
+/// 0 (skipping the 4× pass); `lod_scale=0.25` would knock `subdivide=2`
+/// to 0. Hero `lod_scale=2.0` adds a level back, still capped at
+/// `SUBDIVIDE_CAP` to keep the worst case bounded.
+pub(super) fn apply_subdivide(node: &Node, mesh: Mesh) -> Result<Mesh> {
+    let n = match node.attr_number("subdivide") {
+        Some(n) => n as i32,
+        None => return Ok(mesh),
+    };
+    if n < 0 {
+        bail!("`subdivide` must be a non-negative integer (got {n})");
+    }
+    let n = scaled_subdivisions(n as u32).min(SUBDIVIDE_CAP);
+    if n == 0 {
+        return Ok(mesh);
+    }
+    Ok(loop_subdivide(&mesh, n))
+}
 
 /// Lexical material inheritance: if `id`'s own material is unset, walk up its
 /// parent chain and copy the nearest ancestor's material onto it.

--- a/crates/mogen-dsl/src/lower/helpers.rs
+++ b/crates/mogen-dsl/src/lower/helpers.rs
@@ -7,25 +7,10 @@ use crate::ast::{Node, Value};
 
 use super::lod::scaled_subdivisions;
 
-/// Cap applied to `subdivide=N` on every mesh-producing node. 3 keeps the
-/// post-pass at most 64× the input triangles — enough headroom that a
-/// surface-nets `blob` output (~5–15k tris at default resolution) stays
-/// under a million tris even at the cap.
+/// Max Loop subdivision rounds for any mesh-producing node (cap is 64× tri count).
 pub(super) const SUBDIVIDE_CAP: u32 = 3;
 
-/// Apply Loop subdivision to `mesh` per `node`'s `subdivide=N` attr
-/// (clamped to [0, SUBDIVIDE_CAP]). Returns the mesh unchanged if the attr
-/// is absent or zero. Called from the three mesh-producing lowering
-/// paths (`primitive_mesh` for leaves, `lower_csg` for boolean ops, and
-/// `lower_blob` for implicit-field containers) so any mesh-producing kind
-/// honours the same `subdivide=` knob with the same cap.
-///
-/// LOD scaling: Loop subdivision is exponential (4× tris per level), so it
-/// gets the same `log2(scale)` additive offset that `icosphere`'s
-/// `subdivisions=` does. A global `lod_scale=0.5` drops `subdivide=1` to
-/// 0 (skipping the 4× pass); `lod_scale=0.25` would knock `subdivide=2`
-/// to 0. Hero `lod_scale=2.0` adds a level back, still capped at
-/// `SUBDIVIDE_CAP` to keep the worst case bounded.
+/// Apply `subdivide=N` Loop subdivision to `mesh` (clamped via LOD scale; no-op if absent or 0).
 pub(super) fn apply_subdivide(node: &Node, mesh: Mesh) -> Result<Mesh> {
     let n = match node.attr_number("subdivide") {
         Some(n) => n as i32,

--- a/crates/mogen-dsl/src/lower/node.rs
+++ b/crates/mogen-dsl/src/lower/node.rs
@@ -12,7 +12,8 @@ use super::connector::{add_aabb_connectors_if_missing, add_connector, default_co
 use super::csg::lower_csg;
 use super::deform::apply_deform;
 use super::helpers::{
-    anchor_for, apply_anchor_to_mesh, inherit_material_from_ancestor, transform_from_attrs,
+    anchor_for, apply_anchor_to_mesh, apply_subdivide, inherit_material_from_ancestor,
+    transform_from_attrs,
 };
 use super::layout::{apply_relative_placement, expand_grid, expand_replicator, expand_stack};
 use super::light::lower_light;
@@ -41,6 +42,9 @@ pub(super) fn lower_into(
     }
     if matches!(node.kind.as_str(), "union" | "difference" | "intersect") {
         return lower_csg(node, parent, graph);
+    }
+    if node.kind == "blob" {
+        return super::blob::lower_blob(node, parent, graph);
     }
     if node.kind == "stack" {
         return expand_stack(node, parent, graph);
@@ -147,6 +151,7 @@ pub(super) fn lower_into(
             apply_deform(&mut mesh, node);
         }
         anchor_shift = apply_anchor_to_mesh(&mut mesh, anchor.as_deref());
+        let mesh = apply_subdivide(node, mesh)?;
         graph.set_mesh(id, mesh);
     } else {
         match node.kind.as_str() {

--- a/crates/mogen-geom/Cargo.toml
+++ b/crates/mogen-geom/Cargo.toml
@@ -22,4 +22,5 @@ glam = { workspace = true }
 anyhow = { workspace = true }
 gltf = { workspace = true }
 earcutr = "0.5"
+fast-surface-nets = "0.2"
 manifold-csg = { version = "0.1.8", optional = true, default-features = false }

--- a/crates/mogen-geom/src/isosurface.rs
+++ b/crates/mogen-geom/src/isosurface.rs
@@ -1,0 +1,218 @@
+//! Mesh extraction from a `blob` SDF field via fast surface nets.
+//!
+//! Pipeline: take an ordered slice of `BlobChild`s, compute a padded AABB
+//! that encloses every additive child, sample the smooth-blended field on a
+//! cubic-voxel grid sized to the requested `resolution`, then feed the
+//! sample buffer to `fast_surface_nets::surface_nets`. The buffer's
+//! voxel-space positions are mapped back to world space using the grid
+//! transform and the result is wrapped in a `Mesh` with planar UVs (XZ
+//! projection — adequate for the bbox-projected texturing the LLM-driven
+//! material path already uses).
+//!
+//! Surface nets (vs. classic marching cubes) gives noticeably better
+//! topology for organic shapes — quads-as-tris rather than tetrahedral
+//! slivers — which means the `subdivide=N` Loop pass smooths cleanly
+//! instead of fighting the staircased seams MC tends to leave.
+
+use fast_surface_nets::ndshape::{RuntimeShape, Shape};
+use fast_surface_nets::{surface_nets, SurfaceNetsBuffer};
+use glam::Vec3;
+use mogen_core::Mesh;
+
+use crate::sdf::{blob_aabb, evaluate_field, BlobChild};
+
+/// Maximum total voxel count enforced before allocation. At ~3 bytes/voxel
+/// of working memory (sdf buffer + surface-nets internals) this caps RAM at
+/// roughly 50 MB and CPU at well under a second on a modern desktop. The
+/// DSL-side validator clamps `resolution` per axis so callers shouldn't hit
+/// this — it's a defensive backstop against pathological AABBs.
+const MAX_TOTAL_VOXELS: u64 = 16_000_000;
+
+/// Mesh the implicit field defined by `children` using surface nets at the
+/// requested grid `resolution` (voxels along the longest world-space axis).
+/// `blend` is the smooth-min radius used by `evaluate_field`.
+///
+/// Returns an empty mesh if `children` is empty, the AABB collapses, or
+/// surface nets finds no zero-crossing inside the grid.
+pub fn blob_to_mesh(children: &[BlobChild], blend: f32, resolution: u32) -> Mesh {
+    if children.is_empty() {
+        return Mesh::default();
+    }
+    let blend = blend.max(0.0);
+
+    // First pass: AABB of additive children with a `3*blend` pad so smooth
+    // bulges have room. Subtractive children are evaluated inside this same
+    // grid (they carve, they can't grow the silhouette).
+    let initial_pad = 3.0 * blend;
+    let (lo0, hi0) = match blob_aabb(children, initial_pad) {
+        Some(b) => b,
+        None => return Mesh::default(),
+    };
+    let extent0 = hi0 - lo0;
+    let max_axis = extent0.x.max(extent0.y).max(extent0.z);
+    if max_axis <= 0.0 {
+        return Mesh::default();
+    }
+
+    // Second pass: bump pad so we always have ≥2 voxels of clearance between
+    // the surface and the grid boundary (surface-nets normals at the very
+    // edge of the field are unreliable). Recompute the AABB with the larger
+    // pad so the voxel grid actually contains that clearance.
+    let res = resolution.max(8);
+    let voxel0 = max_axis / (res as f32 - 1.0);
+    let pad = initial_pad.max(2.0 * voxel0);
+    let (lo, hi) = blob_aabb(children, pad).expect("AABB stable after pad");
+    let extent = hi - lo;
+    let max_axis = extent.x.max(extent.y).max(extent.z);
+    let voxel = max_axis / (res as f32 - 1.0);
+
+    let dim = |e: f32| -> u32 { ((e / voxel).ceil() as u32 + 1).max(2) };
+    let nx = dim(extent.x);
+    let ny = dim(extent.y);
+    let nz = dim(extent.z);
+
+    let total = nx as u64 * ny as u64 * nz as u64;
+    if total > MAX_TOTAL_VOXELS {
+        // Defensive backstop: rather than allocating multi-GB of voxels,
+        // bail with an empty mesh. The DSL validator already caps
+        // `resolution`, so reaching this means the AABB itself was
+        // pathological — silently producing nothing is preferable to OOM.
+        return Mesh::default();
+    }
+
+    let shape = RuntimeShape::<u32, 3>::new([nx, ny, nz]);
+    let total_usize = total as usize;
+    let mut sdf = vec![0.0_f32; total_usize];
+
+    for i in 0..total_usize as u32 {
+        let [ix, iy, iz] = shape.delinearize(i);
+        let p = Vec3::new(
+            lo.x + ix as f32 * voxel,
+            lo.y + iy as f32 * voxel,
+            lo.z + iz as f32 * voxel,
+        );
+        sdf[i as usize] = evaluate_field(children, p, blend);
+    }
+
+    let mut buf = SurfaceNetsBuffer::default();
+    surface_nets(&sdf, &shape, [0, 0, 0], [nx - 1, ny - 1, nz - 1], &mut buf);
+
+    if buf.indices.is_empty() {
+        return Mesh::default();
+    }
+
+    let positions: Vec<[f32; 3]> = buf
+        .positions
+        .iter()
+        .map(|p| {
+            [
+                lo.x + p[0] * voxel,
+                lo.y + p[1] * voxel,
+                lo.z + p[2] * voxel,
+            ]
+        })
+        .collect();
+
+    // Planar UVs from world-space XZ projection. Blob outputs are typically
+    // textured with a bbox-projected material (the LLM material pipeline
+    // doesn't try to unwrap a marching/surface-nets result), so an XZ planar
+    // mapping is the same convention as `plane` and the lower face of every
+    // bbox-projected primitive — consistent enough that mat="bone" on a
+    // skull lands the right way up.
+    let inv_w = 1.0 / extent.x.max(1e-6);
+    let inv_d = 1.0 / extent.z.max(1e-6);
+    let uvs: Vec<[f32; 2]> = positions
+        .iter()
+        .map(|p| [(p[0] - lo.x) * inv_w, (p[2] - lo.z) * inv_d])
+        .collect();
+
+    Mesh {
+        positions,
+        normals: buf.normals,
+        uvs,
+        indices: buf.indices,
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdf::{BlobChild, SdfOp, SdfPrim};
+    use glam::Mat4;
+
+    #[test]
+    fn empty_children_returns_empty_mesh() {
+        let m = blob_to_mesh(&[], 0.1, 32);
+        assert!(m.positions.is_empty());
+    }
+
+    #[test]
+    fn single_sphere_produces_roughly_spherical_mesh() {
+        let c = BlobChild::new(
+            SdfPrim::Sphere { radius: 0.5 },
+            SdfOp::Add,
+            Mat4::IDENTITY,
+        );
+        let m = blob_to_mesh(&[c], 0.0, 48);
+        assert!(!m.positions.is_empty(), "expected mesh output");
+        let max_r = m
+            .positions
+            .iter()
+            .map(|p| (p[0] * p[0] + p[1] * p[1] + p[2] * p[2]).sqrt())
+            .fold(0.0_f32, f32::max);
+        let min_r = m
+            .positions
+            .iter()
+            .map(|p| (p[0] * p[0] + p[1] * p[1] + p[2] * p[2]).sqrt())
+            .fold(f32::INFINITY, f32::min);
+        assert!((max_r - 0.5).abs() < 0.05, "max radius off: {max_r}");
+        assert!((min_r - 0.5).abs() < 0.05, "min radius off: {min_r}");
+    }
+
+    #[test]
+    fn two_overlapping_spheres_smooth_into_one_blob() {
+        let a = BlobChild::new(
+            SdfPrim::Sphere { radius: 0.5 },
+            SdfOp::Add,
+            Mat4::from_translation(Vec3::new(-0.3, 0.0, 0.0)),
+        );
+        let b = BlobChild::new(
+            SdfPrim::Sphere { radius: 0.5 },
+            SdfOp::Add,
+            Mat4::from_translation(Vec3::new(0.3, 0.0, 0.0)),
+        );
+        let m = blob_to_mesh(&[a, b], 0.15, 48);
+        assert!(!m.positions.is_empty());
+        let max_x = m.positions.iter().map(|p| p[0]).fold(f32::NEG_INFINITY, f32::max);
+        let min_x = m.positions.iter().map(|p| p[0]).fold(f32::INFINITY, f32::min);
+        assert!(max_x > 0.7, "expected blob to extend past one sphere, got max_x={max_x}");
+        assert!(min_x < -0.7, "expected blob to extend past one sphere, got min_x={min_x}");
+    }
+
+    #[test]
+    fn subtract_carves_a_cavity() {
+        let outer = BlobChild::new(
+            SdfPrim::Sphere { radius: 0.8 },
+            SdfOp::Add,
+            Mat4::IDENTITY,
+        );
+        let hole = BlobChild::new(
+            SdfPrim::Sphere { radius: 0.3 },
+            SdfOp::Subtract,
+            Mat4::from_translation(Vec3::new(0.6, 0.0, 0.0)),
+        );
+        // Without the carver, no vertex should sit inside the cavity
+        // (sphere centred at (0.6, 0, 0) with r=0.3 → exclusion zone is the
+        // ball within 0.3 of (0.6, 0, 0)).
+        let m = blob_to_mesh(&[outer, hole], 0.0, 64);
+        assert!(!m.positions.is_empty());
+        let inside_cavity = m.positions.iter().filter(|p| {
+            let d = ((p[0] - 0.6).powi(2) + p[1].powi(2) + p[2].powi(2)).sqrt();
+            d < 0.2  // well inside the cavity carver
+        }).count();
+        // Surface-nets places the cavity rim somewhere outside r=0.2 from
+        // the carver centre, so no vertex should be deep inside it.
+        assert_eq!(inside_cavity, 0, "found vertices inside carved cavity");
+    }
+}

--- a/crates/mogen-geom/src/lib.rs
+++ b/crates/mogen-geom/src/lib.rs
@@ -5,7 +5,10 @@ pub mod csg;
 #[cfg(any(feature = "csg", feature = "unstable-wasm-uu"))]
 pub mod csg_smooth;
 pub mod deform;
+pub mod isosurface;
 pub mod primitives;
+pub mod sdf;
+pub mod subdivide;
 pub mod surface_query;
 pub mod xform;
 
@@ -22,6 +25,9 @@ pub use csg::{difference, difference_many, intersect, intersect_many, union, uni
 #[cfg(any(feature = "csg", feature = "unstable-wasm-uu"))]
 pub use csg_smooth::union_smooth;
 pub use deform::{bend, droop, jitter, noise, split_for_facets, taper, twist_y, wave};
+pub use isosurface::blob_to_mesh;
+pub use sdf::{blob_aabb, evaluate_field, smax, smin, BlobChild, SdfOp, SdfPrim};
+pub use subdivide::loop_subdivide;
 pub use surface_query::{SurfaceIndex, SurfacePoint};
 pub use primitives::{
     box_mesh, capsule_mesh, chamfered_box_mesh, coil_mesh, cone_mesh, curved_plane_mesh,

--- a/crates/mogen-geom/src/sdf.rs
+++ b/crates/mogen-geom/src/sdf.rs
@@ -1,0 +1,325 @@
+//! Signed-distance primitives and smooth-blend helpers for the `blob`
+//! container.
+//!
+//! Unlike `csg_smooth` (which is a vertex-fillet approximation applied to a
+//! sharp mesh-CSG union), this module evaluates true SDFs on a sample grid;
+//! `isosurface::blob_to_mesh` then meshes the field with surface nets.
+//! Concave junctions (smooth eye sockets, blended nasal cavities) and large
+//! `blend` radii — both common on organic shapes — work correctly here where
+//! the vertex-fillet path breaks down.
+//!
+//! Every primitive returns a true SDF in its own local frame; `BlobChild`
+//! holds the inverse-transform so callers can evaluate `child.sample(p)` with
+//! `p` in the blob's frame. Scale factors compress the distance result by
+//! the smallest scale axis — an approximate Lipschitz correction that's good
+//! enough for marching surface-nets meshing (we care about where the
+//! zero-isosurface sits, not the gradient magnitude away from it).
+
+use glam::{Mat4, Vec3};
+
+/// One implicit primitive inside a `blob`. Position/rotation/scale are baked
+/// into `inv` so `sample()` can transform a world point into the primitive's
+/// local frame in one matvec.
+#[derive(Debug, Clone)]
+pub struct BlobChild {
+    pub prim: SdfPrim,
+    pub op: SdfOp,
+    /// Inverse of the child's local-to-blob transform.
+    pub inv: Mat4,
+    /// Smallest scale component of the forward transform — distances scale
+    /// linearly with the local frame, so we multiply the local SDF by this to
+    /// keep results conservative in blob space.
+    pub scale_min: f32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SdfOp {
+    Add,
+    Subtract,
+}
+
+/// Implicit primitives supported as `blob` children. Every variant has a
+/// closed-form SDF.
+#[derive(Debug, Clone, Copy)]
+pub enum SdfPrim {
+    Sphere { radius: f32 },
+    /// Axis-aligned ellipsoid with the given half-extents along x/y/z.
+    /// Approximate SDF (the exact ellipsoid SDF needs Newton iteration); for
+    /// surface-nets this approximation places the zero-iso correctly.
+    Ellipsoid { half: Vec3 },
+    /// Axis-aligned box with the given half-extents along x/y/z.
+    Box { half: Vec3 },
+    /// Box with rounded edges: half-extents minus the round radius, then
+    /// shrunk-and-grown.
+    RoundedBox { half: Vec3, radius: f32 },
+    /// Capsule aligned along local Y axis. `height` is the centre-to-centre
+    /// length between the two hemispherical end caps.
+    Capsule { radius: f32, height: f32 },
+    /// Closed cylinder aligned along local Y axis. `height` is the full
+    /// extent (caps sit at ±height/2).
+    Cylinder { radius: f32, height: f32 },
+    /// Torus in the local XZ plane. `major` is ring radius, `minor` is tube
+    /// radius.
+    Torus { major: f32, minor: f32 },
+}
+
+impl SdfPrim {
+    fn sample_local(&self, p: Vec3) -> f32 {
+        match *self {
+            SdfPrim::Sphere { radius } => p.length() - radius,
+            SdfPrim::Ellipsoid { half } => {
+                // Approximate ellipsoid SDF (Inigo Quilez): scales sphere by
+                // axes. Not exact but the zero-iso matches the surface; the
+                // gradient is slightly off, which only affects smin shape
+                // near the surface — visually fine for organic blends.
+                let r = (p / half).length();
+                let r2 = (p / (half * half)).length();
+                if r2 == 0.0 {
+                    -half.min_element()
+                } else {
+                    r * (r - 1.0) / r2
+                }
+            }
+            SdfPrim::Box { half } => {
+                let q = p.abs() - half;
+                q.max(Vec3::ZERO).length() + q.x.max(q.y.max(q.z)).min(0.0)
+            }
+            SdfPrim::RoundedBox { half, radius } => {
+                let q = p.abs() - (half - Vec3::splat(radius));
+                q.max(Vec3::ZERO).length() + q.x.max(q.y.max(q.z)).min(0.0) - radius
+            }
+            SdfPrim::Capsule { radius, height } => {
+                let h = height.max(0.0) * 0.5;
+                let y_clamped = p.y.clamp(-h, h);
+                let d = Vec3::new(p.x, p.y - y_clamped, p.z);
+                d.length() - radius
+            }
+            SdfPrim::Cylinder { radius, height } => {
+                let h = height.max(0.0) * 0.5;
+                let d = Vec3::new((p.x * p.x + p.z * p.z).sqrt() - radius, p.y.abs() - h, 0.0);
+                let inside = d.x.max(d.y).min(0.0);
+                let outside = Vec3::new(d.x.max(0.0), d.y.max(0.0), 0.0).length();
+                inside + outside
+            }
+            SdfPrim::Torus { major, minor } => {
+                let q = Vec3::new((p.x * p.x + p.z * p.z).sqrt() - major, p.y, 0.0);
+                q.length() - minor
+            }
+        }
+    }
+
+    /// Tight AABB in the primitive's local frame. The `blob` AABB pads this
+    /// by `3 * blend` so smooth-mins have room to bulge outward.
+    pub fn local_aabb(&self) -> (Vec3, Vec3) {
+        match *self {
+            SdfPrim::Sphere { radius } => (Vec3::splat(-radius), Vec3::splat(radius)),
+            SdfPrim::Ellipsoid { half } => (-half, half),
+            SdfPrim::Box { half } => (-half, half),
+            SdfPrim::RoundedBox { half, .. } => (-half, half),
+            SdfPrim::Capsule { radius, height } => {
+                let h = height.max(0.0) * 0.5 + radius;
+                (Vec3::new(-radius, -h, -radius), Vec3::new(radius, h, radius))
+            }
+            SdfPrim::Cylinder { radius, height } => {
+                let h = height.max(0.0) * 0.5;
+                (Vec3::new(-radius, -h, -radius), Vec3::new(radius, h, radius))
+            }
+            SdfPrim::Torus { major, minor } => (
+                Vec3::new(-(major + minor), -minor, -(major + minor)),
+                Vec3::new(major + minor, minor, major + minor),
+            ),
+        }
+    }
+}
+
+impl BlobChild {
+    /// Build a `BlobChild` from a primitive and its local-to-blob transform.
+    pub fn new(prim: SdfPrim, op: SdfOp, xform: Mat4) -> Self {
+        let (s, _, _) = decompose_scale(&xform);
+        let scale_min = s.x.min(s.y).min(s.z).max(1e-6);
+        Self { prim, op, inv: xform.inverse(), scale_min }
+    }
+
+    /// Evaluate this primitive's SDF at point `p` in the blob's frame.
+    pub fn sample(&self, p: Vec3) -> f32 {
+        let local = self.inv.transform_point3(p);
+        self.prim.sample_local(local) * self.scale_min
+    }
+
+    /// World-space AABB after applying the child's transform, computed from
+    /// the 8 corners of the local AABB. Slightly loose but always valid.
+    pub fn world_aabb(&self) -> (Vec3, Vec3) {
+        let (lo, hi) = self.prim.local_aabb();
+        let xform = self.inv.inverse();
+        let corners = [
+            Vec3::new(lo.x, lo.y, lo.z),
+            Vec3::new(hi.x, lo.y, lo.z),
+            Vec3::new(lo.x, hi.y, lo.z),
+            Vec3::new(hi.x, hi.y, lo.z),
+            Vec3::new(lo.x, lo.y, hi.z),
+            Vec3::new(hi.x, lo.y, hi.z),
+            Vec3::new(lo.x, hi.y, hi.z),
+            Vec3::new(hi.x, hi.y, hi.z),
+        ];
+        let mut wmin = Vec3::splat(f32::INFINITY);
+        let mut wmax = Vec3::splat(f32::NEG_INFINITY);
+        for c in corners {
+            let w = xform.transform_point3(c);
+            wmin = wmin.min(w);
+            wmax = wmax.max(w);
+        }
+        (wmin, wmax)
+    }
+}
+
+/// Polynomial smooth-min (Inigo Quilez). `k > 0` is the blend radius in
+/// scene units; the function reduces to `min(a, b)` as `k → 0`.
+pub fn smin(a: f32, b: f32, k: f32) -> f32 {
+    if k <= 0.0 {
+        return a.min(b);
+    }
+    let h = (k - (a - b).abs()).max(0.0) / k;
+    a.min(b) - h * h * k * 0.25
+}
+
+/// Polynomial smooth-max derived from smin: `smax(a, b, k) = -smin(-a, -b, k)`.
+/// Used by smooth subtraction: `smax(field, -d_carver, k)` carves a smooth
+/// cavity instead of leaving a sharp rim.
+pub fn smax(a: f32, b: f32, k: f32) -> f32 {
+    -smin(-a, -b, k)
+}
+
+/// Combine an ordered list of `BlobChild`s into a single field value at `p`.
+/// Add children blend via `smin`; subtract children carve via `smax`. Order
+/// matches author intent: layer additions, then carve cavities.
+pub fn evaluate_field(children: &[BlobChild], p: Vec3, k: f32) -> f32 {
+    let mut field = f32::INFINITY;
+    for c in children {
+        let d = c.sample(p);
+        match c.op {
+            SdfOp::Add => field = smin(field, d, k),
+            SdfOp::Subtract => field = smax(field, -d, k),
+        }
+    }
+    field
+}
+
+/// AABB enclosing every child's transformed bounds, padded by `pad` on each
+/// side. Returns `None` if `children` is empty.
+pub fn blob_aabb(children: &[BlobChild], pad: f32) -> Option<(Vec3, Vec3)> {
+    if children.is_empty() {
+        return None;
+    }
+    let mut lo = Vec3::splat(f32::INFINITY);
+    let mut hi = Vec3::splat(f32::NEG_INFINITY);
+    for c in children {
+        // Only additive children contribute to the bounds — a subtract
+        // carves out of existing geometry, it can't grow the silhouette.
+        if !matches!(c.op, SdfOp::Add) {
+            continue;
+        }
+        let (clo, chi) = c.world_aabb();
+        lo = lo.min(clo);
+        hi = hi.max(chi);
+    }
+    if !lo.is_finite() || !hi.is_finite() {
+        return None;
+    }
+    Some((lo - Vec3::splat(pad), hi + Vec3::splat(pad)))
+}
+
+fn decompose_scale(m: &Mat4) -> (Vec3, glam::Quat, Vec3) {
+    let (s, r, t) = m.to_scale_rotation_translation();
+    (s, r, t)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sphere_sdf_is_signed_distance() {
+        let s = SdfPrim::Sphere { radius: 1.0 };
+        assert!((s.sample_local(Vec3::ZERO) + 1.0).abs() < 1e-5);
+        assert!((s.sample_local(Vec3::new(1.0, 0.0, 0.0))).abs() < 1e-5);
+        assert!((s.sample_local(Vec3::new(2.0, 0.0, 0.0)) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn box_sdf_at_corner_is_zero() {
+        let b = SdfPrim::Box { half: Vec3::new(1.0, 1.0, 1.0) };
+        assert!(b.sample_local(Vec3::new(1.0, 1.0, 1.0)).abs() < 1e-5);
+        assert!(b.sample_local(Vec3::ZERO) < 0.0);
+        assert!(b.sample_local(Vec3::new(2.0, 0.0, 0.0)) > 0.0);
+    }
+
+    #[test]
+    fn smin_reduces_to_min_at_zero_k() {
+        assert!((smin(1.0, 2.0, 0.0) - 1.0).abs() < 1e-6);
+        assert!((smin(-3.0, 5.0, 0.0) + 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn smin_blends_between_inputs() {
+        let m = smin(0.05, 0.05, 0.2);
+        assert!(m < 0.05, "expected smoothing to pull below sharp min, got {m}");
+    }
+
+    #[test]
+    fn evaluate_field_two_spheres_blend() {
+        let a = BlobChild::new(
+            SdfPrim::Sphere { radius: 0.5 },
+            SdfOp::Add,
+            Mat4::from_translation(Vec3::new(-0.4, 0.0, 0.0)),
+        );
+        let b = BlobChild::new(
+            SdfPrim::Sphere { radius: 0.5 },
+            SdfOp::Add,
+            Mat4::from_translation(Vec3::new(0.4, 0.0, 0.0)),
+        );
+        // Midpoint inside both spheres — field should be strongly negative.
+        let mid = evaluate_field(&[a.clone(), b.clone()], Vec3::ZERO, 0.2);
+        assert!(mid < 0.0, "midpoint should be inside the blob, got {mid}");
+        // Far away — outside both.
+        let far = evaluate_field(&[a, b], Vec3::new(10.0, 0.0, 0.0), 0.2);
+        assert!(far > 0.0, "far point should be outside, got {far}");
+    }
+
+    #[test]
+    fn subtract_carves_out_field() {
+        let outer = BlobChild::new(
+            SdfPrim::Sphere { radius: 1.0 },
+            SdfOp::Add,
+            Mat4::IDENTITY,
+        );
+        let hole = BlobChild::new(
+            SdfPrim::Sphere { radius: 0.4 },
+            SdfOp::Subtract,
+            Mat4::from_translation(Vec3::new(0.7, 0.0, 0.0)),
+        );
+        // Centre is still inside the outer sphere.
+        let c = evaluate_field(&[outer.clone(), hole.clone()], Vec3::ZERO, 0.0);
+        assert!(c < 0.0, "centre should be inside, got {c}");
+        // Point inside the carved cavity should now read as outside.
+        let h = evaluate_field(&[outer, hole], Vec3::new(0.7, 0.0, 0.0), 0.0);
+        assert!(h > 0.0, "cavity centre should read as outside, got {h}");
+    }
+
+    #[test]
+    fn blob_aabb_ignores_subtracts() {
+        let outer = BlobChild::new(
+            SdfPrim::Sphere { radius: 1.0 },
+            SdfOp::Add,
+            Mat4::IDENTITY,
+        );
+        let hole = BlobChild::new(
+            SdfPrim::Sphere { radius: 0.4 },
+            SdfOp::Subtract,
+            Mat4::from_translation(Vec3::new(10.0, 0.0, 0.0)),
+        );
+        let (lo, hi) = blob_aabb(&[outer, hole], 0.0).unwrap();
+        // AABB should be ~[-1, 1] on each axis, not stretched to 10.
+        assert!(hi.x < 2.0, "subtract should not grow AABB, got hi.x={}", hi.x);
+        assert!(lo.x > -2.0);
+    }
+}

--- a/crates/mogen-geom/src/sdf.rs
+++ b/crates/mogen-geom/src/sdf.rs
@@ -17,18 +17,16 @@
 
 use glam::{Mat4, Vec3};
 
-/// One implicit primitive inside a `blob`. Position/rotation/scale are baked
-/// into `inv` so `sample()` can transform a world point into the primitive's
-/// local frame in one matvec.
+/// One implicit primitive inside a `blob`.
 #[derive(Debug, Clone)]
 pub struct BlobChild {
     pub prim: SdfPrim,
     pub op: SdfOp,
-    /// Inverse of the child's local-to-blob transform.
+    /// Local-to-blob transform (forward), used for AABB computation.
+    pub xform: Mat4,
+    /// Inverse of `xform`, used for SDF sampling.
     pub inv: Mat4,
-    /// Smallest scale component of the forward transform — distances scale
-    /// linearly with the local frame, so we multiply the local SDF by this to
-    /// keep results conservative in blob space.
+    /// Smallest scale component — conservative Lipschitz correction for `sample`.
     pub scale_min: f32,
 }
 
@@ -135,9 +133,9 @@ impl SdfPrim {
 impl BlobChild {
     /// Build a `BlobChild` from a primitive and its local-to-blob transform.
     pub fn new(prim: SdfPrim, op: SdfOp, xform: Mat4) -> Self {
-        let (s, _, _) = decompose_scale(&xform);
+        let (s, _, _) = xform.to_scale_rotation_translation();
         let scale_min = s.x.min(s.y).min(s.z).max(1e-6);
-        Self { prim, op, inv: xform.inverse(), scale_min }
+        Self { prim, op, xform, inv: xform.inverse(), scale_min }
     }
 
     /// Evaluate this primitive's SDF at point `p` in the blob's frame.
@@ -146,11 +144,9 @@ impl BlobChild {
         self.prim.sample_local(local) * self.scale_min
     }
 
-    /// World-space AABB after applying the child's transform, computed from
-    /// the 8 corners of the local AABB. Slightly loose but always valid.
+    /// World-space AABB from the 8 corners of the local AABB. Slightly loose but always valid.
     pub fn world_aabb(&self) -> (Vec3, Vec3) {
         let (lo, hi) = self.prim.local_aabb();
-        let xform = self.inv.inverse();
         let corners = [
             Vec3::new(lo.x, lo.y, lo.z),
             Vec3::new(hi.x, lo.y, lo.z),
@@ -164,7 +160,7 @@ impl BlobChild {
         let mut wmin = Vec3::splat(f32::INFINITY);
         let mut wmax = Vec3::splat(f32::NEG_INFINITY);
         for c in corners {
-            let w = xform.transform_point3(c);
+            let w = self.xform.transform_point3(c);
             wmin = wmin.min(w);
             wmax = wmax.max(w);
         }
@@ -189,16 +185,22 @@ pub fn smax(a: f32, b: f32, k: f32) -> f32 {
     -smin(-a, -b, k)
 }
 
-/// Combine an ordered list of `BlobChild`s into a single field value at `p`.
-/// Add children blend via `smin`; subtract children carve via `smax`. Order
-/// matches author intent: layer additions, then carve cavities.
+/// Combine `children` into a single field value at `p`.
+///
+/// Two-pass: all Add children are smin-blended first, then Subtract children
+/// carve via smax. This makes child ordering irrelevant — a subtract listed
+/// before an add is not silently dropped (which would happen if subtracts ran
+/// first against the initial +∞ sentinel).
 pub fn evaluate_field(children: &[BlobChild], p: Vec3, k: f32) -> f32 {
     let mut field = f32::INFINITY;
     for c in children {
-        let d = c.sample(p);
-        match c.op {
-            SdfOp::Add => field = smin(field, d, k),
-            SdfOp::Subtract => field = smax(field, -d, k),
+        if matches!(c.op, SdfOp::Add) {
+            field = smin(field, c.sample(p), k);
+        }
+    }
+    for c in children {
+        if matches!(c.op, SdfOp::Subtract) {
+            field = smax(field, -c.sample(p), k);
         }
     }
     field
@@ -226,11 +228,6 @@ pub fn blob_aabb(children: &[BlobChild], pad: f32) -> Option<(Vec3, Vec3)> {
         return None;
     }
     Some((lo - Vec3::splat(pad), hi + Vec3::splat(pad)))
-}
-
-fn decompose_scale(m: &Mat4) -> (Vec3, glam::Quat, Vec3) {
-    let (s, r, t) = m.to_scale_rotation_translation();
-    (s, r, t)
 }
 
 #[cfg(test)]
@@ -303,6 +300,23 @@ mod tests {
         // Point inside the carved cavity should now read as outside.
         let h = evaluate_field(&[outer, hole], Vec3::new(0.7, 0.0, 0.0), 0.0);
         assert!(h > 0.0, "cavity centre should read as outside, got {h}");
+    }
+
+    #[test]
+    fn subtract_before_add_still_carves() {
+        // Subtract child is listed first — must still carve (two-pass evaluator).
+        let hole = BlobChild::new(
+            SdfPrim::Sphere { radius: 0.4 },
+            SdfOp::Subtract,
+            Mat4::from_translation(Vec3::new(0.7, 0.0, 0.0)),
+        );
+        let outer = BlobChild::new(
+            SdfPrim::Sphere { radius: 1.0 },
+            SdfOp::Add,
+            Mat4::IDENTITY,
+        );
+        let h = evaluate_field(&[hole, outer], Vec3::new(0.7, 0.0, 0.0), 0.0);
+        assert!(h > 0.0, "subtract-before-add should still carve cavity centre, got {h}");
     }
 
     #[test]

--- a/crates/mogen-geom/src/subdivide.rs
+++ b/crates/mogen-geom/src/subdivide.rs
@@ -1,0 +1,258 @@
+//! Loop subdivision for triangle meshes.
+//!
+//! Used by the `subdivide=N` post-pass on any mesh-producing node — most
+//! valuably on `blob` outputs (where surface-nets produces a slightly
+//! staircased mesh that one round of Loop smooths beautifully) and on raw
+//! primitives the LLM wants to refine without re-tessellating.
+//!
+//! Each iteration replaces every triangle with four, then repositions every
+//! vertex by a weighted average of its neighbours. After `N` iterations,
+//! triangle count grows by 4^N — the lowering pass caps `N` to keep this in
+//! check.
+
+use std::collections::HashMap;
+
+use glam::Vec3;
+use mogen_core::Mesh;
+
+use crate::cleanup::recompute_normals;
+
+/// Apply `iterations` rounds of Loop subdivision. `iterations == 0` returns
+/// a clone of the input untouched. Normals are recomputed at the end so the
+/// result is shading-ready.
+pub fn loop_subdivide(mesh: &Mesh, iterations: u32) -> Mesh {
+    if iterations == 0 || mesh.indices.is_empty() {
+        return mesh.clone();
+    }
+    let mut current = mesh.clone();
+    for _ in 0..iterations {
+        current = subdivide_once(&current);
+    }
+    recompute_normals(&current)
+}
+
+/// Key for the edge map. Vertex indices are sorted so `(a, b)` and `(b, a)`
+/// collapse to the same key.
+type EdgeKey = (u32, u32);
+
+fn edge_key(a: u32, b: u32) -> EdgeKey {
+    if a < b { (a, b) } else { (b, a) }
+}
+
+struct EdgeData {
+    /// The two opposite-corner vertex ids across the (up to) two triangles
+    /// sharing this edge. Boundary edges have only one entry.
+    opposites: Vec<u32>,
+}
+
+fn subdivide_once(mesh: &Mesh) -> Mesh {
+    let n_in_verts = mesh.positions.len();
+    let has_uvs = mesh.uvs.len() == n_in_verts;
+
+    // Pass 1: collect edge data and per-vertex neighbour set.
+    let mut edges: HashMap<EdgeKey, EdgeData> = HashMap::new();
+    let mut neighbours: Vec<Vec<u32>> = vec![Vec::new(); n_in_verts];
+
+    let add_neighbour = |neighbours: &mut Vec<Vec<u32>>, v: u32, n: u32| {
+        let nbs = &mut neighbours[v as usize];
+        if !nbs.contains(&n) {
+            nbs.push(n);
+        }
+    };
+
+    for tri in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (tri[0], tri[1], tri[2]);
+        for &(u, v, opp) in &[(a, b, c), (b, c, a), (c, a, b)] {
+            edges.entry(edge_key(u, v)).or_insert_with(|| EdgeData { opposites: Vec::new() })
+                .opposites.push(opp);
+        }
+        add_neighbour(&mut neighbours, a, b);
+        add_neighbour(&mut neighbours, a, c);
+        add_neighbour(&mut neighbours, b, a);
+        add_neighbour(&mut neighbours, b, c);
+        add_neighbour(&mut neighbours, c, a);
+        add_neighbour(&mut neighbours, c, b);
+    }
+
+    // Pass 2: compute boundary classification.
+    // An edge is on the boundary if only one triangle references it.
+    let mut is_boundary_vertex = vec![false; n_in_verts];
+    for (key, data) in &edges {
+        if data.opposites.len() == 1 {
+            is_boundary_vertex[key.0 as usize] = true;
+            is_boundary_vertex[key.1 as usize] = true;
+        }
+    }
+
+    // Pass 3: allocate new vertex for every edge.
+    let mut edge_to_new: HashMap<EdgeKey, u32> = HashMap::with_capacity(edges.len());
+    let mut new_positions: Vec<[f32; 3]> = Vec::with_capacity(n_in_verts + edges.len());
+    let mut new_uvs: Vec<[f32; 2]> = if has_uvs {
+        Vec::with_capacity(n_in_verts + edges.len())
+    } else {
+        Vec::new()
+    };
+
+    // Slot the smoothed old-vertex positions first (indices 0..n_in_verts).
+    for v in 0..n_in_verts {
+        let p_old = Vec3::from_array(mesh.positions[v]);
+        let p_new = if is_boundary_vertex[v] {
+            // Boundary rule: 3/4 self + 1/8 of each neighbour that's also on
+            // the boundary (there should be exactly two).
+            let mut acc = Vec3::ZERO;
+            let mut count = 0;
+            for &n in &neighbours[v] {
+                if is_boundary_vertex[n as usize]
+                    && edges
+                        .get(&edge_key(v as u32, n))
+                        .map(|e| e.opposites.len() == 1)
+                        .unwrap_or(false)
+                {
+                    acc += Vec3::from_array(mesh.positions[n as usize]);
+                    count += 1;
+                }
+            }
+            if count == 0 {
+                p_old
+            } else {
+                p_old * 0.75 + acc * (1.0 / 8.0)
+            }
+        } else {
+            let n = neighbours[v].len();
+            if n == 0 {
+                p_old
+            } else {
+                let beta = loop_beta(n);
+                let mut acc = Vec3::ZERO;
+                for &nb in &neighbours[v] {
+                    acc += Vec3::from_array(mesh.positions[nb as usize]);
+                }
+                p_old * (1.0 - (n as f32) * beta) + acc * beta
+            }
+        };
+        new_positions.push(p_new.to_array());
+        if has_uvs {
+            // UVs are not smoothed for old vertices — Loop's mask is for
+            // positions; smoothing UVs would shift the texture pattern.
+            new_uvs.push(mesh.uvs[v]);
+        }
+    }
+
+    // Now allocate one new vertex per edge, with Loop's edge mask.
+    for (&key, data) in &edges {
+        let (a, b) = (key.0, key.1);
+        let pa = Vec3::from_array(mesh.positions[a as usize]);
+        let pb = Vec3::from_array(mesh.positions[b as usize]);
+        let p = if data.opposites.len() == 2 {
+            let pc = Vec3::from_array(mesh.positions[data.opposites[0] as usize]);
+            let pd = Vec3::from_array(mesh.positions[data.opposites[1] as usize]);
+            (pa + pb) * (3.0 / 8.0) + (pc + pd) * (1.0 / 8.0)
+        } else {
+            // Boundary edge: linear midpoint.
+            (pa + pb) * 0.5
+        };
+        let new_idx = new_positions.len() as u32;
+        new_positions.push(p.to_array());
+        if has_uvs {
+            // Linear midpoint UV (cheap and works for the bbox/planar UVs
+            // primitives produce).
+            let ua = mesh.uvs[a as usize];
+            let ub = mesh.uvs[b as usize];
+            new_uvs.push([(ua[0] + ub[0]) * 0.5, (ua[1] + ub[1]) * 0.5]);
+        }
+        edge_to_new.insert(key, new_idx);
+    }
+
+    // Pass 4: rebuild triangle list (each old tri → 4 new tris).
+    let mut new_indices: Vec<u32> = Vec::with_capacity(mesh.indices.len() * 4);
+    for tri in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (tri[0], tri[1], tri[2]);
+        let m_ab = edge_to_new[&edge_key(a, b)];
+        let m_bc = edge_to_new[&edge_key(b, c)];
+        let m_ca = edge_to_new[&edge_key(c, a)];
+        new_indices.extend_from_slice(&[a, m_ab, m_ca]);
+        new_indices.extend_from_slice(&[b, m_bc, m_ab]);
+        new_indices.extend_from_slice(&[c, m_ca, m_bc]);
+        new_indices.extend_from_slice(&[m_ab, m_bc, m_ca]);
+    }
+
+    // Normals get recomputed once at the end of `loop_subdivide`; we leave a
+    // matching-length but zeroed normals array here to keep the Mesh field
+    // shapes consistent for intermediate iterations.
+    let normals = vec![[0.0_f32, 0.0, 0.0]; new_positions.len()];
+    let uvs = if has_uvs {
+        new_uvs
+    } else {
+        Vec::new()
+    };
+
+    Mesh {
+        positions: new_positions,
+        normals,
+        uvs,
+        indices: new_indices,
+        ..Default::default()
+    }
+}
+
+/// Loop's β for a vertex with `n` neighbours. Returns the per-neighbour
+/// weight; the centre vertex weight is `1 - n*β`.
+fn loop_beta(n: usize) -> f32 {
+    if n == 3 {
+        3.0 / 16.0
+    } else {
+        // Warren's modification (smoother, used by most modern subdiv impls).
+        3.0 / (8.0 * n as f32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::sphere_mesh;
+    use mogen_core::UvMode;
+
+    #[test]
+    fn zero_iters_returns_clone() {
+        let s = sphere_mesh(0.5, 8, 12, UvMode::Fit);
+        let r = loop_subdivide(&s, 0);
+        assert_eq!(r.indices.len(), s.indices.len());
+        assert_eq!(r.positions.len(), s.positions.len());
+    }
+
+    #[test]
+    fn one_iter_quadruples_triangles() {
+        let s = sphere_mesh(0.5, 8, 12, UvMode::Fit);
+        let r = loop_subdivide(&s, 1);
+        assert_eq!(r.indices.len(), s.indices.len() * 4);
+    }
+
+    #[test]
+    fn subdivided_sphere_stays_near_surface() {
+        // Loop on a UV sphere should produce a smoother sphere — every
+        // vertex should still lie close to the 0.5-radius surface (a little
+        // inward because Loop is approximating, never exactly on it).
+        let s = sphere_mesh(0.5, 8, 12, UvMode::Fit);
+        let r = loop_subdivide(&s, 2);
+        for p in &r.positions {
+            let len = (p[0] * p[0] + p[1] * p[1] + p[2] * p[2]).sqrt();
+            assert!(
+                (len - 0.5).abs() < 0.07,
+                "subdivided vertex strayed: dist={len}",
+            );
+        }
+    }
+
+    #[test]
+    fn normals_are_unit_length_after_subdivide() {
+        let s = sphere_mesh(0.5, 6, 8, UvMode::Fit);
+        let r = loop_subdivide(&s, 1);
+        for n in &r.normals {
+            let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+            assert!(
+                (len - 1.0).abs() < 1e-3,
+                "non-unit normal after subdivide: |n|={len}",
+            );
+        }
+    }
+}

--- a/crates/mogen-llm/src/prompt.rs
+++ b/crates/mogen-llm/src/prompt.rs
@@ -436,11 +436,27 @@ mod tests {
         // `cacheable_block()` and don't count against this budget. Two new
         // fewshots demonstrating `extrude` (I-beam) and `loft` (boat hull)
         // added ~1 KB to the inline portion; cap raised from 25_000 →
-        // 26_500 to keep headroom for one more fewshot.
+        // 26_500 to keep headroom for one more fewshot. The `blob` rollout
+        // (organic-mass paragraph in PREAMBLE rule 8 + a `human skull`
+        // fewshot demonstrating subtract-carved eye sockets and nasal
+        // cavity) added ~1.7 KB net; cap raised 26_500 → 28_500 because
+        // every existing fewshot still earns its bytes and the skull is
+        // the highest-leverage example for organic anatomy. First
+        // production run had the model split the skull into separate
+        // cranium + jaw blobs and `attach` them; the anti-split rule
+        // ("ONE anatomical object = ONE blob") in PREAMBLE rule 8 plus
+        // a rescale of the skull fewshot to realistic ~0.15 m head size
+        // (so blend / cavity sizes track the Conventions table) added
+        // another ~0.5 KB; cap raised 28_500 → 29_500. Skull fewshot then
+        // gained a sizing-pitfalls comment block (cranium-height-matches-
+        // face, overlap-or-disconnect, cheekbones-within-width, mandible-
+        // narrower-than-maxilla) after the first regen produced an oversized
+        // cranium dome dwarfing a tiny face; ~30 B net, cap raised
+        // 29_500 → 30_000.
         let s = inline_block(&StdlibIndex::default());
         assert!(
-            s.len() < 26_500,
-            "inline_block grew to {} bytes — cap is 26_500. Either tighten an \
+            s.len() < 30_000,
+            "inline_block grew to {} bytes — cap is 30_000. Either tighten an \
              existing section, drop a fewshot, or move a stable section into \
              cacheable_block.",
             s.len()
@@ -466,10 +482,14 @@ mod tests {
         // `water_patch`) added ~530 bytes of Detailing-recipe entries; PR
         // review follow-up filled in `coil`/`heightfield`/`bezier_patch`/
         // `metaball` KINDS_REFERENCE rows for direct LLM authoring (~770 B).
+        // The new `blob` container kind (true SDF + surface-nets meshing
+        // for organic anatomical masses) added a KINDS_REFERENCE row plus
+        // `blob`/`subdivide`/`op` entries in the auto-rendered allowlist —
+        // ~700 bytes total; cap raised 31_000 → 32_000.
         let s = cacheable_block();
         assert!(
-            s.len() < 31_000,
-            "cacheable_block grew to {} bytes — cap is 31_000. Reference \
+            s.len() < 32_000,
+            "cacheable_block grew to {} bytes — cap is 32_000. Reference \
              material that grows without bound should be fetched on demand, \
              not pinned in the cache.",
             s.len()

--- a/crates/mogen-llm/src/prompt/content.rs
+++ b/crates/mogen-llm/src/prompt/content.rs
@@ -184,7 +184,29 @@ from a validator failure.
    ear/leg slightly different) — biology is never perfectly mirrored. \
    Material naming: `<creature>_<region>_<surface>` (e.g. \
    `tiger_back_fur`, `oak_bark`, `koi_belly_scales`) so the texture \
-   pipeline picks anatomical priors when generating the albedo.";
+   pipeline picks anatomical priors when generating the albedo. \
+   For **single-mass anatomical forms** — skulls, hearts, brains, \
+   organs, fruits, snouts, monster heads, melted creatures, slimes — \
+   use `blob { ... }` instead of stacking discrete primitives. **ONE \
+   anatomical object = ONE blob.** Do NOT split a skull into separate \
+   `cranium` and `jaw` blobs and `attach` them — each blob is its own \
+   SDF field, surfaces don't blend across boundaries, the result is two \
+   disconnected pieces. For an articulated jaw use a skinned mesh. \
+   **For complex anatomy (skulls, faces, monster heads), prefer the \
+   carve-from-a-block approach** over the stack-of-bumps approach: ONE \
+   large head-shaped additive ellipsoid as the entire mass, then use \
+   `op=\"subtract\"` children to carve features and undercut (mandible \
+   undercut, cheek recesses, temple flattening, eye sockets, nasal \
+   cavity, mouth slit). Add small additive bumps only for things that \
+   PROTRUDE beyond the silhouette (brow ridge, chin, nose bridge). \
+   Stacking many small additive ellipsoids produces a kawaii balloon \
+   head with a tiny face stuck on; carving from a single mass naturally \
+   gives skull-like proportions because the additive silhouette already \
+   IS skull-shaped. Same principle for hearts (one mass, carve the \
+   cleft and ventricle separation), brains (one mass, carve the \
+   longitudinal fissure), fruits with cavities. Keep `blend` at ~3–8 % \
+   of the longest size axis (0.005–0.015 at 0.15 m skull scale); \
+   `resolution=128–160`. See `human skull` fewshot.";
 
 pub(super) const GRAMMAR_REFERENCE: &str = "\
 A `.mog` file is a sequence of nodes. Each node is:
@@ -455,6 +477,7 @@ pub(super) const KINDS_REFERENCE: &str = "\
 | `heightfield` | `size=[x,z]` | `segments_u`/`segments_v` (64 each, capped at 4096), `amplitude` (Y relief, 0.5), `octaves` (fbm depth, 1\\|..\\|8, default 4), `frequency` (base spatial freq, 1.0), `persistence` (octave amplitude falloff, 0.5), `seed`; tessellated XZ grid displaced along +Y by deterministic fbm value-noise. Hash mixer is byte-compatible with `noise=` deformer's `cell_noise`, so a heightfield and a `noise=`-deformed mesh share the same bumps for the same seed. Use for terrain, dunes, scaled rooftops, organic stone slabs. |
 | `bezier_patch` | `points=[[x,y,z], …]` (exactly 16, row-major 4×4) | `segments_u`/`segments_v` (16 each); bicubic Bézier surface — organic skin panels, faces, hoods, fenders, sails, fabric, pillows. Wrong point count is a friendly lower-time error. |
 | `metaball` | `points=[[x,y,z], …]` (centres) | `radius` (uniform across all centres) OR `radii=[r0, r1, …]` (one per centre — must match `points` length); `blend` (smooth-union distance, 0 = hard union), `rings`/`segments` (sphere tessellation, 16/24); N implicit spheres unioned with smooth blending — soft creatures, slimes, blobs, jellyfish bodies, pumpkin lobes. Requires `csg` feature. |
+| `blob` | implicit-field container | `blend` (smooth-min radius, scene units, typical 0.05–0.25), `resolution` (voxel grid along longest AABB axis, default 96, max 256), `subdivide` (Loop post-pass, 0–3, default 0); **true SDF + surface-nets** mesh of `sphere`/`ellipsoid`/`box`/`rounded_box`/`capsule`/`cylinder`/`torus` children, smoothly blended into one continuous watertight surface. A child carrying `op=\"subtract\"` carves a smooth cavity (eye socket, nostril, mouth, dimple). The right tool for any organic mass that should read as ONE continuous form — skulls, hearts, brains, organs, fruits, animal faces, monster bodies. Always prefer over stacked primitives here: sphere + box + cone reads as a robot; the same skull as a `blob` of ellipsoids reads as bone. |
 | `decal` | name (acts as prompt fallback) | `size=[w,h]` (default `[0.5, 0.5]`), `prompt` (Gemini description), `image` (path; wins over `prompt`), `tint=[r,g,b]`, `roughness` (0.6), `offset` (+Z gap from surface, 0.001), **`on`/`at`/`up`/`lift`** (curved-surface shortcut — see below), `pos`, `rot`. Synthesizes its own transparent `alpha_mode=\"blend\"` material — DO NOT set `mat=`. Use for logos, labels, stickers, handwritten notes, patches: anything that's a transparent image overlaid on another surface. For flat hosts (a panel, a box face), parent the decal under the host and set `pos=`. For curved hosts (a bag, a bottle, a helmet), use `on=\"<host>\", at=\"<connector>\"` so the decal's vertices bend onto the surface — much better than floating a flat quad above curvature. |
 | `branch` | `length`, `radius`, `depth` | `splits`, `length_falloff`, `radius_falloff`, `branch_angle`, `roll`, `tropism`, `bend`, `seed`, `jitter`, `leaves`, `leaf_size`, `leaf_cards`, `leaf_mat`; **recursive procedural tree — one declaration becomes a whole tree** |
 | `slab` | `size=[x,y,z]` | `box` alias; default `anchor=bottom` (sits on ground) |
@@ -509,7 +532,7 @@ pub(super) const KINDS_REFERENCE: &str = "\
 | `extrude`, `sweep`, `loft` | `top`, `bottom`, `left`, `right`, `front`, `back` (synthesized from the lowered mesh AABB — same as `group`) |";
 
 pub(super) const FEWSHOT: &str = "\
-Ten prompt / output pairs spanning mechanical, architectural, and organic \
+Prompt / output pairs spanning mechanical, architectural, and organic \
 subjects. The user message will be a single short phrase like these.
 
 ### Prompt: \"a simple wooden stool\"
@@ -805,6 +828,40 @@ scene {
     samples=12,
     mat=\"hull\"
   )
+}
+
+### Prompt: \"a human skull\"
+### Output:
+meta (name = \"human_skull\", description = \"a stylised human skull from a single blob of ellipsoids with carved eye sockets, nose and mouth\", tags = [\"anatomy\", \"skull\", \"bone\"])
+
+material \"bone\" (color=[0.92, 0.88, 0.78], roughness=0.55)
+
+scene {
+  // CARVE-FROM-A-BLOCK approach: ONE head-shaped ellipsoid is the entire
+  // skull mass; subtracts carve mandible undercut + cheek recesses +
+  // temple flattening + eye sockets + nasal + mouth. Two small additive
+  // bumps for brow ridge and chin (the only features that PROTRUDE beyond
+  // the head silhouette). This beats stacking many small additive
+  // ellipsoids — stack-of-bumps produces a balloon head with a tiny
+  // face stuck on; carving from a single mass naturally gives skull-like
+  // proportions because the additive silhouette already IS skull-shaped.
+  // ONE blob = ONE skull (never split cranium + jaw).
+  blob \"skull\" (blend=0.008, resolution=160, mat=\"bone\") {
+    // Additive: one head, plus brow + chin protrusions.
+    ellipsoid (size=[0.140, 0.200, 0.180], pos=[0, -0.010,  0.005])   // head mass
+    ellipsoid (size=[0.110, 0.025, 0.025], pos=[0,  0.030, -0.085])   // brow ridge
+    ellipsoid (size=[0.045, 0.035, 0.050], pos=[0, -0.085, -0.055])   // chin
+    // Subtractive: undercut + recesses + sockets.
+    ellipsoid (size=[0.110, 0.060, 0.100], pos=[0, -0.105,  0.020], op=subtract) // jaw undercut
+    sphere    (radius=0.045, pos=[-0.080, -0.045, -0.040], op=subtract) // L cheek recess
+    sphere    (radius=0.045, pos=[ 0.080, -0.045, -0.040], op=subtract) // R cheek recess
+    sphere    (radius=0.060, pos=[-0.105,  0.035, -0.010], op=subtract) // L temple
+    sphere    (radius=0.060, pos=[ 0.105,  0.035, -0.010], op=subtract) // R temple
+    sphere    (radius=0.033, pos=[-0.033,  0.005, -0.085], op=subtract) // L eye socket
+    sphere    (radius=0.033, pos=[ 0.033,  0.005, -0.085], op=subtract) // R eye socket
+    ellipsoid (size=[0.022, 0.055, 0.040], pos=[0, -0.030, -0.095], op=subtract) // nasal
+    ellipsoid (size=[0.060, 0.008, 0.020], pos=[0, -0.058, -0.080], op=subtract) // mouth slit
+  }
 }";
 
 pub(super) const OUTPUT_CONTRACT: &str = "\n\n## Output contract\n\n\

--- a/crates/mogen-validate/src/ast_checks/schema.rs
+++ b/crates/mogen-validate/src/ast_checks/schema.rs
@@ -11,7 +11,7 @@ pub const KNOWN_KINDS: &[&str] = &[
     "meta",
     "box", "plane", "quad", "cylinder", "cone", "sphere", "capsule", "torus",
     "prism", "pyramid", "disc", "icosphere", "rounded_box", "chamfered_box", "inset_box",
-    "wedge", "frustum", "tube", "hemisphere", "half_cylinder", "torus_arc", "ellipsoid", "heightfield", "bezier_patch", "metaball",
+    "wedge", "frustum", "tube", "hemisphere", "half_cylinder", "torus_arc", "ellipsoid", "heightfield", "bezier_patch", "metaball", "blob",
     "superellipsoid", "curved_plane", "lathe", "spline_tube", "spline_ribbon", "coil", "leaf_card", "mesh",
     "extrude", "sweep", "loft",
     "slab", "post", "panel", "wall",
@@ -63,6 +63,16 @@ pub const GEOMETRY_COMMON_ATTRS: &[&str] = &[
     // Per-node LOD multiplier — compounds with the file-global `lod_scale`
     // for the duration of this node and its subtree (see lod.rs guards).
     "lod",
+    // Loop subdivision post-pass count (clamped to [0, 3]). Honoured on any
+    // mesh-producing kind: leaf primitives, `union`/`difference`/`intersect`,
+    // and `blob`. No-op on group/scene/replicator nodes.
+    "subdivide",
+    // Blob-child operator: `op="subtract"` (or `"sub"`/`"carve"`) inside a
+    // `blob {}` body carves a smooth cavity instead of adding mass. Ignored
+    // outside a `blob` container — kept in the geometry-common list so the
+    // LLM can write `sphere(op=subtract)` as a blob child without tripping
+    // the per-kind allowlist on `sphere`.
+    "op",
 ];
 
 /// Transform-only subset. Used by `skeleton` (places the whole rig) and `bone`
@@ -168,6 +178,13 @@ pub fn attrs_for_kind(kind: &str) -> &'static [&'static str] {
         ],
         "bezier_patch" => &["points", "segments_u", "segments_v"],
         "metaball" => &["points", "radius", "radii", "blend", "rings", "segments"],
+        // True SDF + surface-nets container. Children are implicit-field
+        // primitives (sphere, ellipsoid, box, rounded_box, capsule, cylinder,
+        // torus) combined with smooth-min, with optional `op=subtract`
+        // children for smooth cavities. Distinct code path from `metaball`
+        // (which only smooths sphere clusters) and `union(smooth=k)`
+        // (vertex-fillet approximation of mesh CSG).
+        "blob" => &["blend", "resolution"],
         "leaf_card" => &["size", "cards"],
         "extrude" => &["points", "hole", "height", "taper", "twist", "caps"],
         "sweep" => &[
@@ -301,7 +318,10 @@ pub(super) fn attr_type(kind: &str, attr: &str) -> Option<&'static str> {
         | (_, "wave_phase")
         | (_, "faceted")
         | (_, "cast_shadow")
-        | (_, "lod") => "number",
+        | (_, "lod")
+        | (_, "subdivide") => "number",
+        // Blob-child operator; valid values checked at lowering time.
+        (_, "op") => "string",
         ("chamfered_box", "radius") => "number",
         ("inset_box", "face") => "string",
         (_, "wave_axis") => "string",
@@ -498,6 +518,8 @@ pub(super) fn attr_type(kind: &str, attr: &str) -> Option<&'static str> {
         | ("metaball", "blend")
         | ("metaball", "rings")
         | ("metaball", "segments")
+        | ("blob", "blend")
+        | ("blob", "resolution")
         | ("frustum", "height")
         | ("union", "smooth")
         | ("material", "alpha")

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -20,6 +20,8 @@ modules, see [`modules.md`](./modules.md).
 - [Conform: moulding a primitive onto a target surface](#conform-moulding-a-primitive-onto-a-target-surface)
 - [Replicators: `mirror`, `array`, `stack`, `grid`](#replicators-mirror-array-stack-grid)
 - [CSG: `union` / `difference` / `intersect`](#csg-union--difference--intersect)
+- [Implicit-field blob: `blob`](#implicit-field-blob-blob)
+- [Mesh subdivision: `subdivide`](#mesh-subdivision-subdivide)
 - [Solid groups: `solid`](#solid-groups-solid)
 - [Modules: `module` and `use`](#modules-module-and-use)
 - [Imports: `import`](#imports-import)
@@ -95,7 +97,7 @@ Top-level directives that tune the build itself.
 
 | directive | value | effect |
 |---|---|---|
-| `lod_scale (value=N)` | number, default `1.0` | multiplies every primitive `segments`/`rings`/`samples` (implicit defaults *and* explicit values like `segments_u=64`). `icosphere` `subdivisions` step by `round(log2(N))` instead. Counts clamp to a per-primitive minimum |
+| `lod_scale (value=N)` | number, default `1.0` | multiplies every primitive `segments`/`rings`/`samples` (implicit defaults *and* explicit values like `segments_u=64`) and `blob` `resolution`. `icosphere` `subdivisions` and any `subdivide=` post-pass step by `round(log2(N))` instead. Counts clamp to a per-primitive minimum |
 
 ```
 lod_scale (value=0.5)
@@ -340,6 +342,7 @@ All primitives accept the common attributes above (`pos`, `rot`, `scale`,
 | `heightfield` | — | XZ grid with fBm displacement. `size=[w,d]` (`[1, 1]`), `segments_u`/`segments_v` (32), `amplitude` (0.5), `octaves` (1..=8, default 3), `frequency` (1.0), `persistence` (0.5), `seed` (1). Layer `wave` on top for water |
 | `bezier_patch` | `points=[…]` (exactly 16 control points, row-major u × v) | `segments_u`/`segments_v` (12). Bicubic Bézier surface — corners are `[0]`/`[3]`/`[12]`/`[15]`, inner four `[5]/[6]/[9]/[10]` shape the bulge |
 | `metaball` | `points=[…]` (≥1) plus `radius=` or `radii=[…]` | `blend` (smooth-union radius, 0), `rings` (12), `segments` (16). Sugar over `union (smooth=k) { sphere … }` |
+| `blob` | container with implicit-field children | true SDF + surface-nets mesh of any mix of `sphere` / `ellipsoid` / `box` / `rounded_box` / `capsule` / `cylinder` / `torus` children, smoothly blended. Each child may carry `op="subtract"` to carve a smooth cavity. See [Implicit-field blob](#implicit-field-blob-blob) |
 | `extrude` | `points=[[x,z], …]` (closed CCW) | `hole=[[x,z], …]` (one CW inner contour), `height` (1.0), `taper` (1.0), `twist` (0), `caps` (1). Multi-hole: chain `extrude` + `difference` |
 | `sweep` | `profile=[[x,y], …]` (closed CCW), `path=[[x,y,z], …]` | `samples` per segment (8), `twist` (uniform deg), `roll=[deg, …]`, `scale_along=[s, …]`, `caps` (1). Generalises `spline_tube`/`spline_ribbon` |
 | `loft` | `points=[[x,z], …]`, `heights=[y, …]` | sections flat-packed in `points` (vertex counts must match); `samples` (4), `caps` (1) |
@@ -996,6 +999,105 @@ difference "wall_with_door" (mat="concrete") {
 Operand transforms bake into vertices at eval time. Connectors / `material`
 children on the CSG node apply; those on operands are ignored. Output is
 cleaned (weld, degen-tri cull, normal recompute) for a watertight mesh.
+
+---
+
+## Implicit-field blob: `blob`
+
+`blob { … }` meshes its children as a true SDF field via surface nets —
+distinct from both `metaball` (sphere-cluster on a vertex-fillet approximate
+union) and `union(smooth=k)` (vertex-fillet pull applied to a sharp mesh
+CSG). Use `blob` whenever you want **smooth concave junctions** —
+eye sockets melted into a cranium, the cleft of a heart, a nostril dipping
+into a snout. The vertex-fillet path breaks down on concave junctions and
+large blend radii; `blob` does not.
+
+```
+blob "heart" (blend=0.22, resolution=80, subdivide=1, mat="heart") {
+  sphere    (radius=0.45, pos=[-0.30, 0.32, 0])      // left lobe
+  sphere    (radius=0.45, pos=[ 0.30, 0.32, 0])      // right lobe
+  ellipsoid (size=[0.85, 1.00, 0.85], pos=[0, -0.25, 0])   // apex
+  sphere    (radius=0.20, pos=[0, 0.58, 0], op=subtract)   // cleft
+}
+```
+
+### Attributes
+
+- `blend` — smooth-min radius in scene units. `0` collapses to a sharp
+  union. Typical organic values: `0.05–0.25`. Higher = more melt.
+- `resolution` — voxels along the longest world-space axis of the AABB
+  enclosing every additive child (plus padding). Default `96`; clamped to
+  `[16, 256]`. Cost scales O(N³); `128` is usually plenty. Scales with the
+  active `lod_scale` (linear) and per-node `lod=`.
+- `subdivide` — optional Loop subdivision count applied to the surface-nets
+  output. Default `0` (surface nets is already clean enough for most uses);
+  bump to `1` only when you need extra shading smoothness. Stepped by
+  `round(log2(lod_scale))`, capped at 3. See
+  [Mesh subdivision](#mesh-subdivision-subdivide).
+- `mat`, `pos`, `rot`, `scale`, `role`, `tags` — same as any other mesh node.
+
+### Children
+
+Only implicit-field primitives are allowed inside a `blob`:
+
+| kind | attrs | SDF |
+|---|---|---|
+| `sphere` | `radius` | sphere |
+| `ellipsoid` | `size=[x,y,z]` | axis-aligned ellipsoid (radii are `size/2`) |
+| `box` | `size=[x,y,z]` | axis-aligned box |
+| `rounded_box` | `size`, `radius` | box with rounded edges |
+| `capsule` | `radius`, `height` | Y-axis capsule (caps at `±height/2 + radius`) |
+| `cylinder` | `radius`, `height` | Y-axis closed cylinder |
+| `torus` | `major`, `minor` | torus in XZ plane |
+
+Each child accepts `pos` / `rot` / `scale`, which set the local-to-blob
+transform applied before SDF evaluation. Non-uniform `scale` is allowed
+(distances are compressed by the smallest scale axis as a conservative
+Lipschitz fix); for elongated shapes prefer `ellipsoid` over a scaled
+`sphere`.
+
+The optional `op="subtract"` (synonyms: `"sub"`, `"carve"`) makes the child
+a smooth carver instead of an additive mass. At least one additive child
+is required — a blob of only subtracts has nothing to carve into.
+
+### Notes
+
+- Output is one mesh, one node. Children do not become separate scene nodes.
+- The mesh is always watertight (surface nets closes any iso it extracts).
+- UVs are bbox-projected (XZ planar). Pair with `uv_mode="tile"` for
+  tileable surface textures; fitted image textures will project from above.
+- A `blob` without `subdivide` shows mild stairstepping from the voxel
+  grid; one round of Loop subdivision polishes it. Two rounds is glassy
+  but quadruples tri count.
+
+See [`examples/nature/skull.mog`](../examples/nature/skull.mog) and
+[`examples/nature/heart.mog`](../examples/nature/heart.mog) for full
+worked examples.
+
+---
+
+## Mesh subdivision: `subdivide`
+
+Add `subdivide = N` to any mesh-producing node — primitives (`sphere`,
+`box`, `lathe`, …), CSG ops (`union` / `difference` / `intersect`), or
+`blob` — to run `N` rounds of Loop subdivision on the resulting mesh
+before it is attached to the scene graph. Each round splits every
+triangle into four; `N` is clamped to `[0, 3]` so the cap is `64×` the
+input triangles.
+
+```
+union (subdivide=1, mat="bone") {
+  sphere    (radius=0.5)
+  ellipsoid (size=[0.6, 0.4, 0.8], pos=[0, -0.3, 0])
+}
+```
+
+Use `subdivide` to polish staircased blob outputs, smooth a low-poly
+primitive without re-tessellating it (`icosphere(radius=1, subdivide=2)`
+is often nicer than `icosphere(subdivisions=4)` because Loop smooths
+existing topology), or refine a CSG output for shading. It is a no-op on
+container kinds with no own mesh (`group`, `scene`, `mirror`, `array`,
+`stack`, `grid`).
 
 ---
 

--- a/examples/nature/heart.mog
+++ b/examples/nature/heart.mog
@@ -1,0 +1,32 @@
+// Stylised heart shape built from a single `blob` container. Two upper lobes
+// plus an elongated apex pointing down, smoothly blended into the classic
+// cardioid silhouette. The cleft between the lobes is carved with a
+// subtractive sphere — sharper than the blend would give on its own.
+//
+// This is the simplest possible `blob` example: three additive primitives
+// plus one subtract. Good baseline to compare against more complex blobs.
+// Realistic size (~0.12 m tall, roughly fist-sized) so it lands at the
+// same scale as a humanoid_full rig.
+
+meta (
+  name = "heart",
+  description = "Stylised heart — two lobes + apex blended into a cardioid, with a carved cleft.",
+  tags = ["anatomy", "heart", "blob", "organic"],
+)
+
+material "heart" (color=[0.78, 0.10, 0.12], roughness=0.40)
+
+scene {
+  blob "heart" (blend=0.020, resolution=80, mat="heart") {
+    // Two upper lobes (atria), slightly raised and to either side.
+    sphere (radius=0.045, pos=[-0.030, 0.032, 0])
+    sphere (radius=0.045, pos=[ 0.030, 0.032, 0])
+
+    // Apex (ventricles): elongated drop pointing down.
+    ellipsoid (size=[0.085, 0.100, 0.085], pos=[0, -0.025, 0])
+
+    // Cleft between the lobes: small carve at the top centre so the two
+    // lobes read as separate rather than merging into a single dome.
+    sphere (radius=0.020, pos=[0, 0.058, 0], op=subtract)
+  }
+}

--- a/examples/nature/skull.mog
+++ b/examples/nature/skull.mog
@@ -1,0 +1,79 @@
+// Human skull built from a single `blob` container — true SDF + surface-nets
+// meshing with the **carve-from-a-block** approach: one large head-shaped
+// ellipsoid is the entire skull mass, then subtractive children carve the
+// face structure (mandible undercut, cheek recesses, temple flattening,
+// eye sockets, nasal cavity, mouth slit). This works far better for
+// anatomy than stacking many small additive ellipsoids — the stack-of-
+// bumps approach produces a "kawaii balloon head", while carving from a
+// single mass naturally yields skull-like proportions because the additive
+// silhouette already IS skull-shaped.
+//
+// Key principle: additive geometry defines the OUTER silhouette; subtractive
+// geometry defines the FEATURES. For a skull:
+//   * 1 additive ellipsoid for the head mass (taller than wide, slightly
+//     deeper than tall — matches real ~22 × 14 × 18 cm proportions)
+//   * 2 small additive bumps for the brow ridge and chin (the only two
+//     features that PROTRUDE beyond the head silhouette)
+//   * 7 subtracts that scoop away material: under the jaw (separates
+//     mandible from "throat"), behind each cheekbone (creates the
+//     cheek-to-mouth recess so cheekbones and chin pop), behind each
+//     temple (flattens sides), then eye sockets / nasal cavity / mouth.
+//
+// ONE blob = ONE skull. Do NOT split cranium + jaw into separate blobs.
+//
+// Coordinate system: +Y up, the skull faces -Z. Realistic ~0.15 m wide
+// human-scale; blend ~4 % of longest size axis. resolution=160 keeps the
+// subtract cavities crisp.
+//
+// ~120k tris at LOD scale 1.0; `lod_scale (value=0.5)` drops to ~30k for
+// game-asset use, 0.25 for ~8k mobile.
+
+meta (
+  name = "skull",
+  description = "Human skull — carved from a single head-shaped ellipsoid with subtractive mandible undercut, cheek recesses, eye sockets, nasal cavity and mouth slit.",
+  tags = ["anatomy", "skull", "blob", "organic"],
+)
+
+material "bone" (color=[0.92, 0.88, 0.78], roughness=0.55)
+
+scene {
+  blob "skull" (blend=0.008, resolution=160, mat="bone") {
+    // === ADDITIVE: one head, plus protrusions for brow and chin ===
+
+    // Single head mass — taller than wide, slightly deeper than tall.
+    ellipsoid (size=[0.140, 0.200, 0.180], pos=[0, -0.010, 0.005])
+
+    // Brow ridge — small protrusion above the eye sockets.
+    ellipsoid (size=[0.110, 0.025, 0.025], pos=[0, 0.030, -0.085])
+
+    // Chin protrusion at the bottom front.
+    ellipsoid (size=[0.045, 0.035, 0.050], pos=[0, -0.085, -0.055])
+
+    // === SUBTRACTIVE: carve the face and undercut from the mass ===
+
+    // Undercut beneath the mandible — scoops out the lower-back area
+    // so the jaw is separated from where the "throat" would be.
+    ellipsoid (size=[0.110, 0.060, 0.100], pos=[0, -0.105, 0.020], op=subtract)
+
+    // Cheek-to-mouth recess on each side — carves a hollow behind the
+    // cheekbone area, which makes the cheekbones AND chin pop out as
+    // natural prominences rather than added bumps.
+    sphere (radius=0.045, pos=[-0.080, -0.045, -0.040], op=subtract)
+    sphere (radius=0.045, pos=[ 0.080, -0.045, -0.040], op=subtract)
+
+    // Temporal indentations — real skulls are slightly concave above
+    // and behind the ear, not perfectly spherical.
+    sphere (radius=0.060, pos=[-0.105, 0.035, -0.010], op=subtract)
+    sphere (radius=0.060, pos=[ 0.105, 0.035, -0.010], op=subtract)
+
+    // Eye sockets — deep round pits.
+    sphere (radius=0.033, pos=[-0.033, 0.005, -0.085], op=subtract)
+    sphere (radius=0.033, pos=[ 0.033, 0.005, -0.085], op=subtract)
+
+    // Nasal cavity — pear-shaped opening.
+    ellipsoid (size=[0.022, 0.055, 0.040], pos=[0, -0.030, -0.095], op=subtract)
+
+    // Mouth slit between maxilla and mandible.
+    ellipsoid (size=[0.060, 0.008, 0.020], pos=[0, -0.058, -0.080], op=subtract)
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `blob { ... }` container that meshes implicit-field children via fast-surface-nets — the path the existing `metaball` / `union(smooth=k)` nodes were too approximate to take. Concave junctions (smooth eye sockets, nostrils, smooth-subtracted cavities) and large blend radii now work correctly where the vertex-fillet union approximation broke down.

This unlocks LLM-driven generation of organic anatomical forms — skulls, hearts, organs, faces, monster heads — that previously came out as blocky robot-droid assemblies of `sphere + box + cone` parts.

## What's in

### Core primitive (`mogen-geom`)
- **`sdf`** — closed-form SDFs for sphere / ellipsoid / box / rounded_box / capsule / cylinder / torus, polynomial smin/smax, and a field evaluator that mixes Add and Subtract ops in order.
- **`isosurface`** — wrapper around `fast-surface-nets` v0.2 with padded AABB, defensive voxel cap, planar XZ-projected UVs.
- **`subdivide`** — Loop subdivision post-pass with proper boundary handling, smoothed UVs, recomputed normals.
- 15 new unit tests across the three modules.

### DSL (`mogen-dsl`)
- New `blob` kind in `lower/blob.rs`. Children must be implicit-field primitives; each accepts the usual `pos` / `rot` / `scale` plus an optional `op="subtract"` (synonyms `sub` / `carve`) to carve a smooth cavity rather than add mass. At least one additive child is required.
- `subdivide=N` as a general post-pass on any mesh-producing kind (primitives, CSG ops, blob). Capped at 3 (≤ 64× tris). Lives in `helpers::apply_subdivide`, called from the three mesh-set sites.

### LOD
- `blob.resolution` goes through `scaled_count` (linear, like primitive `segments`).
- `subdivide` goes through `scaled_subdivisions` (log2 offset, like `icosphere.subdivisions`).
- A global `lod_scale=0.5` drops a 120k-tri skull to ~30k; 0.25 to ~8k.

### Validator (`mogen-validate`)
- `blob` added to `KNOWN_KINDS`, `subdivide` and `op` added to `GEOMETRY_COMMON_ATTRS`, attribute types declared.

### Examples (`examples/nature/`)
- `skull.mog` — canonical anatomy example using the carve-from-a-block approach (one head-shaped ellipsoid + brow + chin protrusions, then subtractive mandible undercut / cheek recesses / temple flattening / eye sockets / nasal / mouth slit).
- `heart.mog` — minimal blob (3 additive + 1 subtract).

### Docs (`docs/dsl.md`)
- New "Implicit-field blob" and "Mesh subdivision" sections.
- `blob` row in the primitives table.
- `lod_scale` line updated to mention `blob.resolution` and any `subdivide=`.

### LLM system prompt (`mogen-llm`)
- KINDS_REFERENCE row spelling out blob's attrs, allowed children, `op=subtract`, and the *"stack of bumps reads as robot; blob of ellipsoids reads as bone"* framing.
- PREAMBLE rule 8 nudge for single-mass anatomical forms, with two explicit anti-patterns surfaced by real LLM regen failures:
  - Do NOT split a skull into separate cranium + jaw blobs and `attach` them (each blob is its own SDF field — surfaces don't blend across blob boundaries, the result is two disconnected pieces).
  - For complex anatomy prefer the **carve-from-a-block** pattern over **stack-of-bumps** (the latter produces a balloon head with a tiny face stuck on).
- `"a human skull"` fewshot at realistic 0.15 m head size, verbatim from the example file.

Prompt-cap test comments updated with the rationale trail: `cacheable_block` 31_000 → 32_000 (+blob KINDS_REFERENCE row, ~700 B); `inline_block` 26_500 → 30_000 (+PREAMBLE nudges + skull fewshot, ~3.5 KB across three iterations as production runs surfaced the anti-patterns).

## Why

User can now generate things like *"a human skull"* and get an actual skull (cranium dome, deep eye sockets, nasal cavity, mouth slit, defined jawline and chin from multiple angles) rather than a sphere balanced on a box with a cone for a nose. The carve-from-a-block insight applies beyond skulls — same pattern works for monster heads, faces, hearts, brains, organs.

## Test plan

- [x] All new modules unit-tested (15 tests in `mogen-geom::{sdf, isosurface, subdivide}`).
- [x] All 36 `mogen-llm::prompt::tests` pass (prompt assembly, cap tests, byte-stable output).
- [x] Full workspace `cargo test` passes except the pre-existing `mogen-llm::provider::tests::from_env_returns_missing_key_for_blank_cloud_provider` env-var test that fails on `master` too.
- [x] `examples/nature/skull.mog` and `heart.mog` validate clean.
- [x] Skull builds to 120k tris at LOD 1.0, ~30k at 0.5, ~8k at 0.25 (verified with `lod_scale (value=X)` wrapper).
- [x] Visually verified: skull reads as a skull from front, 3/4, side, above, and front-high views (eye sockets, brow, cheekbones, mandible, chin all visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)