### PR TITLE
ci: publish MoGen Studio to itch.io via butler on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,12 +239,21 @@ jobs:
   itch:
     name: Publish to itch.io
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build, publish]
     if: startsWith(github.ref, 'refs/tags/')
     env:
       BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
       ITCH_TARGET: cattrall/mogen-studio
+      # Pin to a known stable release; bump this when upgrading butler.
+      BUTLER_VERSION: "15.24.0"
     steps:
+      - name: Check credentials
+        run: |
+          if [[ -z "${BUTLER_API_KEY}" ]]; then
+            echo "::error::BUTLER_API_KEY secret is not set — cannot publish to itch.io" >&2
+            exit 1
+          fi
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -253,7 +262,8 @@ jobs:
 
       - name: Install butler
         run: |
-          curl -sL -o butler.zip https://broth.itch.zone/butler/linux-amd64/LATEST/archive/default
+          sudo apt-get install -y --no-install-recommends unzip
+          curl -sL -o butler.zip "https://broth.itch.zone/butler/linux-amd64/${BUTLER_VERSION}/archive/default"
           unzip -q butler.zip
           chmod +x butler
           ./butler -V

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,3 +231,47 @@ jobs:
             mogen-*.msi
             mogen-studio-*.dmg
             SHA256SUMS
+
+  # Publish MoGen Studio to itch.io (cattrall/mogen-studio) via butler, tag
+  # pushes only. Windows/Linux go up as raw folders so the itch app can
+  # delta-patch between versions; macOS ships the per-arch .dmg. Channel names
+  # containing "windows", "linux" and "mac" let itch auto-detect each platform.
+  itch:
+    name: Publish to itch.io
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: startsWith(github.ref, 'refs/tags/')
+    env:
+      BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
+      ITCH_TARGET: cattrall/mogen-studio
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+
+      - name: Install butler
+        run: |
+          curl -sL -o butler.zip https://broth.itch.zone/butler/linux-amd64/LATEST/archive/default
+          unzip -q butler.zip
+          chmod +x butler
+          ./butler -V
+
+      - name: Stage raw builds
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          mkdir -p push/windows push/linux
+          unzip -q "mogen-${tag}-x86_64-pc-windows-msvc.zip" -d push/windows
+          tar -xzf "mogen-${tag}-x86_64-unknown-linux-gnu.tar.gz" -C push/linux
+
+      - name: Push to itch.io
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          V="${tag#v}"
+          ./butler push push/windows "$ITCH_TARGET:windows"           --userversion "$V"
+          ./butler push push/linux   "$ITCH_TARGET:linux"             --userversion "$V"
+          ./butler push "mogen-studio-${tag}-aarch64-apple-darwin.dmg" "$ITCH_TARGET:mac-apple-silicon" --userversion "$V"
+          ./butler push "mogen-studio-${tag}-x86_64-apple-darwin.dmg"  "$ITCH_TARGET:mac-intel"         --userversion "$V"


### PR DESCRIPTION
## Summary

Adds an `itch` job to the release workflow that publishes **MoGen Studio** to [cattrall/mogen-studio](https://cattrall.itch.io/mogen-studio) via butler on every `v*` tag push. Modeled on the existing setup in the Oversleep repo.

## What changed

- New `itch` job in `.github/workflows/release.yml`, gated to tag pushes (`if: startsWith(github.ref, 'refs/tags/')`) and depending on `build`.
- Downloads the already-built per-platform artifacts and pushes them with butler:
  - **`windows`** / **`linux`** — raw unpacked folders (delta-patchable in the itch app)
  - **`mac-apple-silicon`** / **`mac-intel`** — per-arch `.dmg`
- itch auto-detects platform from channel names; `--userversion` is the tag minus the `v` prefix.

## Reviewer notes

- Requires a `BUTLER_API_KEY` repo secret — **already set** on `krazyjakee/MoGen`.
- `ITCH_TARGET` is hardcoded to `cattrall/mogen-studio` (the page is public). Can be moved to a secret if preferred.
- Two open layout choices, currently shipping the simpler option:
  - The Windows/Linux folders bundle the `mogen` CLI alongside `mogen-studio`. Could repackage to ship studio-only.
  - macOS ships as two separate `.dmg` downloads (no universal build); `.dmg` can't be delta-patched but carries the proper `.app` bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)