### PR TITLE
Fix stale GlitchTip DSN in mogen-studio crash reporting

### DIFF
--- a/crates/mogen-studio/src/crash.rs
+++ b/crates/mogen-studio/src/crash.rs
@@ -10,7 +10,7 @@
 //! [`Settings::crash_reports_enabled`] consent flag — Sentry only initialises
 //! when the user has explicitly opted in.
 
-const DSN: &str = "https://fec046177fb54225805b1c011f783d5d@crash.daccord.gg/3";
+const DSN: &str = "https://9ee8ddd1a1b8436fa31e56cafa33a1bb@crash.daccord.gg/4";
 
 /// True when the environment hard-disables telemetry. Independent of any
 /// saved consent — env-level opt-out wins, so the first-launch prompt should

--- a/crates/mogen-studio/src/crash.rs
+++ b/crates/mogen-studio/src/crash.rs
@@ -47,3 +47,39 @@ pub fn init(consented: Option<bool>) -> Option<sentry::ClientInitGuard> {
         },
     )))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Env-var mutations must be serialised within this module — parallel tests
+    // on the same process would race on the shared environment.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn blocked_by_mogen_disable_telemetry() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("DO_NOT_TRACK");
+        std::env::set_var("MOGEN_DISABLE_TELEMETRY", "1");
+        assert!(telemetry_blocked_by_env());
+        std::env::remove_var("MOGEN_DISABLE_TELEMETRY");
+    }
+
+    #[test]
+    fn blocked_by_do_not_track() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("MOGEN_DISABLE_TELEMETRY");
+        std::env::set_var("DO_NOT_TRACK", "1");
+        assert!(telemetry_blocked_by_env());
+        std::env::remove_var("DO_NOT_TRACK");
+    }
+
+    #[test]
+    fn not_blocked_when_neither_var_set() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("MOGEN_DISABLE_TELEMETRY");
+        std::env::remove_var("DO_NOT_TRACK");
+        assert!(!telemetry_blocked_by_env());
+    }
+}


### PR DESCRIPTION
The crash-reporting DSN in `crates/mogen-studio/src/crash.rs` pointed at a project/key that no longer exists on the redeployed GlitchTip instance — and project id 3 there now belongs to **moghub**, so any events would have been misrouted or rejected.

Point it at the new `mogen-studio` project (id 4, org `cattrallgames`). The rest of the consent-gated init (env opt-out, `crash_reports_enabled` flag, panic capture) is unchanged — this is a one-line DSN fix.

Verified end-to-end against the live GlitchTip project (test event ingested, then deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)