### PR TITLE
studio: Tab inserts 2 spaces; debounce inspector transform edits

### DIFF
--- a/crates/mogen-studio/src/app/compile.rs
+++ b/crates/mogen-studio/src/app/compile.rs
@@ -275,24 +275,12 @@ impl MogenStudioApp {
                     node_path: self.current_selection_path(i),
                 };
                 self.push_undo(i, undo_before, key);
-                // Inspector DragValues emit a fresh edit on every frame of a
-                // drag, whereas the gizmo and discrete widgets (combo picks,
-                // typed values, deletes) emit once on release. A full
-                // recompile + mesh re-flatten reloads geometry and textures
-                // from disk, so doing it per frame makes the app visibly hang
-                // while a transform field is dragged. While the pointer is
-                // still mid-drag we therefore defer to the debounce —
-                // `drive_compile_debounce` coalesces the burst into a single
-                // recompile once the user pauses (and still fires mid-drag if
-                // they hold without moving for the debounce window).
-                //
-                // On a discrete commit we keep compiling immediately so the
-                // viewport reflects the change on the very next frame.
-                // Gizmo releases are discrete events, not keystroke bursts —
-                // without the immediate compile the preview clears on release
-                // and the new scene only arrives on the next idle tick, which
-                // looks to the user like the action was rejected and the value
-                // snapped back. Deletes are always discrete too.
+                // Inspector DragValues fire every frame of a drag; a full
+                // recompile per frame makes the app visibly hang. Defer to
+                // the debounce while the pointer is held. Gizmo releases and
+                // deletes are discrete — compile immediately so the viewport
+                // updates on the very next frame and values don't appear to
+                // snap back.
                 let mid_drag = ctx.is_using_pointer() && !any_delete;
                 if !mid_drag {
                     self.compile_active();

--- a/crates/mogen-studio/src/app/compile.rs
+++ b/crates/mogen-studio/src/app/compile.rs
@@ -275,21 +275,38 @@ impl MogenStudioApp {
                     node_path: self.current_selection_path(i),
                 };
                 self.push_undo(i, undo_before, key);
+                // Inspector DragValues emit a fresh edit on every frame of a
+                // drag, whereas the gizmo and discrete widgets (combo picks,
+                // typed values, deletes) emit once on release. A full
+                // recompile + mesh re-flatten reloads geometry and textures
+                // from disk, so doing it per frame makes the app visibly hang
+                // while a transform field is dragged. While the pointer is
+                // still mid-drag we therefore defer to the debounce —
+                // `drive_compile_debounce` coalesces the burst into a single
+                // recompile once the user pauses (and still fires mid-drag if
+                // they hold without moving for the debounce window).
+                //
+                // On a discrete commit we keep compiling immediately so the
+                // viewport reflects the change on the very next frame.
                 // Gizmo releases are discrete events, not keystroke bursts —
-                // skip the 180 ms debounce and compile immediately so the
-                // viewport can pick up the rotated / translated / scaled
-                // scene on the very next frame. Without this, the preview
-                // clears on release and the new scene only arrives on the
-                // next idle tick, which looks to the user like the gizmo
-                // action was rejected and the value snapped back.
-                self.compile_active();
-                // Belt-and-braces: also request the debounce-boundary
-                // repaint so if something does leave `needs_compile` set
-                // (e.g. the caller wraps a batch of gizmo edits through
-                // this path), the next window still fires.
+                // without the immediate compile the preview clears on release
+                // and the new scene only arrives on the next idle tick, which
+                // looks to the user like the action was rejected and the value
+                // snapped back. Deletes are always discrete too.
+                let mid_drag = ctx.is_using_pointer() && !any_delete;
+                if !mid_drag {
+                    self.compile_active();
+                }
+                // Request the debounce-boundary repaint either way: an
+                // immediate compile clears `needs_compile`, but a deferred one
+                // relies on this to wake `drive_compile_debounce`.
                 ctx.request_repaint_after(COMPILE_DEBOUNCE);
                 if trace {
-                    eprintln!("[gizmo] drain done — triggered immediate compile");
+                    if mid_drag {
+                        eprintln!("[gizmo] drain done — deferred compile (mid-drag)");
+                    } else {
+                        eprintln!("[gizmo] drain done — triggered immediate compile");
+                    }
                 }
             }
         }

