### PR TITLE
chore: bump version to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "mogen"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-anim"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "glam 0.30.10",
  "mogen-core",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "glam 0.30.10",
  "serde",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-dsl"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "glam 0.30.10",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-export"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "fbxcel",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-geom"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "earcutr",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-llm"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-moghub-client"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "mogen-registry",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-registry"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "mogen-core",
@@ -2780,7 +2780,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-render"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "glam 0.30.10",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-studio"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "arboard",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-update"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2843,7 +2843,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-validate"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "codespan-reporting 0.12.0",
  "mogen-core",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-wasm"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [workspace.dependencies]


### PR DESCRIPTION
## Summary
- Bump workspace version `0.1.7` → `0.1.8` for the next patch release.
- Refresh `Cargo.lock` for all workspace crates.

Release CI is tag-driven (`v*`); tag `v0.1.8` on `master` after this merges to cut the release.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, push `v0.1.8` tag to trigger the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)