### PR TITLE
fix(ci): build cargo-deb from source to avoid glibc mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Install cargo-deb
         if: runner.os == 'Linux'
-        run: cargo install cargo-deb --locked
+        run: cargo install cargo-deb --version 3.7.0 --locked
 
       - name: Package .deb (linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,9 +85,7 @@ jobs:
 
       - name: Install cargo-deb
         if: runner.os == 'Linux'
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-deb
+        run: cargo install cargo-deb --locked
 
       - name: Package .deb (linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary
- The release workflow's `Install cargo-deb` step used `taiki-e/install-action`, which downloads a prebuilt `cargo-deb` v3.7.0 binary linked against `GLIBC_2.39`.
- The Linux build runs on `ubuntu-22.04` (glibc 2.35), so the binary failed with `version 'GLIBC_2.39' not found`, breaking the `.deb` packaging step.
- Switched to `cargo install cargo-deb --locked`, which compiles against the runner's own glibc.

## Why not bump the runner?
Moving to `ubuntu-24.04` would resolve the prebuilt-binary glibc requirement, but it would also raise the glibc floor of the **shipped** `mogen`/`mogen-studio` binaries and the `.deb`, reducing compatibility on older Linux systems. Building on 22.04 keeps that floor low.

## Notes for reviewer
- Only the Linux `cargo-deb` step changed. The Windows `cargo-wix` step still uses `taiki-e/install-action` since the glibc mismatch is Linux-only.
- `cargo install` adds a one-time compile cost (mitigated by the existing `Swatinem/rust-cache`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)