### PR TITLE
ci(release): build Linux binaries on ubuntu-22.04 for older glibc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - os: macos-15-intel
             target: x86_64-apple-darwin


### PR DESCRIPTION
## Summary

Pin the Linux release runner to `ubuntu-22.04` (GLIBC 2.35) instead of `ubuntu-latest` (Ubuntu 24.04, GLIBC 2.39).

Prebuilt `mogen` / `mogen-studio` Linux binaries are dynamically linked against the runner's glibc. Built on 2.39, they require GLIBC 2.38+ at runtime and fail on Debian 12 / bookworm (GLIBC 2.36) — blocking both the CLI and the `mogen mcp` route in common container bases like `node:22-bookworm-slim`. GLIBC 2.35 covers Debian 12 and most current distros.

This is Option 1 (the quick fix) from #69. A static musl target remains the durable follow-up.

## Changes

- `.github/workflows/release.yml`: Linux build matrix entry `ubuntu-latest` → `ubuntu-22.04`.

## Notes for reviewers

- The `publish` job stays on `ubuntu-latest` — it only downloads artifacts and runs `sha256sum`, so no glibc-linked binary is produced there.
- `ubuntu-20.04` runners are being deprecated by GitHub, so 22.04 is the practical floor.

Fixes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)