### PR TITLE
fix(studio): stop inspector field keystrokes leaking into code editor

### DIFF
--- a/crates/mogen-studio/src/app/ui_panels/editor.rs
+++ b/crates/mogen-studio/src/app/ui_panels/editor.rs
@@ -317,7 +317,21 @@ impl MogenStudioApp {
                                 CCursor::new(char_idx),
                             )));
                             state.store(ui.ctx(), editor_id);
-                            ui.ctx().memory_mut(|m| m.request_focus(editor_id));
+                            // Only pull keyboard focus into the editor when no
+                            // *other* widget already owns it. A viewport pick /
+                            // gizmo release leaves focus None (the GL viewport
+                            // isn't focusable) so the caret-jump grabs focus as
+                            // before. But an inspector DragValue the user is
+                            // actively typing into holds focus — and that field
+                            // queues this same pending_caret on every keystroke.
+                            // Stealing focus here would route the next character
+                            // into the editor instead of the field (issue #74).
+                            let other_focus = ui
+                                .ctx()
+                                .memory(|m| m.focused().is_some_and(|f| f != editor_id));
+                            if !other_focus {
+                                ui.ctx().memory_mut(|m| m.request_focus(editor_id));
+                            }
                         }
                     }
 

--- a/crates/mogen-studio/src/app/ui_panels/editor.rs
+++ b/crates/mogen-studio/src/app/ui_panels/editor.rs
@@ -317,15 +317,9 @@ impl MogenStudioApp {
                                 CCursor::new(char_idx),
                             )));
                             state.store(ui.ctx(), editor_id);
-                            // Only pull keyboard focus into the editor when no
-                            // *other* widget already owns it. A viewport pick /
-                            // gizmo release leaves focus None (the GL viewport
-                            // isn't focusable) so the caret-jump grabs focus as
-                            // before. But an inspector DragValue the user is
-                            // actively typing into holds focus — and that field
-                            // queues this same pending_caret on every keystroke.
-                            // Stealing focus here would route the next character
-                            // into the editor instead of the field (issue #74).
+                            // Don't steal focus from a widget the user is
+                            // actively typing into (fixes #74). Viewport picks
+                            // leave focus None, so the guard still passes.
                             let other_focus = ui
                                 .ctx()
                                 .memory(|m| m.focused().is_some_and(|f| f != editor_id));


### PR DESCRIPTION
## Summary

Fixes #74 — typing into a right-sidebar inspector field (position/scale) also inserted the characters into the code editor on the left.

## Root cause

Each keystroke in an inspector `DragValue` fires `.changed()`, which queues an edit **and** sets `pending_caret` to the node's declaration (`selected/mod.rs`) — a "jump the editor caret to what just changed" feature shared with viewport picks. The editor consumes that `pending_caret` the same frame and unconditionally called `request_focus(editor_id)` (`editor.rs`), yanking keyboard focus out of the field. The next character then landed in the code editor, and the cycle repeated on every keystroke.

## The fix

Only grab editor focus when no *other* widget already owns it:

```rust
let other_focus = ui.ctx().memory(|m| m.focused().is_some_and(|f| f != editor_id));
if !other_focus {
    ui.ctx().memory_mut(|m| m.request_focus(editor_id));
}
```

The focus states distinguish the two paths cleanly:

- **Viewport pick / gizmo release** — the GL viewport uses `Sense::click_and_drag()` (not focusable), so the click surrenders focus to `None` → the guard passes → caret-jump grabs focus exactly as before.
- **Typing in a DragValue** — the field genuinely holds focus → the guard skips `request_focus`, so the field keeps it. The editor caret still moves to the declaration (visual "what changed"); it just no longer steals keystrokes.

## Test plan

- [x] `cargo build -p mogen-studio` compiles clean
- [ ] Manual: select a node, type into a position/scale field, confirm characters stay in the field and don't appear in the code editor, while the editor caret still tracks the edited node
- [ ] Manual: confirm clicking a node in the 3D viewport still jumps the editor caret to its declaration and focuses the editor (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)