--- a/crates/mogen-studio/src/app/indent.rs
+++ b/crates/mogen-studio/src/app/indent.rs
@@ -18,6 +18,9 @@ const SPACES_PER_TAB: usize = 2;
 /// default `\t` so the code surface stays space-indented.
 const INDENT: &str = "  ";
 
+// Compile-time guard: if someone changes one constant they must update both.
+const _: () = assert!(INDENT.len() == SPACES_PER_TAB);
+
 impl MogenStudioApp {
     /// Returns `true` when the source was mutated and the caller should mark
     /// the file dirty / schedule a recompile.
@@ -47,7 +50,6 @@ impl MogenStudioApp {
         let lo_byte = char_to_byte(source_ref, lo.index);
         let hi_byte = char_to_byte(source_ref, hi.index);
         let multi_line = source_ref[lo_byte..hi_byte].contains('\n');
-        let has_selection = hi_byte > lo_byte;
 
         // Tab is always intercepted so it inserts spaces instead of egui's
         // default literal `\t`: a multi-line selection block-indents, a caret
@@ -73,7 +75,6 @@ impl MogenStudioApp {
         }
         // Shift+Tab on a line with no leading whitespace is a no-op but we
         // still consume the key so focus doesn't escape the editor.
-        let _ = has_selection;
 
         let first_line_start = source_ref[..lo_byte]
             .rfind('\n')
@@ -92,61 +93,11 @@ impl MogenStudioApp {
             }
         }
 
-        let mut new_lo = lo_byte;
-        let mut new_hi = hi_byte;
         let source = &mut self.files[i].source;
-
-        let mutated = if tab {
-            if multi_line {
-                // Block-indent every covered line by one indent unit. Insert
-                // in reverse so earlier byte offsets stay valid.
-                for &ls in line_starts.iter().rev() {
-                    source.insert_str(ls, INDENT);
-                }
-                for &ls in &line_starts {
-                    if ls < new_lo {
-                        new_lo += INDENT.len();
-                    }
-                    if ls < new_hi {
-                        new_hi += INDENT.len();
-                    }
-                }
-            } else {
-                // Caret or in-line selection: replace the selection (empty for
-                // a bare caret) with one indent unit and drop the cursor after
-                // it. This is what makes a plain Tab insert two spaces.
-                source.replace_range(lo_byte..hi_byte, INDENT);
-                new_lo = lo_byte + INDENT.len();
-                new_hi = new_lo;
-            }
-            true
+        let (new_lo, new_hi, mutated) = if tab {
+            apply_tab(source, lo_byte, hi_byte, &line_starts, multi_line)
         } else {
-            let removals: Vec<usize> = line_starts
-                .iter()
-                .map(|&ls| count_indent_removable(source.as_bytes(), ls))
-                .collect();
-            let any = removals.iter().any(|&n| n > 0);
-            for (&ls, &n) in line_starts.iter().rev().zip(removals.iter().rev()) {
-                if n > 0 {
-                    source.replace_range(ls..ls + n, "");
-                }
-            }
-            for (&ls, &n) in line_starts.iter().zip(removals.iter()) {
-                if n == 0 {
-                    continue;
-                }
-                if ls + n <= new_lo {
-                    new_lo -= n;
-                } else if ls < new_lo {
-                    new_lo = ls;
-                }
-                if ls + n <= new_hi {
-                    new_hi -= n;
-                } else if ls < new_hi {
-                    new_hi = ls;
-                }
-            }
-            any
+            apply_shift_tab(source, lo_byte, hi_byte, &line_starts)
         };
 
         // Persist the new selection so the TextEdit (rendered immediately
@@ -177,6 +128,86 @@ impl MogenStudioApp {
     }
 }
 
+/// Apply a Tab key press to `source` in-place, returning `(new_lo, new_hi, mutated)`.
+///
+/// For multi-line selections every covered line is block-indented by one
+/// `INDENT` unit. For a caret or same-line selection the selection is replaced
+/// with one `INDENT` and the cursor placed after it.
+fn apply_tab(
+    source: &mut String,
+    lo_byte: usize,
+    hi_byte: usize,
+    line_starts: &[usize],
+    multi_line: bool,
+) -> (usize, usize, bool) {
+    if multi_line {
+        // Block-indent every covered line by one indent unit. Insert in
+        // reverse so earlier byte offsets stay valid for later inserts.
+        for &ls in line_starts.iter().rev() {
+            source.insert_str(ls, INDENT);
+        }
+        // Adjust the selection endpoints. Each insertion at a line start
+        // that falls BEFORE the original endpoint shifts it right by
+        // INDENT.len(). We compare against the ORIGINAL positions (not the
+        // accumulating new_lo/new_hi) to avoid counting a line start that
+        // only appears to fall before an endpoint because earlier increments
+        // pushed it there — this would over-count and produce a stale cursor
+        // when INDENT is more than one byte.
+        let count_before = |orig: usize| {
+            line_starts.iter().filter(|&&ls| ls < orig).count()
+        };
+        let new_lo = lo_byte + count_before(lo_byte) * INDENT.len();
+        let new_hi = hi_byte + count_before(hi_byte) * INDENT.len();
+        (new_lo, new_hi, true)
+    } else {
+        // Caret or in-line selection: replace the selection (empty for a
+        // bare caret) with one indent unit and drop the cursor after it.
+        source.replace_range(lo_byte..hi_byte, INDENT);
+        let new_pos = lo_byte + INDENT.len();
+        (new_pos, new_pos, true)
+    }
+}
+
+/// Apply a Shift+Tab key press to `source` in-place, returning `(new_lo, new_hi, mutated)`.
+///
+/// Every covered line loses up to `SPACES_PER_TAB` leading spaces (or one
+/// leading tab). Returns `mutated = false` when no line had removable indent.
+fn apply_shift_tab(
+    source: &mut String,
+    lo_byte: usize,
+    hi_byte: usize,
+    line_starts: &[usize],
+) -> (usize, usize, bool) {
+    let removals: Vec<usize> = line_starts
+        .iter()
+        .map(|&ls| count_indent_removable(source.as_bytes(), ls))
+        .collect();
+    let any = removals.iter().any(|&n| n > 0);
+    for (&ls, &n) in line_starts.iter().rev().zip(removals.iter().rev()) {
+        if n > 0 {
+            source.replace_range(ls..ls + n, "");
+        }
+    }
+    let mut new_lo = lo_byte;
+    let mut new_hi = hi_byte;
+    for (&ls, &n) in line_starts.iter().zip(removals.iter()) {
+        if n == 0 {
+            continue;
+        }
+        if ls + n <= new_lo {
+            new_lo -= n;
+        } else if ls < new_lo {
+            new_lo = ls;
+        }
+        if ls + n <= new_hi {
+            new_hi -= n;
+        } else if ls < new_hi {
+            new_hi = ls;
+        }
+    }
+    (new_lo, new_hi, any)
+}
+
 fn char_to_byte(s: &str, char_idx: usize) -> usize {
     s.char_indices()
         .nth(char_idx)
@@ -200,4 +231,215 @@ fn count_indent_removable(bytes: &[u8], ls: usize) -> usize {
         n += 1;
     }
     n
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tab(src: &str, lo: usize, hi: usize) -> (String, usize, usize) {
+        let first_line_start = src[..lo].rfind('\n').map(|p| p + 1).unwrap_or(0);
+        let mut line_starts = vec![first_line_start];
+        let mut p = first_line_start;
+        while let Some(off) = src[p..].find('\n') {
+            let next = p + off + 1;
+            if next >= hi {
+                break;
+            }
+            line_starts.push(next);
+            p = next;
+        }
+        let multi_line = src[lo..hi].contains('\n');
+        let mut source = src.to_string();
+        let (new_lo, new_hi, _) = apply_tab(&mut source, lo, hi, &line_starts, multi_line);
+        (source, new_lo, new_hi)
+    }
+
+    fn shift_tab(src: &str, lo: usize, hi: usize) -> (String, usize, usize, bool) {
+        let first_line_start = src[..lo].rfind('\n').map(|p| p + 1).unwrap_or(0);
+        let mut line_starts = vec![first_line_start];
+        let mut p = first_line_start;
+        while let Some(off) = src[p..].find('\n') {
+            let next = p + off + 1;
+            if next >= hi {
+                break;
+            }
+            line_starts.push(next);
+            p = next;
+        }
+        let mut source = src.to_string();
+        let (new_lo, new_hi, mutated) =
+            apply_shift_tab(&mut source, lo, hi, &line_starts);
+        (source, new_lo, new_hi, mutated)
+    }
+
+    // --- Tab: caret / inline selection ---
+
+    #[test]
+    fn tab_caret_inserts_two_spaces() {
+        let src = "foo\nbar\n";
+        let (text, lo, hi) = tab(src, 4, 4); // caret at start of "bar"
+        assert_eq!(text, "foo\n  bar\n");
+        assert_eq!(lo, 6); // cursor after the two inserted spaces
+        assert_eq!(hi, 6);
+    }
+
+    #[test]
+    fn tab_inline_selection_replaced_by_indent() {
+        // Selecting "ba" inside "bar" (same line) — should replace with two spaces.
+        let src = "foo\nbar\n";
+        let (text, lo, hi) = tab(src, 4, 6); // selects "ba"
+        assert_eq!(text, "foo\n  r\n");
+        assert_eq!(lo, 6);
+        assert_eq!(hi, 6);
+    }
+
+    #[test]
+    fn tab_middle_of_line_caret() {
+        let src = "hello world";
+        let (text, lo, hi) = tab(src, 5, 5); // caret between 'o' and ' '
+        assert_eq!(text, "hello   world");
+        assert_eq!(lo, 7);
+        assert_eq!(hi, 7);
+    }
+
+    // --- Tab: multi-line block indent ---
+
+    #[test]
+    fn tab_multiline_indents_each_line() {
+        let src = "foo\nbar\nbaz\n";
+        // Select all three lines (lo=0, hi=12 which is len)
+        let (text, lo, hi) = tab(src, 0, 12);
+        assert_eq!(text, "  foo\n  bar\n  baz\n");
+        assert_eq!(lo, 0); // selection starts at line start — stays there
+        assert_eq!(hi, 18); // 12 + 3 lines * 2 spaces
+    }
+
+    #[test]
+    fn tab_multiline_cursor_in_middle_of_first_line() {
+        // lo=1 (inside "foo"), hi=7 (inside "bar") — two lines.
+        let src = "foo\nbar\n";
+        let (text, lo, hi) = tab(src, 1, 7);
+        assert_eq!(text, "  foo\n  bar\n");
+        // Original lo=1 is after line-start=0, so it shifts by 2 → 3.
+        assert_eq!(lo, 3);
+        // Original hi=7 is after line-start=4, so it shifts by 2 (from ls=0) + 2 (from ls=4) → 11.
+        assert_eq!(hi, 11);
+    }
+
+    #[test]
+    fn tab_multiline_cursor_not_overcounted_when_close_line_starts() {
+        // Regression: when INDENT.len()>1 and a line start falls between
+        // original_lo and the first incremented new_lo, the old algorithm
+        // would count it twice and produce a stale cursor position.
+        //
+        // Source: "a\nbc\ndef\n"  (line starts at 0, 2, 5)
+        // Selection lo=1 (after 'a'), hi=9 (full "def\n").
+        // Inserts happen at 0, 2, 5.  Only ls=0 is < orig lo=1 → new_lo = 3.
+        let src = "a\nbc\ndef\n";
+        let (text, lo, hi) = tab(src, 1, 9);
+        assert_eq!(text, "  a\n  bc\n  def\n");
+        // lo=1, only insert at ls=0 (< 1) shifts it: 1 + 1*2 = 3.
+        assert_eq!(lo, 3);
+        // hi=9, all three inserts (0<9, 2<9, 5<9) shift it: 9 + 3*2 = 15.
+        assert_eq!(hi, 15);
+    }
+
+    // --- Shift+Tab: dedent ---
+
+    #[test]
+    fn shift_tab_removes_two_spaces() {
+        let src = "  foo\n  bar\n";
+        let (text, lo, hi, mutated) = shift_tab(src, 0, 12);
+        assert_eq!(text, "foo\nbar\n");
+        assert_eq!(mutated, true);
+        assert_eq!(lo, 0);
+        assert_eq!(hi, 8);
+    }
+
+    #[test]
+    fn shift_tab_partial_indent_removes_available() {
+        // Only one leading space — should remove just that one.
+        let src = " foo\n";
+        let (text, _, _, mutated) = shift_tab(src, 0, 5);
+        assert_eq!(text, "foo\n");
+        assert_eq!(mutated, true);
+    }
+
+    #[test]
+    fn shift_tab_no_indent_is_noop() {
+        let src = "foo\n";
+        let (text, _, _, mutated) = shift_tab(src, 0, 4);
+        assert_eq!(text, "foo\n");
+        assert_eq!(mutated, false);
+    }
+
+    #[test]
+    fn shift_tab_removes_tab_character() {
+        let src = "\tfoo\n";
+        let (text, _, _, mutated) = shift_tab(src, 0, 5);
+        assert_eq!(text, "foo\n");
+        assert_eq!(mutated, true);
+    }
+
+    // --- Round-trip: Tab then Shift+Tab ---
+
+    #[test]
+    fn tab_shift_tab_round_trip_single_line() {
+        let src = "foo\n";
+        let (indented, lo, hi) = tab(src, 0, 0);
+        assert_eq!(indented, "  foo\n");
+        let (back, _, _, _) = shift_tab(&indented, lo, hi);
+        assert_eq!(back, "foo\n");
+    }
+
+    #[test]
+    fn tab_shift_tab_round_trip_multiline() {
+        let src = "foo\nbar\n";
+        let (indented, lo, hi) = tab(src, 0, 8);
+        let (back, _, _, _) = shift_tab(&indented, lo, hi);
+        assert_eq!(back, "foo\nbar\n");
+    }
+
+    // --- Helper function coverage ---
+
+    #[test]
+    fn char_to_byte_ascii() {
+        let s = "hello";
+        assert_eq!(char_to_byte(s, 0), 0);
+        assert_eq!(char_to_byte(s, 3), 3);
+        assert_eq!(char_to_byte(s, 5), 5);
+    }
+
+    #[test]
+    fn char_to_byte_multibyte() {
+        let s = "hé"; // 'é' is 2 bytes
+        assert_eq!(char_to_byte(s, 1), 1);
+        assert_eq!(char_to_byte(s, 2), 3);
+    }
+
+    #[test]
+    fn byte_to_char_basic() {
+        let s = "hello";
+        assert_eq!(byte_to_char(s, 0), 0);
+        assert_eq!(byte_to_char(s, 3), 3);
+    }
+
+    #[test]
+    fn count_indent_removable_full() {
+        let s = "  foo";
+        assert_eq!(count_indent_removable(s.as_bytes(), 0), 2);
+    }
+
+    #[test]
+    fn count_indent_removable_partial() {
+        let s = " foo";
+        assert_eq!(count_indent_removable(s.as_bytes(), 0), 1);
+    }
+
+    #[test]
+    fn count_indent_removable_none() {
+        let s = "foo";
+        assert_eq!(count_indent_removable(s.as_bytes(), 0), 0);
+    }
 }

--- a/crates/mogen-studio/src/app/indent.rs
+++ b/crates/mogen-studio/src/app/indent.rs
@@ -1,15 +1,22 @@
 //! Block-indent / block-dedent for the code editor's selection.
 //!
 //! Runs before the `TextEdit` paints so it can swallow Tab / Shift+Tab and
-//! rewrite the source + cursor itself. Defaults are preserved when the action
-//! doesn't apply: a single-line Tab still inserts a literal `\t`.
+//! rewrite the source + cursor itself. Tab inserts two spaces (one indent
+//! unit) rather than a literal `\t`: a multi-line selection indents every
+//! covered line, while a caret or in-line selection inserts a single indent.
 
 use eframe::egui;
 use egui::text::{CCursor, CCursorRange};
 
 use super::MogenStudioApp;
 
-const SPACES_PER_TAB: usize = 4;
+/// Width of one indent level, in spaces. Drives both the Tab insert and the
+/// Shift+Tab dedent so the two stay symmetric.
+const SPACES_PER_TAB: usize = 2;
+
+/// One indent level as literal text. Inserted on Tab in place of egui's
+/// default `\t` so the code surface stays space-indented.
+const INDENT: &str = "  ";
 
 impl MogenStudioApp {
     /// Returns `true` when the source was mutated and the caller should mark
@@ -42,18 +49,19 @@ impl MogenStudioApp {
         let multi_line = source_ref[lo_byte..hi_byte].contains('\n');
         let has_selection = hi_byte > lo_byte;
 
-        // Tab is only intercepted for multi-line selections — otherwise the
-        // default code-editor behaviour (insert / replace with `\t`) wins.
-        // Shift+Tab is always handled (dedents the current line at minimum).
+        // Tab is always intercepted so it inserts spaces instead of egui's
+        // default literal `\t`: a multi-line selection block-indents, a caret
+        // or in-line selection inserts a single indent unit. Shift+Tab is
+        // likewise always handled (dedents the current line at minimum).
         //
         // Check Shift+Tab FIRST: egui's `consume_key` uses
         // `Modifiers::matches_logically`, which ignores extra modifiers — so
         // `consume_key(NONE, Tab)` happily matches a Shift+Tab event too. If
-        // we matched the broader Tab pattern first on a multi-line selection,
-        // Shift+Tab would silently re-indent instead of dedenting.
+        // we matched the broader Tab pattern first, Shift+Tab would silently
+        // re-indent instead of dedenting.
         let (tab, shift_tab) = ui.input_mut(|i| {
             let shift_tab = i.consume_key(egui::Modifiers::SHIFT, egui::Key::Tab);
-            let tab = if multi_line && !shift_tab {
+            let tab = if !shift_tab {
                 i.consume_key(egui::Modifiers::NONE, egui::Key::Tab)
             } else {
                 false
@@ -89,17 +97,27 @@ impl MogenStudioApp {
         let source = &mut self.files[i].source;
 
         let mutated = if tab {
-            // Insert in reverse so earlier byte offsets stay valid.
-            for &ls in line_starts.iter().rev() {
-                source.insert(ls, '\t');
-            }
-            for &ls in &line_starts {
-                if ls < new_lo {
-                    new_lo += 1;
+            if multi_line {
+                // Block-indent every covered line by one indent unit. Insert
+                // in reverse so earlier byte offsets stay valid.
+                for &ls in line_starts.iter().rev() {
+                    source.insert_str(ls, INDENT);
                 }
-                if ls < new_hi {
-                    new_hi += 1;
+                for &ls in &line_starts {
+                    if ls < new_lo {
+                        new_lo += INDENT.len();
+                    }
+                    if ls < new_hi {
+                        new_hi += INDENT.len();
+                    }
                 }
+            } else {
+                // Caret or in-line selection: replace the selection (empty for
+                // a bare caret) with one indent unit and drop the cursor after
+                // it. This is what makes a plain Tab insert two spaces.
+                source.replace_range(lo_byte..hi_byte, INDENT);
+                new_lo = lo_byte + INDENT.len();
+                new_hi = new_lo;
             }
             true
         } else {

--- a/crates/mogen-studio/src/app/ui_panels/editor.rs
+++ b/crates/mogen-studio/src/app/ui_panels/editor.rs
@@ -208,9 +208,11 @@ impl MogenStudioApp {
                         f32::INFINITY
                     };
                     let mut editor = egui::TextEdit::multiline(&mut self.files[i].source)
-                        // code_editor() implies lock_focus(true), so Tab inserts
-                        // a tab character instead of moving focus out of the
-                        // editor — the right behavior for a code surface.
+                        // code_editor() implies lock_focus(true) so Tab stays
+                        // in the editor instead of moving focus out — the right
+                        // behavior for a code surface. `handle_indent_keys`
+                        // (run above) intercepts Tab to insert two spaces
+                        // rather than the literal `\t` egui would otherwise add.
                         .code_editor()
                         .desired_rows(visible_rows)
                         .desired_width(desired_width)


### PR DESCRIPTION
Editor: intercept Tab for all selections (not just multi-line) and insert
two spaces (one indent unit) instead of egui's default literal tab. A
caret or in-line selection inserts a single indent; a multi-line selection
block-indents every covered line. Shift+Tab dedent now matches at 2 spaces.

Performance: inspector position/rotation/scale DragValues fire a fresh
edit every frame of a drag, and drain_viewport_edits compiled immediately
on each one — a full recompile + mesh re-flatten (reloading geometry and
textures from disk) per frame, which hung the app for a second or more
while dragging. Defer the recompile to the existing debounce while the
pointer is mid-drag; keep the immediate compile for discrete commits
(gizmo release, combo picks, typed values, deletes) so the viewport still
updates on the next frame and values can't appear to snap back.