### PR TITLE
studio: generate a wizard scene from a single source image

### DIFF
--- a/crates/mogen-llm/src/image.rs
+++ b/crates/mogen-llm/src/image.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 
 use crate::gemini::{GeminiAuth, GeminiClient, GeminiError};
 use crate::google_oauth;
+use crate::types::ImageInput;
 
 /// Default image model for API-key flows. 2.5 Flash Image ("Nano Banana") is
 /// the cheapest tier on the public `generativelanguage.googleapis.com` surface
@@ -68,6 +69,22 @@ impl GeminiClient {
         prompt: &str,
         seed: Option<u64>,
     ) -> Result<GeneratedImage, GeminiError> {
+        self.generate_image_with_inputs(model, prompt, seed, &[])
+    }
+
+    /// Same as [`Self::generate_image`] but conditions generation on one or
+    /// more input images (image-to-image / editing). The images are attached
+    /// as `inline_data` parts ahead of the text prompt — the shape Gemini's
+    /// image surface uses for "edit this picture" requests. Used by the Scene
+    /// Wizard to cut an isolated per-object reference out of a source photo.
+    /// Pass an empty slice for plain text-to-image.
+    pub fn generate_image_with_inputs(
+        &self,
+        model: &str,
+        prompt: &str,
+        seed: Option<u64>,
+        input_images: &[ImageInput],
+    ) -> Result<GeneratedImage, GeminiError> {
         // Honor the `ImageClient::generate_image` contract that `""` means
         // "use the provider default". Empty model would otherwise produce
         // `/models/:generateContent` and a confusing 404.
@@ -81,7 +98,7 @@ impl GeminiClient {
             GeminiAuth::ApiKey(key) => {
                 // Public API speaks `responseModalities: ["IMAGE"]` and returns
                 // a single JSON envelope.
-                let inner = build_image_request(prompt, seed, Some(&["IMAGE"]));
+                let inner = build_image_request(prompt, seed, Some(&["IMAGE"]), input_images);
                 let url = format!(
                     "{}/models/{}:generateContent?key={}",
                     self.base_url(),
@@ -144,7 +161,7 @@ impl GeminiClient {
                 let project = self
                     .oauth_project_id()
                     .ok_or_else(|| GeminiError::OAuth("missing project id in token bundle".into()))?;
-                let inner = build_image_request(prompt, seed, None);
+                let inner = build_image_request(prompt, seed, None, input_images);
 
                 let candidates: Vec<(String, bool)> =
                     if model == DEFAULT_OAUTH_IMAGE_MODEL || model.is_empty() {
@@ -388,6 +405,7 @@ fn build_image_request(
     prompt: &str,
     seed: Option<u64>,
     modalities: Option<&[&str]>,
+    input_images: &[ImageInput],
 ) -> serde_json::Value {
     let mut gen_cfg = serde_json::json!({});
     if let Some(m) = modalities {
@@ -399,10 +417,23 @@ fn build_image_request(
         let clipped = (s as i64) & 0x7FFF_FFFF;
         gen_cfg["seed"] = serde_json::json!(clipped);
     }
+    // Input images first, then the text instruction — the ordering Gemini
+    // recommends for image-editing turns (mirrors the text vision path in
+    // `gemini::build_request`).
+    let mut parts: Vec<serde_json::Value> = Vec::with_capacity(input_images.len() + 1);
+    for img in input_images {
+        parts.push(serde_json::json!({
+            "inline_data": {
+                "mime_type": img.mime_type,
+                "data": STANDARD.encode(&img.data),
+            }
+        }));
+    }
+    parts.push(serde_json::json!({ "text": prompt }));
     serde_json::json!({
         "contents": [{
             "role": "user",
-            "parts": [{ "text": prompt }],
+            "parts": parts,
         }],
         "generationConfig": gen_cfg,
     })
@@ -479,6 +510,31 @@ mod tests {
                 }
             })
         )
+    }
+
+    #[test]
+    fn build_image_request_text_only_has_single_text_part() {
+        let req = build_image_request("a chair", Some(7), Some(&["IMAGE"]), &[]);
+        let parts = req["contents"][0]["parts"].as_array().expect("parts array");
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0]["text"], "a chair");
+        assert_eq!(req["generationConfig"]["responseModalities"][0], "IMAGE");
+    }
+
+    #[test]
+    fn build_image_request_input_image_comes_before_text() {
+        let inputs = vec![ImageInput {
+            mime_type: "image/png".into(),
+            data: b"hello".to_vec(),
+        }];
+        let req = build_image_request("extract the chair", None, None, &inputs);
+        let parts = req["contents"][0]["parts"].as_array().expect("parts array");
+        assert_eq!(parts.len(), 2);
+        // Image part is first.
+        assert_eq!(parts[0]["inline_data"]["mime_type"], "image/png");
+        assert_eq!(parts[0]["inline_data"]["data"], STANDARD.encode(b"hello"));
+        // Text part is last.
+        assert_eq!(parts[1]["text"], "extract the chair");
     }
 
     #[test]

--- a/crates/mogen-llm/src/image_client.rs
+++ b/crates/mogen-llm/src/image_client.rs
@@ -69,9 +69,29 @@ impl ImageClient {
         seed: Option<u64>,
         ctx: &crate::spend::CallContext,
     ) -> Result<GeneratedImage, ImageError> {
+        self.generate_image_with_inputs(model, prompt, seed, &[], ctx)
+    }
+
+    /// Like [`Self::generate_image_with_context`] but conditions generation on
+    /// one or more input images (image-to-image / editing). Only providers
+    /// where [`Self::supports_image_input`] is `true` actually use the inputs;
+    /// others silently fall back to text-to-image. Records to the spend DB the
+    /// same way as the context variant.
+    pub fn generate_image_with_inputs(
+        &self,
+        model: &str,
+        prompt: &str,
+        seed: Option<u64>,
+        input_images: &[crate::types::ImageInput],
+        ctx: &crate::spend::CallContext,
+    ) -> Result<GeneratedImage, ImageError> {
         let result = match self {
-            Self::Gemini(c) => c.generate_image(model, prompt, seed).map_err(ImageError::from),
-            Self::Zai(c) => c.generate_image(model, prompt, seed).map_err(ImageError::from),
+            Self::Gemini(c) => c
+                .generate_image_with_inputs(model, prompt, seed, input_images)
+                .map_err(ImageError::from),
+            Self::Zai(c) => c
+                .generate_image_with_inputs(model, prompt, seed, input_images)
+                .map_err(ImageError::from),
         };
 
         if !ctx.is_empty() {
@@ -108,6 +128,17 @@ impl ImageClient {
         match self {
             Self::Gemini(_) => "gemini",
             Self::Zai(_) => "zai",
+        }
+    }
+
+    /// Whether this backend honours input images passed to
+    /// [`Self::generate_image_with_inputs`] (true image-to-image / editing).
+    /// Gemini's `generateContent` image surface does; Z.ai's `glm-image`
+    /// `/images/generations` is text-to-image only and ignores them.
+    pub fn supports_image_input(&self) -> bool {
+        match self {
+            Self::Gemini(_) => true,
+            Self::Zai(_) => false,
         }
     }
 }

--- a/crates/mogen-llm/src/zai.rs
+++ b/crates/mogen-llm/src/zai.rs
@@ -73,6 +73,23 @@ impl ZaiClient {
         Ok(Self::new(key))
     }
 
+    /// Image-to-image variant kept for signature symmetry with
+    /// [`crate::gemini::GeminiClient::generate_image_with_inputs`]. The public
+    /// Z.ai `glm-image` `/images/generations` surface is text-to-image only —
+    /// it has no input-image field — so `_input_images` is ignored and this is
+    /// a plain forward to [`Self::generate_image`]. Callers that need true
+    /// image-to-image (the Scene Wizard) must gate on
+    /// [`crate::image_client::ImageClient::supports_image_input`].
+    pub fn generate_image_with_inputs(
+        &self,
+        model: &str,
+        prompt: &str,
+        seed: Option<u64>,
+        _input_images: &[crate::types::ImageInput],
+    ) -> Result<GeneratedImage, ZaiError> {
+        self.generate_image(model, prompt, seed)
+    }
+
     /// Issue an image generation call and return decoded PNG bytes.
     ///
     /// `seed` is accepted for API symmetry with [`crate::gemini::GeminiClient`]

--- a/crates/mogen-studio/src/app/ui_wizard.rs
+++ b/crates/mogen-studio/src/app/ui_wizard.rs
@@ -686,14 +686,28 @@ impl MogenStudioApp {
             return;
         };
         session.state.prompt = session.prompt_draft.clone();
-        let has_image = session.state.source_image.is_some();
+        let has_image_path = session.state.source_image.is_some();
+        let (source_bytes, source_mime) = read_source_image(&session.state);
+        let has_image = source_bytes.is_some();
+        // Source image path is set but the file can't be read — likely moved or
+        // deleted after being picked. Surface this rather than silently falling
+        // back to text-only while the status line says "Reading the source image".
+        if has_image_path && !has_image {
+            session.error = Some(
+                "Source image could not be read — it may have been moved or deleted. \
+                 Clear the source image or choose a new one."
+                    .into(),
+            );
+            return;
+        }
         // An image-driven run needs a vision-capable text provider for the
         // brief/manifest; bail clearly instead of sending a photo into the
         // void on a text-only provider.
         if has_image && !provider.supports_images() {
             session.error = Some(format!(
-                "{provider:?} can't read images — switch to a vision provider (Gemini, OpenAI, \
-                 Anthropic…) in Preferences, or clear the source image."
+                "{} can't read images — switch to a vision provider (Gemini, OpenAI, \
+                 Anthropic…) in Preferences, or clear the source image.",
+                provider.label()
             ));
             return;
         }
@@ -701,7 +715,6 @@ impl MogenStudioApp {
             session.error = Some("Enter a scene prompt or choose a source image first.".into());
             return;
         }
-        let (source_bytes, source_mime) = read_source_image(&session.state);
         let _ = persist::save(&session.state);
         session.running = WizardBusy::Brief;
         session.error = None;
@@ -805,30 +818,44 @@ impl MogenStudioApp {
             pending.len(),
             names.join(", ")
         );
+        // Read the source image once here so batch spawns don't each re-read
+        // the file from disk (one read per object for up to 18 objects is
+        // wasteful; the bytes are cloned into each worker thread instead).
+        let (source_bytes, source_mime) = read_source_image(&session.state);
         // Wrap in Arc so each worker shares the same client without forcing
         // `ImageClient: Clone` (its inner Gemini auth holds a Mutex).
         let client = Arc::new(client);
         let seed = cfg.seed;
         for obj in pending {
-            self.spawn_reference_worker(ctx, obj, Arc::clone(&client), seed);
+            self.spawn_reference_worker(
+                ctx,
+                obj,
+                Arc::clone(&client),
+                seed,
+                source_bytes.clone(),
+                source_mime.clone(),
+            );
         }
     }
 
     /// Spawn a single reference-image worker. Assumes the caller has already
     /// reserved `obj.id` in `running_ref_ids` so the snapshot-and-filter loop
-    /// can't double-issue an id.
+    /// can't double-issue an id. `source_bytes`/`source_mime` should be read
+    /// once by the caller (via `read_source_image`) and passed in so batch
+    /// spawns don't re-read the source file once per object.
     fn spawn_reference_worker(
         &mut self,
         ctx: &egui::Context,
         obj: super::wizard::state::ObjectEntry,
         client: Arc<ImageClient>,
         seed: u64,
+        source_bytes: Option<Vec<u8>>,
+        source_mime: Option<String>,
     ) {
         let Some(session) = self.wizard.as_mut() else {
             return;
         };
         let out = session.state.references_dir().join(format!("{}.png", obj.id));
-        let (source_bytes, source_mime) = read_source_image(&session.state);
         let tx = session.tx.clone();
         let ctx_clone = ctx.clone();
         let id = obj.id.clone();
@@ -872,7 +899,13 @@ impl MogenStudioApp {
             s.running_ref_ids.insert(id.clone());
             obj
         };
-        self.spawn_reference_worker(ctx, obj, Arc::new(client), seed);
+        let (source_bytes, source_mime) = {
+            let Some(s) = self.wizard.as_ref() else {
+                return;
+            };
+            read_source_image(&s.state)
+        };
+        self.spawn_reference_worker(ctx, obj, Arc::new(client), seed, source_bytes, source_mime);
     }
 
     /// Spawn up to `target_concurrency` per-object module workers, skipping

--- a/crates/mogen-studio/src/app/ui_wizard.rs
+++ b/crates/mogen-studio/src/app/ui_wizard.rs
@@ -334,6 +334,8 @@ impl MogenStudioApp {
                     let _ = persist::save(&s.state);
                 }
             }
+            WizardAction::PickSourceImage => self.pick_wizard_source_image(),
+            WizardAction::ClearSourceImage => self.clear_wizard_source_image(),
             WizardAction::GenerateBrief => self.start_wizard_brief(ctx),
             WizardAction::AdvanceToManifest => {
                 if let Some(s) = self.wizard.as_mut() {
@@ -498,6 +500,57 @@ impl MogenStudioApp {
         }
     }
 
+    /// Pick a source image and copy it into the wizard project dir as
+    /// `source.<ext>`, then point `state.source_image` at the copy. Copying
+    /// keeps the run self-contained: the file survives even if the user moves
+    /// or deletes the original, and a Studio restart resumes image-driven.
+    fn pick_wizard_source_image(&mut self) {
+        let picked = rfd::FileDialog::new()
+            .set_title("Choose a source image")
+            .add_filter("Image", &["png", "jpg", "jpeg", "webp"])
+            .set_directory(&self.project_root)
+            .pick_file();
+        let Some(picked) = picked else {
+            return;
+        };
+        let Some(s) = self.wizard.as_mut() else {
+            return;
+        };
+        let ext = picked
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase())
+            .filter(|e| matches!(e.as_str(), "png" | "jpg" | "jpeg" | "webp"))
+            .unwrap_or_else(|| "png".to_string());
+        // Drop any prior copy so a re-pick with a different extension doesn't
+        // leave a stale source.* behind.
+        if let Some(old) = s.state.source_image.take() {
+            let _ = std::fs::remove_file(old);
+        }
+        let dest = s.state.project_dir.join(format!("source.{ext}"));
+        match std::fs::copy(&picked, &dest) {
+            Ok(_) => {
+                s.state.source_image = Some(dest);
+                s.error = None;
+                s.status = "Source image set — the scene will be generated from it.".into();
+                let _ = persist::save(&s.state);
+            }
+            Err(e) => {
+                s.error = Some(format!("Couldn't copy source image: {e}"));
+            }
+        }
+    }
+
+    fn clear_wizard_source_image(&mut self) {
+        if let Some(s) = self.wizard.as_mut() {
+            if let Some(old) = s.state.source_image.take() {
+                let _ = std::fs::remove_file(old);
+            }
+            s.status = "Source image cleared — back to a text-only run.".into();
+            let _ = persist::save(&s.state);
+        }
+    }
+
     fn confirm_wizard_location(&mut self) {
         let Some(s) = self.wizard.as_mut() else {
             return;
@@ -627,24 +680,41 @@ impl MogenStudioApp {
             self.wizard_set_error("Provider credentials missing — open Preferences and sign in.".into());
             return;
         };
+        let provider = self.settings.provider_slot().to_provider();
         let cfg = self.build_wizard_run_config();
         let Some(session) = self.wizard.as_mut() else {
             return;
         };
         session.state.prompt = session.prompt_draft.clone();
-        if session.state.prompt.trim().is_empty() {
-            session.error = Some("Enter a scene prompt first.".into());
+        let has_image = session.state.source_image.is_some();
+        // An image-driven run needs a vision-capable text provider for the
+        // brief/manifest; bail clearly instead of sending a photo into the
+        // void on a text-only provider.
+        if has_image && !provider.supports_images() {
+            session.error = Some(format!(
+                "{provider:?} can't read images — switch to a vision provider (Gemini, OpenAI, \
+                 Anthropic…) in Preferences, or clear the source image."
+            ));
             return;
         }
+        if !has_image && session.state.prompt.trim().is_empty() {
+            session.error = Some("Enter a scene prompt or choose a source image first.".into());
+            return;
+        }
+        let (source_bytes, source_mime) = read_source_image(&session.state);
         let _ = persist::save(&session.state);
         session.running = WizardBusy::Brief;
         session.error = None;
-        session.status = "Generating scene brief…".into();
+        session.status = if has_image {
+            "Reading the source image…".into()
+        } else {
+            "Generating scene brief…".into()
+        };
         let tx = session.tx.clone();
         let ctx_clone = ctx.clone();
         let prompt = session.state.prompt.clone();
         std::thread::spawn(move || {
-            let result = run_brief(client, sys, prompt, cfg);
+            let result = run_brief(client, sys, prompt, source_bytes, source_mime, cfg);
             let _ = tx.send(WizardMessage::BriefDone(result));
             ctx_clone.request_repaint();
         });
@@ -664,13 +734,14 @@ impl MogenStudioApp {
             session.error = Some("Generate a brief first.".into());
             return;
         };
+        let (source_bytes, source_mime) = read_source_image(&session.state);
         session.running = WizardBusy::Manifest;
         session.error = None;
         session.status = "Generating object manifest…".into();
         let tx = session.tx.clone();
         let ctx_clone = ctx.clone();
         std::thread::spawn(move || {
-            let result = run_manifest(client, sys, prompt, brief, cfg);
+            let result = run_manifest(client, sys, prompt, brief, source_bytes, source_mime, cfg);
             let _ = tx.send(WizardMessage::ManifestDone(result));
             ctx_clone.request_repaint();
         });
@@ -757,11 +828,12 @@ impl MogenStudioApp {
             return;
         };
         let out = session.state.references_dir().join(format!("{}.png", obj.id));
+        let (source_bytes, source_mime) = read_source_image(&session.state);
         let tx = session.tx.clone();
         let ctx_clone = ctx.clone();
         let id = obj.id.clone();
         std::thread::spawn(move || {
-            let result = run_reference_image(&client, obj, out, seed);
+            let result = run_reference_image(&client, obj, out, source_bytes, source_mime, seed);
             let _ = tx.send(WizardMessage::ReferenceDone { id, result });
             ctx_clone.request_repaint();
         });
@@ -1167,6 +1239,20 @@ fn build_assembly(asm_path: &std::path::Path) -> Result<PathBuf, String> {
     Ok(out)
 }
 
+/// Read the run's source image (if any) into bytes + mime for handing to a
+/// wizard worker thread. Returns `(None, None)` when there's no source image
+/// or it can't be read (e.g. the user deleted the copy) — workers treat that
+/// as a plain text-driven stage.
+fn read_source_image(state: &WizardState) -> (Option<Vec<u8>>, Option<String>) {
+    let Some(path) = state.source_image.as_ref() else {
+        return (None, None);
+    };
+    match std::fs::read(path) {
+        Ok(bytes) => (Some(bytes), Some(guess_image_mime(path))),
+        Err(_) => (None, None),
+    }
+}
+
 fn guess_image_mime(path: &std::path::Path) -> String {
     match path
         .extension()
@@ -1194,6 +1280,11 @@ enum WizardAction {
     /// state from there, and advance to the Prompt stage.
     ConfirmLocation,
     SavePrompt,
+    /// Open an image picker and set `state.source_image` (copied into the
+    /// project dir) so the run becomes image-driven.
+    PickSourceImage,
+    /// Drop the source image, reverting to a text-only run.
+    ClearSourceImage,
     GenerateBrief,
     RegenerateBrief,
     AdvanceToManifest,
@@ -1323,11 +1414,51 @@ fn draw_location_stage(ui: &mut egui::Ui, session: &mut WizardSession) -> Wizard
 
 fn draw_prompt_stage(ui: &mut egui::Ui, session: &mut WizardSession) -> WizardAction {
     let mut action = WizardAction::None;
-    ui.label("Scene prompt:");
+    let has_image = session.state.source_image.is_some();
+
+    // Source image row — when set, it drives the whole run and the typed
+    // prompt becomes optional guidance.
+    ui.label("Source image (optional):");
+    ui.label(
+        egui::RichText::new(
+            "Upload a photo to generate the scene FROM it: each object is cut out as an isolated \
+             reference, then modelled. Needs a Gemini image credential (API key or Antigravity).",
+        )
+        .weak(),
+    );
+    ui.add_space(4.0);
+    ui.horizontal(|ui| {
+        if ui.button("Choose image…").clicked() {
+            action = WizardAction::PickSourceImage;
+        }
+        if let Some(path) = session.state.source_image.as_ref() {
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("source");
+            ui.label(name);
+            if ui.button("Clear").clicked() {
+                action = WizardAction::ClearSourceImage;
+            }
+        } else {
+            ui.label(egui::RichText::new("No image — text-only run.").weak());
+        }
+    });
+
+    ui.add_space(8.0);
+    ui.label(if has_image {
+        "Scene prompt (optional guidance):"
+    } else {
+        "Scene prompt:"
+    });
     let id = egui::Id::new("wizard_prompt_draft");
     ui.add(
         egui::TextEdit::multiline(&mut session.prompt_draft)
-            .hint_text("e.g. a cosy reading nook with a chair, lamp, and a stack of books")
+            .hint_text(if has_image {
+                "optional — e.g. make it stylized, warmer lighting, drop the clutter"
+            } else {
+                "e.g. a cosy reading nook with a chair, lamp, and a stack of books"
+            })
             .desired_rows(4)
             .desired_width(f32::INFINITY)
             .id(id),
@@ -1341,9 +1472,15 @@ fn draw_prompt_stage(ui: &mut egui::Ui, session: &mut WizardSession) -> WizardAc
     ui.add_space(8.0);
     ui.horizontal(|ui| {
         let busy = !matches!(session.running, WizardBusy::None);
-        let can_run = !busy && !session.prompt_draft.trim().is_empty();
+        // With an image, the prompt is optional; without one it's required.
+        let can_run = !busy && (has_image || !session.prompt_draft.trim().is_empty());
+        let label = if has_image {
+            "Generate scene from image →"
+        } else {
+            "Generate brief →"
+        };
         if ui
-            .add_enabled(can_run, egui::Button::new("Generate brief →"))
+            .add_enabled(can_run, egui::Button::new(label))
             .on_hover_text("Calls the active LLM provider for a one-paragraph design brief")
             .clicked()
         {

--- a/crates/mogen-studio/src/app/wizard/pipeline.rs
+++ b/crates/mogen-studio/src/app/wizard/pipeline.rs
@@ -40,20 +40,48 @@ pub fn run_brief(
     client: LlmClient,
     sys_instr: Arc<String>,
     prompt: String,
+    source_bytes: Option<Vec<u8>>,
+    source_mime: Option<String>,
     cfg: WizardRunConfig,
 ) -> Result<String, String> {
-    let user = format!(
-        "You are planning an ISOMETRIC, DENSELY POPULATED 3D scene from this user prompt:\n\n\
-         \"{}\"\n\n\
-         Write a single design brief paragraph (60-120 words). Cover:\n\
-         - the setting and mood\n\
-         - lighting / time of day\n\
-         - the kind of objects that should appear (broad strokes — the next stage will list them)\n\
-         - any background / floor / wall hints\n\n\
-         The camera is always isometric (30° pitch, 45° yaw) and the floor is the Y=0 plane.\n\
-         Write the brief and nothing else — no headings, no markdown, no commentary.",
-        prompt.replace('"', "'")
-    );
+    let has_image = source_bytes.is_some() && source_mime.is_some();
+    let user = if has_image {
+        // Image-driven: the attached photo is the source of truth; any typed
+        // prompt is folded in as supplementary guidance.
+        let guidance = if prompt.trim().is_empty() {
+            String::new()
+        } else {
+            format!(
+                "\n\nAdditional guidance from the user (apply where it doesn't contradict the image): \"{}\"",
+                prompt.replace('"', "'")
+            )
+        };
+        format!(
+            "Study the ATTACHED IMAGE. You are planning how to recreate it as an ISOMETRIC, \
+             DENSELY POPULATED 3D scene.\n\n\
+             Write a single design brief paragraph (60-120 words). Cover:\n\
+             - the setting and mood actually shown in the image\n\
+             - lighting / time of day visible in the image\n\
+             - the kind of objects present (broad strokes — the next stage will list them)\n\
+             - any background / floor / wall hints from the image\n\n\
+             The camera is always isometric (30° pitch, 45° yaw) and the floor is the Y=0 plane.\n\
+             Describe what is in the image, not a generic scene.\n\
+             Write the brief and nothing else — no headings, no markdown, no commentary.{guidance}"
+        )
+    } else {
+        format!(
+            "You are planning an ISOMETRIC, DENSELY POPULATED 3D scene from this user prompt:\n\n\
+             \"{}\"\n\n\
+             Write a single design brief paragraph (60-120 words). Cover:\n\
+             - the setting and mood\n\
+             - lighting / time of day\n\
+             - the kind of objects that should appear (broad strokes — the next stage will list them)\n\
+             - any background / floor / wall hints\n\n\
+             The camera is always isometric (30° pitch, 45° yaw) and the floor is the Y=0 plane.\n\
+             Write the brief and nothing else — no headings, no markdown, no commentary.",
+            prompt.replace('"', "'")
+        )
+    };
     let user = apply_style_to_prompt(&user, cfg.style);
     let mut gc = GenerateConfig::new(user);
     gc.model = cfg.model.clone();
@@ -70,6 +98,9 @@ pub fn run_brief(
             Some(cfg.session_id.clone())
         },
     };
+    if let (Some(data), Some(mime)) = (source_bytes, source_mime) {
+        gc.user_images.push(mogen_llm::ImageInput { mime_type: mime, data });
+    }
     let resp = client.generate(&gc).map_err(|e| e.to_string())?;
     Ok(resp.text.trim().to_string())
 }
@@ -82,8 +113,18 @@ pub fn run_manifest(
     sys_instr: Arc<String>,
     prompt: String,
     brief: String,
+    source_bytes: Option<Vec<u8>>,
+    source_mime: Option<String>,
     cfg: WizardRunConfig,
 ) -> Result<Vec<ObjectEntry>, String> {
+    let has_image = source_bytes.is_some() && source_mime.is_some();
+    let image_rule = if has_image {
+        "- An IMAGE is attached. Inventory every DISTINCT physical object visible in it; \
+         estimate each object's `size`/`position`/`rotation_y_deg` from where it sits in the image \
+         (image left→right maps to -X→+X, nearer-the-camera→+Z). Don't invent objects that aren't in the image.\n"
+    } else {
+        ""
+    };
     let user = format!(
         "You are filling in the OBJECT MANIFEST for an isometric, densely-populated 3D scene.\n\n\
          Original user prompt: \"{}\"\n\n\
@@ -91,6 +132,7 @@ pub fn run_manifest(
          Return STRICT JSON describing every object in the scene. The shape:\n\
          {{\n  \"objects\": [\n    {{\n      \"id\": \"snake_case_unique_id\",\n      \"name\": \"Human readable\",\n      \"role\": \"hero\" | \"filler\" | \"decor\",\n      \"prompt\": \"5-15 word focused prompt for this single object\",\n      \"size\": [width, height, depth] in metres,\n      \"position\": [x, y, z] in metres with Y up and floor at Y=0,\n      \"rotation_y_deg\": yaw rotation in degrees\n    }}, ...\n  ]\n}}\n\n\
          Rules:\n\
+         {image_rule}\
          - For a dense scene, target 10-18 objects across roles.\n\
          - Cluster props sensibly (a desk has a chair near it, a lamp on top, etc.).\n\
          - Keep `id` lowercase, snake_case, unique across the manifest.\n\
@@ -116,6 +158,9 @@ pub fn run_manifest(
             Some(cfg.session_id.clone())
         },
     };
+    if let (Some(data), Some(mime)) = (source_bytes, source_mime) {
+        gc.user_images.push(mogen_llm::ImageInput { mime_type: mime, data });
+    }
     let resp = client.generate(&gc).map_err(|e| e.to_string())?;
     parse_manifest_json(&resp.text)
 }
@@ -128,28 +173,64 @@ pub fn run_reference_image(
     image_client: &ImageClient,
     obj: ObjectEntry,
     out_path: PathBuf,
+    source_bytes: Option<Vec<u8>>,
+    source_mime: Option<String>,
     seed: u64,
 ) -> Result<PathBuf, String> {
     if let Some(parent) = out_path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
     }
-    let prompt = format!(
-        "A clean studio reference photo of {name} — {prompt}. \
-         Render ONLY the object itself, fully isolated against a plain neutral \
-         background. No ground, no floor, no surface, no table, no pedestal, \
-         no shadow plane — the object must appear to float with nothing beneath \
-         it. No text, no watermark, no logos, no people. Reference-grade \
-         lighting, full object visible.",
-        name = obj.name,
-        prompt = obj.prompt
-    );
+    // Image-to-image only when a source photo is present AND the backend can
+    // actually consume input images (Gemini yes, Z.ai no). Otherwise fall back
+    // to text-to-image so a scene still gets references either way.
+    let inputs: Vec<mogen_llm::ImageInput> = match (source_bytes, source_mime) {
+        (Some(data), Some(mime)) if image_client.supports_image_input() => {
+            vec![mogen_llm::ImageInput { mime_type: mime, data }]
+        }
+        _ => Vec::new(),
+    };
+    let prompt = if inputs.is_empty() {
+        format!(
+            "A clean studio reference photo of {name} — {prompt}. \
+             Render ONLY the object itself, fully isolated against a plain neutral \
+             background. No ground, no floor, no surface, no table, no pedestal, \
+             no shadow plane — the object must appear to float with nothing beneath \
+             it. No text, no watermark, no logos, no people. Reference-grade \
+             lighting, full object visible.",
+            name = obj.name,
+            prompt = obj.prompt
+        )
+    } else {
+        format!(
+            "From the ATTACHED photo of a scene, render a clean studio reference of ONLY \
+             the {name} ({prompt}) that appears in it — match its real shape, colours and \
+             proportions as seen in the photo. Isolate it against a plain neutral background: \
+             no ground, no floor, no surface, no table, no pedestal, no shadow plane — the \
+             object must appear to float with nothing beneath it. Remove every other object. \
+             No text, no watermark, no logos, no people. Reference-grade lighting, full object visible.",
+            name = obj.name,
+            prompt = obj.prompt
+        )
+    };
     // Three attempts: image APIs occasionally return RECITATION (Gemini) or
     // transient 5xx. The textures pipeline does the same retry shape.
     let mut last_err: Option<String> = None;
     for attempt in 0..3u8 {
         let model = "";
-        match image_client.generate_image(model, &prompt, Some(seed ^ attempt as u64)) {
+        let seed = Some(seed ^ attempt as u64);
+        let result = if inputs.is_empty() {
+            image_client.generate_image(model, &prompt, seed)
+        } else {
+            image_client.generate_image_with_inputs(
+                model,
+                &prompt,
+                seed,
+                &inputs,
+                &mogen_llm::CallContext::default(),
+            )
+        };
+        match result {
             Ok(img) => {
                 std::fs::write(&out_path, &img.png_bytes)
                     .map_err(|e| format!("write {}: {e}", out_path.display()))?;

--- a/crates/mogen-studio/src/app/wizard/state.rs
+++ b/crates/mogen-studio/src/app/wizard/state.rs
@@ -182,6 +182,12 @@ pub struct WizardState {
     /// open time so a wizard rerun against the same prompt reproduces.
     #[serde(default)]
     pub seed: u64,
+    /// Optional source image driving the run. When set, the brief/manifest are
+    /// derived from this image (vision input) and per-object references are cut
+    /// out of it (image-to-image). Copied into `project_dir` at pick time so
+    /// the run is self-contained and resumes after a restart.
+    #[serde(default)]
+    pub source_image: Option<PathBuf>,
 }
 
 impl WizardState {


### PR DESCRIPTION
## What

Adds an **image-driven mode** to the AI Scene Wizard. Upload one photo and the wizard:

1. Derives the **brief** and **object manifest** from the image (vision input), rather than from a typed prompt.
2. Cuts an **isolated reference for each object** out of the photo via **image-to-image** ("extract just the chair from this scene, isolated on a neutral background").
3. Hands those references to the existing per-object model generator with the usual manifest/brief context.

The typed prompt becomes **optional guidance** when an image is present; with no image, the wizard behaves exactly as before.

## Why

The wizard previously only generated scenes from text. Driving it from a single image lets users reproduce a real scene faithfully — each generated object is grounded in what's actually in the photo instead of a generic text description.

## How

**mogen-llm — input-image conditioning (the image-gen path was text-only):**
- `image.rs`: `build_image_request` now attaches `inline_data` parts **ahead of** the text instruction (Gemini's image-edit ordering); new `GeminiClient::generate_image_with_inputs` with the existing `generate_image` delegating via an empty slice. Both API-key and OAuth flavours carry the parts (`wrap_image_body` preserves `contents` verbatim).
- `zai.rs`: signature-symmetric `generate_image_with_inputs` — `glm-image` is text-to-image only, so inputs are ignored.
- `image_client.rs`: `generate_image_with_inputs` (with spend recording) + `supports_image_input()` for capability gating.

**mogen-studio:**
- `pipeline.rs`: `run_brief` / `run_manifest` / `run_reference_image` accept an optional source image. References use image-to-image when the backend supports it and **fall back to text-only** otherwise.
- `state.rs`: persisted `source_image` field so an image-driven run resumes after a restart.
- `ui_wizard.rs`: Prompt-stage image picker (copies the file into the project dir), image-primary/prompt-optional UI, vision-provider gating with a clear error, and a `read_source_image` helper reusing the existing `guess_image_mime`.

## Reviewer notes
- **Image-to-image needs Gemini** (API key or Antigravity OAuth). With a Z.ai-only image credential, references degrade gracefully to text-only; the brief/manifest still require a vision-capable *text* provider (gated with an explicit error via `Provider::supports_images()`).
- No changes to the assemble/review stages — they consume the per-object `.mog` + thumbnails unchanged.

## Testing
- `cargo test --workspace` — green (added two `build_image_request` tests asserting input-image parts precede the text part).
- `cargo build -p mogen-studio` — clean.
- Text-only wizard path is unchanged (empty `input_images` slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)