### PR TITLE
Add Xiaomi MiMo provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ connectors, skeletons + skinning + animation templates, full PBR materials with 
 textures, validation diagnostics, and LLM-driven generate/modify/animate are all
 working. Multiple LLM backends are supported out of the box — Gemini (API key or
 Google OAuth), OpenAI, Anthropic, Ollama (local), Claude Code (subscription),
-Fireworks AI Firepass (Kimi K2 routers), and Z.ai (GLM family, default `glm-5.1`). See
+Fireworks AI Firepass (Kimi K2 routers), Z.ai (GLM family, default `glm-5.1`),
+and Xiaomi MiMo (default `mimo-v2.5-pro`). See
 [`docs/dsl.md`](docs/dsl.md) for the full feature surface.
 
 ## Install
@@ -166,7 +167,7 @@ mogen update                                           # self-update from the la
 default that's Gemini (`GEMINI_API_KEY` env var, `--api-key` flag, stored OAuth
 bundle, or the shared settings file — see below). Pick a different backend with
 `--provider <name>` and the matching env var: `OPENAI_API_KEY`,
-`ANTHROPIC_API_KEY`, `FIREWORKS_API_KEY`, `ZAI_API_KEY`, etc. `animate` is
+`ANTHROPIC_API_KEY`, `FIREWORKS_API_KEY`, `ZAI_API_KEY`, `XIAOMI_API_KEY`, etc. `animate` is
 scoped to top-level animation declarations only (`joint`, `clip`/`track`, and
 the `spin` / `open_close` / `wave` / `flap` / `idle` templates) — it leaves
 geometry, materials, and hierarchy untouched. There are a few more
@@ -197,7 +198,8 @@ The file is plain JSON. A minimal example:
   "openai_api_key": "sk-...",
   "anthropic_api_key": "sk-ant-...",
   "fireworks_api_key": "fw_...",
-  "zai_api_key": "..."
+  "zai_api_key": "...",
+  "xiaomi_api_key": "sk-..."
 }
 ```
 
@@ -212,6 +214,7 @@ The file is plain JSON. A minimal example:
 | Claude Code  | `claude-code`      | `sonnet` (delegates to `claude` CLI)       | — (subscription)      |
 | Fireworks AI Firepass | `fireworks` | `accounts/fireworks/routers/kimi-k2p6`     | `FIREWORKS_API_KEY`   |
 | Z.ai (GLM)   | `zai`              | `glm-5.1`                                  | `ZAI_API_KEY`         |
+| Xiaomi MiMo | `xiaomi`           | `mimo-v2.5-pro`                          | `XIAOMI_API_KEY`      |
 
 \* Ollama is keyless for local installs — the env var is only consulted when
 running behind an authenticating reverse proxy.
@@ -224,6 +227,10 @@ Notes:
 - **Z.ai** uses an OpenAI-compatible Chat Completions endpoint at
   `api.z.ai/api/paas/v4/chat/completions`. The same `ZAI_API_KEY` also
   authenticates the `glm-image` image-gen path used by `mogen textures`.
+- **Xiaomi MiMo** uses the OpenAI-compatible Chat Completions endpoint at
+  `api.xiaomimimo.com/v1/chat/completions`; MoGen uses Bearer auth because
+  Xiaomi documents it alongside the `api-key` header. Vision calls auto-switch
+  to `mimo-v2.5`.
 - **Claude Code** is keyless — it shells out to the `claude` CLI, so auth
   is whatever `claude login` already set up.
 

--- a/crates/mogen-llm/src/lib.rs
+++ b/crates/mogen-llm/src/lib.rs
@@ -4,13 +4,15 @@
 //! `modify`, `animate`, `repair`, `bench`, and `textures` commands:
 //!
 //! - [`provider`] — the [`LlmClient`] enum dispatches to the right backend
-//!   (Gemini, OpenAI, Anthropic, Ollama). [`Provider`] describes the
-//!   selector and per-provider defaults; [`ProviderError`] is the unified
-//!   error returned by [`LlmClient::generate`].
-//! - [`gemini`] / [`openai`] / [`anthropic`] / [`ollama`] — per-backend
-//!   HTTP clients, each with its own request/response wire types.
+//!   (Gemini, OpenAI, Anthropic, Ollama, Claude Code, Fireworks, Z.ai,
+//!   Xiaomi MiMo, or a generic OpenAI-compatible host). [`Provider`]
+//!   describes the selector and per-provider defaults; [`ProviderError`] is
+//!   the unified error returned by [`LlmClient::generate`].
+//! - [`gemini`] / [`openai`] / [`anthropic`] / [`ollama`] / provider-specific
+//!   OpenAI-compatible modules — per-backend HTTP clients, each with its own
+//!   request/response wire types.
 //! - [`prompt`] — assembles the system instruction (grammar + stdlib index +
-//!   examples). Provider-agnostic — the same string ships to all four.
+//!   examples). Provider-agnostic — the same string ships to every text backend.
 //! - [`repair`] — drives parse → validate → feed JSON diagnostics back on
 //!   error. Takes [`LlmClient`] so it works against any provider.
 //!
@@ -38,21 +40,25 @@ pub mod refine;
 pub mod repair;
 pub mod settings_store;
 pub mod spend;
-pub mod textures;
 pub mod style;
+pub mod textures;
 pub mod types;
+pub mod xiaomi;
 pub mod zai;
 pub mod zai_chat;
 
-pub use cache::{default_cache_path, resolve_or_create as resolve_or_create_cache, DEFAULT_TTL_SECONDS};
+pub use cache::{
+    default_cache_path, resolve_or_create as resolve_or_create_cache, DEFAULT_TTL_SECONDS,
+};
+pub use fireworks::{FireworksClient, FireworksError};
 pub use gemini::{CachedContent, GeminiAuth, GeminiClient, GeminiError};
+pub use google_oauth::client::{resolve_user_path, PathMode};
 pub use google_oauth::{
     all_existing_token_paths, all_existing_token_paths_for, delete_bundle, load_bundle,
     run_login_flow, save_bundle, token_store_path, token_store_path_for, token_store_write_path,
     token_store_write_path_for, LoginOptions, LoginOutcome, OAuthBundle, OAuthError,
     TOKEN_STORE_FILENAME,
 };
-pub use google_oauth::client::{resolve_user_path, PathMode};
 pub use image::{GeneratedImage, DEFAULT_IMAGE_MODEL};
 pub use image_client::{ImageClient, ImageError};
 pub use imports::{
@@ -72,21 +78,21 @@ pub use repair::{
 pub use settings_store::{
     load_api_keys, read_api_key, settings_path as settings_store_path, zai_base_url, ApiKeys,
 };
-pub use fireworks::{FireworksClient, FireworksError};
-pub use textures::parse_prompt_header;
-pub use style::{apply_style_to_prompt, style_prompt_block, Style, STYLES};
-pub use zai::{ZaiClient, ZaiError};
-pub use zai_chat::{
-    ZaiChatClient, ZaiChatError, CODING_PLAN_BASE_URL as ZAI_CODING_PLAN_BASE_URL,
-    DEFAULT_BASE_URL as ZAI_DEFAULT_BASE_URL, DEFAULT_VISION_MODEL as ZAI_DEFAULT_VISION_MODEL,
+pub use spend::{
+    CallContext, CallFilter, CallRecord, CallRow, ModelSummary, NoopRecorder, Operation,
+    SpendRecorder, SqliteRecorder, SummaryRow,
 };
+pub use style::{apply_style_to_prompt, style_prompt_block, Style, STYLES};
+pub use textures::parse_prompt_header;
 pub use types::{
     GenerateConfig, GenerateResponse, ImageInput, Role, ThinkingLevel, Turn, Usage,
     DEFAULT_TEMPERATURE,
 };
-pub use spend::{
-    CallContext, CallFilter, CallRecord, CallRow, ModelSummary, NoopRecorder, Operation,
-    SpendRecorder, SqliteRecorder, SummaryRow,
+pub use xiaomi::{XiaomiClient, XiaomiError, DEFAULT_VISION_MODEL as XIAOMI_DEFAULT_VISION_MODEL};
+pub use zai::{ZaiClient, ZaiError};
+pub use zai_chat::{
+    ZaiChatClient, ZaiChatError, CODING_PLAN_BASE_URL as ZAI_CODING_PLAN_BASE_URL,
+    DEFAULT_BASE_URL as ZAI_DEFAULT_BASE_URL, DEFAULT_VISION_MODEL as ZAI_DEFAULT_VISION_MODEL,
 };
 
 /// Default heavy text model — kept as the legacy alias so existing callers
@@ -279,7 +285,8 @@ scene { box \"b\" (size=[1,1,1], mat=\"wood\") }
 
     #[test]
     fn embed_strips_legacy_comments() {
-        let src = "// mogen-generate seed=1\n// mogen-generate thinking=low\n// prompt: old\nscene {}\n";
+        let src =
+            "// mogen-generate seed=1\n// mogen-generate thinking=low\n// prompt: old\nscene {}\n";
         let wrapped = embed_seed_header(src, 2, "new", Some(ThinkingLevel::High));
         assert!(!wrapped.contains("// mogen-generate"));
         assert!(!wrapped.contains("// prompt:"));

--- a/crates/mogen-llm/src/provider.rs
+++ b/crates/mogen-llm/src/provider.rs
@@ -17,6 +17,7 @@ use crate::google_oauth::OAuthBundle;
 use crate::ollama::{OllamaClient, OllamaError};
 use crate::openai::{OpenAIClient, OpenAIError};
 use crate::types::{GenerateConfig, GenerateResponse};
+use crate::xiaomi::{XiaomiClient, XiaomiError};
 use crate::zai_chat::{ZaiChatClient, ZaiChatError};
 
 /// How the user's Google credential is supplied. Surfaced in the CLI's
@@ -59,6 +60,10 @@ pub enum Provider {
     /// Z.ai (Zhipu AI) GLM family. OpenAI-compatible Chat Completions at
     /// `api.z.ai/api/paas/v4/chat/completions`. Default model is `glm-5.1`.
     Zai,
+    /// Xiaomi MiMo Open Platform. OpenAI-compatible Chat Completions at
+    /// `api.xiaomimimo.com/v1/chat/completions`. Default model is
+    /// `mimo-v2.5-pro`.
+    Xiaomi,
     /// Generic OpenAI-compatible Chat Completions endpoint, aimed at local
     /// runtimes (llama.cpp's `server`, LM Studio, etc.) that expose
     /// `POST {base_url}/chat/completions`. Reuses the [`OpenAIClient`]; the
@@ -88,6 +93,7 @@ impl Provider {
             Provider::Fireworks => "fireworks",
             Provider::Zai => "zai",
             Provider::OpenAiCompat => "openai-compat",
+            Provider::Xiaomi => "xiaomi",
         }
     }
 
@@ -102,6 +108,7 @@ impl Provider {
             Provider::Fireworks => "Fireworks AI Firepass",
             Provider::Zai => "Z.ai (GLM)",
             Provider::OpenAiCompat => "OpenAI-compatible (local)",
+            Provider::Xiaomi => "Xiaomi MiMo",
         }
     }
 
@@ -118,6 +125,7 @@ impl Provider {
             Provider::Fireworks => "Fireworks AI Firepass",
             Provider::Zai => "Z.ai",
             Provider::OpenAiCompat => "OpenAI-compatible",
+            Provider::Xiaomi => "Xiaomi MiMo",
         }
     }
 
@@ -133,6 +141,7 @@ impl Provider {
             "claude-code" | "claude_code" | "claudecode" | "cc" => Some(Self::ClaudeCode),
             "fireworks" | "fireworks-ai" | "firepass" | "kimi" => Some(Self::Fireworks),
             "zai" | "z-ai" | "z.ai" | "zhipu" | "glm" => Some(Self::Zai),
+            "xiaomi" | "mimo" | "xiaomimimo" | "xiaomi-mimo" | "xiaomi_mimo" => Some(Self::Xiaomi),
             "openai-compat" | "openai-compatible" | "openai_compat" | "local-openai"
             | "lmstudio" | "lm-studio" | "llamacpp" | "llama-cpp" | "llama.cpp" => {
                 Some(Self::OpenAiCompat)
@@ -156,6 +165,7 @@ impl Provider {
             Provider::Fireworks => "FIREWORKS_API_KEY",
             Provider::Zai => "ZAI_API_KEY",
             Provider::OpenAiCompat => "OPENAI_COMPAT_API_KEY",
+            Provider::Xiaomi => "XIAOMI_API_KEY",
         }
     }
 
@@ -171,6 +181,7 @@ impl Provider {
             Provider::Fireworks => crate::fireworks::DEFAULT_MODEL,
             Provider::Zai => crate::zai_chat::DEFAULT_MODEL,
             Provider::OpenAiCompat => OPENAI_COMPAT_DEFAULT_MODEL,
+            Provider::Xiaomi => crate::xiaomi::DEFAULT_MODEL,
         }
     }
 
@@ -186,6 +197,7 @@ impl Provider {
             Provider::Fireworks => crate::fireworks::DEFAULT_FAST_MODEL,
             Provider::Zai => crate::zai_chat::DEFAULT_FAST_MODEL,
             Provider::OpenAiCompat => OPENAI_COMPAT_DEFAULT_MODEL,
+            Provider::Xiaomi => crate::xiaomi::DEFAULT_FAST_MODEL,
         }
     }
 
@@ -206,8 +218,9 @@ impl Provider {
     /// back to the model). Today: Gemini, OpenAI (all current `gpt-4o`/
     /// `gpt-4.1`/`gpt-5`/`gpt-5.5` models are multimodal), Z.ai
     /// (`glm-5v-turbo`), Fireworks (Kimi K2.5/K2.6 are native multimodal),
-    /// and Claude Code (`claude --print` resolves filesystem-path image
-    /// references via the model's built-in `Read` tool).
+    /// Xiaomi MiMo (`mimo-v2.5`), and Claude Code (`claude --print`
+    /// resolves filesystem-path image references via the model's built-in
+    /// `Read` tool).
     ///
     /// This is **not** about image *generation* (the textures pipeline) —
     /// that lives behind the `ImageProvider` enum in the Studio settings.
@@ -218,6 +231,7 @@ impl Provider {
                 | Provider::OpenAI
                 | Provider::Zai
                 | Provider::Fireworks
+                | Provider::Xiaomi
                 | Provider::ClaudeCode
         )
     }
@@ -244,7 +258,7 @@ impl fmt::Display for Provider {
 /// Provider-agnostic error type emitted by [`LlmClient::generate`]. Each
 /// per-provider error variant is mapped into one of these on the way out so
 /// callers (the repair loop, the Studio classifier) don't need to match on
-/// four error enums.
+/// each backend's error enum.
 ///
 /// Network failures are split into [`Self::Offline`] / [`Self::Timeout`] /
 /// [`Self::Tls`] / [`Self::Transport`] so the UI can show "you appear to be
@@ -278,7 +292,10 @@ pub enum ProviderError {
     #[error("invalid response: {0}")]
     InvalidResponse(String),
     #[error("provider {provider} does not support {feature}")]
-    Unsupported { provider: Provider, feature: &'static str },
+    Unsupported {
+        provider: Provider,
+        feature: &'static str,
+    },
     /// OAuth subsystem failure (refresh failed, project missing, store
     /// corrupted). The body carries the [`crate::google_oauth::OAuthError`]
     /// message verbatim so the CLI can show the actionable hint.
@@ -289,7 +306,9 @@ pub enum ProviderError {
 impl From<GeminiError> for ProviderError {
     fn from(e: GeminiError) -> Self {
         match e {
-            GeminiError::MissingApiKey => Self::MissingApiKey { var: "GEMINI_API_KEY" },
+            GeminiError::MissingApiKey => Self::MissingApiKey {
+                var: "GEMINI_API_KEY",
+            },
             GeminiError::Transport(err) => classify_reqwest(&err),
             GeminiError::Api { status, message } => Self::Api { status, message },
             GeminiError::EmptyResponse => Self::EmptyResponse,
@@ -311,7 +330,9 @@ impl From<GeminiError> for ProviderError {
 impl From<OpenAIError> for ProviderError {
     fn from(e: OpenAIError) -> Self {
         match e {
-            OpenAIError::MissingApiKey => Self::MissingApiKey { var: "OPENAI_API_KEY" },
+            OpenAIError::MissingApiKey => Self::MissingApiKey {
+                var: "OPENAI_API_KEY",
+            },
             OpenAIError::Transport(err) => classify_reqwest(&err),
             OpenAIError::Api { status, message } => Self::Api { status, message },
             OpenAIError::EmptyResponse => Self::EmptyResponse,
@@ -324,11 +345,15 @@ impl From<OpenAIError> for ProviderError {
 impl From<AnthropicError> for ProviderError {
     fn from(e: AnthropicError) -> Self {
         match e {
-            AnthropicError::MissingApiKey => Self::MissingApiKey { var: "ANTHROPIC_API_KEY" },
+            AnthropicError::MissingApiKey => Self::MissingApiKey {
+                var: "ANTHROPIC_API_KEY",
+            },
             AnthropicError::Transport(err) => classify_reqwest(&err),
             AnthropicError::Api { status, message } => Self::Api { status, message },
             AnthropicError::EmptyResponse => Self::EmptyResponse,
-            AnthropicError::BudgetExceeded { used, budget } => Self::BudgetExceeded { used, budget },
+            AnthropicError::BudgetExceeded { used, budget } => {
+                Self::BudgetExceeded { used, budget }
+            }
             AnthropicError::InvalidResponse(s) => Self::InvalidResponse(s),
         }
     }
@@ -349,11 +374,15 @@ impl From<OllamaError> for ProviderError {
 impl From<FireworksError> for ProviderError {
     fn from(e: FireworksError) -> Self {
         match e {
-            FireworksError::MissingApiKey => Self::MissingApiKey { var: "FIREWORKS_API_KEY" },
+            FireworksError::MissingApiKey => Self::MissingApiKey {
+                var: "FIREWORKS_API_KEY",
+            },
             FireworksError::Transport(err) => classify_reqwest(&err),
             FireworksError::Api { status, message } => Self::Api { status, message },
             FireworksError::EmptyResponse => Self::EmptyResponse,
-            FireworksError::BudgetExceeded { used, budget } => Self::BudgetExceeded { used, budget },
+            FireworksError::BudgetExceeded { used, budget } => {
+                Self::BudgetExceeded { used, budget }
+            }
             FireworksError::InvalidResponse(s) => Self::InvalidResponse(s),
         }
     }
@@ -368,6 +397,21 @@ impl From<ZaiChatError> for ProviderError {
             ZaiChatError::EmptyResponse => Self::EmptyResponse,
             ZaiChatError::BudgetExceeded { used, budget } => Self::BudgetExceeded { used, budget },
             ZaiChatError::InvalidResponse(s) => Self::InvalidResponse(s),
+        }
+    }
+}
+
+impl From<XiaomiError> for ProviderError {
+    fn from(e: XiaomiError) -> Self {
+        match e {
+            XiaomiError::MissingApiKey => Self::MissingApiKey {
+                var: "XIAOMI_API_KEY",
+            },
+            XiaomiError::Transport(err) => classify_reqwest(&err),
+            XiaomiError::Api { status, message } => Self::Api { status, message },
+            XiaomiError::EmptyResponse => Self::EmptyResponse,
+            XiaomiError::BudgetExceeded { used, budget } => Self::BudgetExceeded { used, budget },
+            XiaomiError::InvalidResponse(s) => Self::InvalidResponse(s),
         }
     }
 }
@@ -469,6 +513,7 @@ pub enum LlmClient {
     ClaudeCode(ClaudeCodeClient),
     Fireworks(FireworksClient),
     Zai(ZaiChatClient),
+    Xiaomi(XiaomiClient),
     /// Generic OpenAI-compatible local server. Same wire client as
     /// [`Self::OpenAI`]; kept as a distinct variant so [`Self::provider`]
     /// reports `OpenAiCompat` (separate model/key settings, no cloud
@@ -490,6 +535,7 @@ impl LlmClient {
             Provider::ClaudeCode => LlmClient::ClaudeCode(ClaudeCodeClient::new()),
             Provider::Fireworks => LlmClient::Fireworks(FireworksClient::new(api_key)),
             Provider::Zai => LlmClient::Zai(ZaiChatClient::new(api_key)),
+            Provider::Xiaomi => LlmClient::Xiaomi(XiaomiClient::new(api_key)),
             Provider::OpenAiCompat => LlmClient::OpenAiCompat(OpenAIClient::new(api_key)),
         }
     }
@@ -501,9 +547,7 @@ impl LlmClient {
     pub fn gemini_from_credential(credential: GoogleCredential) -> Self {
         match credential {
             GoogleCredential::ApiKey(key) => LlmClient::Gemini(GeminiClient::new(key)),
-            GoogleCredential::OAuth(bundle) => {
-                LlmClient::Gemini(GeminiClient::from_oauth(bundle))
-            }
+            GoogleCredential::OAuth(bundle) => LlmClient::Gemini(GeminiClient::from_oauth(bundle)),
             GoogleCredential::AntigravityOAuth(bundle) => {
                 LlmClient::Gemini(GeminiClient::from_antigravity_oauth(bundle))
             }
@@ -552,6 +596,7 @@ impl LlmClient {
                 LlmClient::Fireworks(FireworksClient::with_base_url(api_key, base_url))
             }
             Provider::Zai => LlmClient::Zai(ZaiChatClient::with_base_url(api_key, base_url)),
+            Provider::Xiaomi => LlmClient::Xiaomi(XiaomiClient::with_base_url(api_key, base_url)),
             Provider::OpenAiCompat => {
                 LlmClient::OpenAiCompat(OpenAIClient::with_base_url(api_key, base_url))
             }
@@ -568,6 +613,7 @@ impl LlmClient {
             LlmClient::ClaudeCode(_) => Provider::ClaudeCode,
             LlmClient::Fireworks(_) => Provider::Fireworks,
             LlmClient::Zai(_) => Provider::Zai,
+            LlmClient::Xiaomi(_) => Provider::Xiaomi,
             LlmClient::OpenAiCompat(_) => Provider::OpenAiCompat,
         }
     }
@@ -612,6 +658,7 @@ impl LlmClient {
             LlmClient::ClaudeCode(c) => c.generate(cfg).map_err(Into::into),
             LlmClient::Fireworks(c) => c.generate(cfg).map_err(Into::into),
             LlmClient::Zai(c) => c.generate(cfg).map_err(Into::into),
+            LlmClient::Xiaomi(c) => c.generate(cfg).map_err(Into::into),
             LlmClient::OpenAiCompat(c) => c.generate(cfg).map_err(Into::into),
         };
 
@@ -651,9 +698,7 @@ impl LlmClient {
                             &usage,
                             &cfg.spend_context,
                             false,
-                            Some(format!(
-                                "budget exceeded: {used} > {budget}"
-                            )),
+                            Some(format!("budget exceeded: {used} > {budget}")),
                         );
                         crate::spend::record(rec);
                     }
@@ -690,6 +735,7 @@ mod tests {
             Provider::ClaudeCode,
             Provider::Fireworks,
             Provider::Zai,
+            Provider::Xiaomi,
             Provider::OpenAiCompat,
         ] {
             assert_eq!(Provider::parse(p.key()), Some(p));
@@ -709,12 +755,20 @@ mod tests {
         assert_eq!(Provider::parse("Z.AI"), Some(Provider::Zai));
         assert_eq!(Provider::parse("zhipu"), Some(Provider::Zai));
         assert_eq!(Provider::parse("glm"), Some(Provider::Zai));
+        assert_eq!(Provider::parse("MiMo"), Some(Provider::Xiaomi));
+        assert_eq!(Provider::parse("xiaomi-mimo"), Some(Provider::Xiaomi));
         assert_eq!(Provider::parse("lmstudio"), Some(Provider::OpenAiCompat));
         assert_eq!(Provider::parse("LM-Studio"), Some(Provider::OpenAiCompat));
         assert_eq!(Provider::parse("llama.cpp"), Some(Provider::OpenAiCompat));
         assert_eq!(Provider::parse("llamacpp"), Some(Provider::OpenAiCompat));
-        assert_eq!(Provider::parse("local-openai"), Some(Provider::OpenAiCompat));
-        assert_eq!(Provider::parse("openai-compatible"), Some(Provider::OpenAiCompat));
+        assert_eq!(
+            Provider::parse("local-openai"),
+            Some(Provider::OpenAiCompat)
+        );
+        assert_eq!(
+            Provider::parse("openai-compatible"),
+            Some(Provider::OpenAiCompat)
+        );
         assert_eq!(Provider::parse("wat"), None);
     }
 
@@ -734,14 +788,15 @@ mod tests {
         // real key on disk (env or settings file) sees this pass on CI but
         // fail locally. Point `MOGEN_SETTINGS` at a guaranteed-absent path so
         // the settings-store fallback reads nothing.
-        let missing_settings =
-            std::env::temp_dir().join("mogen-test-nonexistent-settings.json");
+        let missing_settings = std::env::temp_dir().join("mogen-test-nonexistent-settings.json");
         std::env::remove_var("OPENAI_API_KEY");
         std::env::set_var("MOGEN_SETTINGS", &missing_settings);
         let result = LlmClient::from_env(Provider::OpenAI);
         std::env::remove_var("MOGEN_SETTINGS");
         match result {
-            Err(ProviderError::MissingApiKey { var: "OPENAI_API_KEY" }) => {}
+            Err(ProviderError::MissingApiKey {
+                var: "OPENAI_API_KEY",
+            }) => {}
             Err(other) => panic!("wrong error: {other}"),
             Ok(_) => panic!("expected MissingApiKey but got Ok"),
         }
@@ -768,9 +823,8 @@ mod tests {
     fn from_env_succeeds_for_ollama_without_key() {
         // Ollama tolerates a blank key; this should construct a client.
         std::env::remove_var("OLLAMA_API_KEY");
-        let c = LlmClient::from_env(Provider::Ollama).unwrap_or_else(|_| {
-            panic!("ollama should work keyless")
-        });
+        let c = LlmClient::from_env(Provider::Ollama)
+            .unwrap_or_else(|_| panic!("ollama should work keyless"));
         assert_eq!(c.provider(), Provider::Ollama);
     }
 
@@ -779,9 +833,8 @@ mod tests {
         // OpenAiCompat is keyless (local servers need no token); from_env
         // must succeed without consulting OPENAI_COMPAT_API_KEY.
         std::env::remove_var("OPENAI_COMPAT_API_KEY");
-        let c = LlmClient::from_env(Provider::OpenAiCompat).unwrap_or_else(|_| {
-            panic!("openai-compat should work keyless")
-        });
+        let c = LlmClient::from_env(Provider::OpenAiCompat)
+            .unwrap_or_else(|_| panic!("openai-compat should work keyless"));
         assert_eq!(c.provider(), Provider::OpenAiCompat);
     }
 }

--- a/crates/mogen-llm/src/settings_store.rs
+++ b/crates/mogen-llm/src/settings_store.rs
@@ -48,6 +48,8 @@ pub struct ApiKeys {
     pub fireworks_api_key: String,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub zai_api_key: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub xiaomi_api_key: String,
     /// When `Some(true)` (or absent — defaults to true), Z.ai chat calls
     /// route through the dedicated GLM Coding Plan endpoint
     /// (`/api/coding/paas/v4`). When `Some(false)`, use the general PaaS
@@ -90,6 +92,7 @@ pub fn read_api_key(provider: Provider) -> Option<String> {
         Provider::Ollama => &keys.ollama_api_key,
         Provider::Fireworks => &keys.fireworks_api_key,
         Provider::Zai => &keys.zai_api_key,
+        Provider::Xiaomi => &keys.xiaomi_api_key,
         Provider::ClaudeCode | Provider::OpenAiCompat => return None,
     };
     let trimmed = raw.trim();
@@ -130,6 +133,7 @@ mod tests {
         assert_eq!(keys.gemini_api_key, "abc123");
         assert_eq!(keys.openai_api_key, "");
         assert_eq!(keys.zai_api_key, "");
+        assert_eq!(keys.xiaomi_api_key, "");
     }
 
     #[test]
@@ -140,7 +144,8 @@ mod tests {
             "anthropic_api_key": "a",
             "ollama_api_key": "ol",
             "fireworks_api_key": "f",
-            "zai_api_key": "z"
+            "zai_api_key": "z",
+            "xiaomi_api_key": "x"
         }"#;
         let keys: ApiKeys = serde_json::from_str(json).unwrap();
         assert_eq!(keys.gemini_api_key, "g");
@@ -149,6 +154,7 @@ mod tests {
         assert_eq!(keys.ollama_api_key, "ol");
         assert_eq!(keys.fireworks_api_key, "f");
         assert_eq!(keys.zai_api_key, "z");
+        assert_eq!(keys.xiaomi_api_key, "x");
     }
 
     #[test]

--- a/crates/mogen-llm/src/spend/pricing.rs
+++ b/crates/mogen-llm/src/spend/pricing.rs
@@ -68,11 +68,7 @@ impl TextPricing {
         }
     }
 
-    pub const fn tiered(
-        threshold: u32,
-        short: (f64, f64, f64),
-        long: (f64, f64, f64),
-    ) -> Self {
+    pub const fn tiered(threshold: u32, short: (f64, f64, f64), long: (f64, f64, f64)) -> Self {
         Self {
             input_per_mtok: short.0,
             output_per_mtok: short.1,
@@ -166,17 +162,21 @@ pub fn text_price_for_model(model: &str) -> TextPricing {
     }
 
     // --- Gemini 2.5 family.
-    if m.starts_with("gemini-pro") || m.contains("2.5-pro") || m.contains("2-5-pro") {
+    if m.starts_with("gemini-pro")
+        || (m.starts_with("gemini") && (m.contains("2.5-pro") || m.contains("2-5-pro")))
+    {
         return TextPricing::tiered(
             DEFAULT_LONG_CONTEXT_THRESHOLD,
             (1.25, 10.00, 0.125),
             (2.50, 15.00, 0.25),
         );
     }
-    if m.contains("flash-lite") {
+    if m.starts_with("gemini") && m.contains("flash-lite") {
         return TextPricing::flat(0.10, 0.40, 0.01);
     }
-    if m.starts_with("gemini-flash") || m.contains("2.5-flash") || m.contains("2-5-flash") {
+    if m.starts_with("gemini-flash")
+        || (m.starts_with("gemini") && (m.contains("2.5-flash") || m.contains("2-5-flash")))
+    {
         return TextPricing::flat(0.30, 2.50, 0.03);
     }
 
@@ -218,6 +218,17 @@ pub fn text_price_for_model(model: &str) -> TextPricing {
         return TextPricing::flat(0.50, 1.50, 0.10);
     }
 
+    // --- Xiaomi MiMo family. Overseas pay-as-you-go rates, USD/M tokens.
+    if m.contains("mimo-v2.5-pro") || m.contains("mimo-v2-pro") {
+        return TextPricing::flat(0.435, 0.87, 0.0036);
+    }
+    if m.contains("mimo-v2.5") || m.contains("mimo-v2-omni") {
+        return TextPricing::flat(0.14, 0.28, 0.0028);
+    }
+    if m.contains("mimo-v2-flash") {
+        return TextPricing::flat(0.10, 0.30, 0.01);
+    }
+
     // --- Local / unknown — bill at zero so the meter stays honest.
     TextPricing::flat(0.0, 0.0, 0.0)
 }
@@ -226,17 +237,22 @@ pub fn text_price_for_model(model: &str) -> TextPricing {
 pub fn image_price_for_model(model: &str) -> ImagePricing {
     let m = model.to_ascii_lowercase();
     if m.contains("flash-image") || m.contains("nano-banana") {
-        return ImagePricing { per_image_usd: 0.039 };
+        return ImagePricing {
+            per_image_usd: 0.039,
+        };
     }
     if m.contains("imagen") {
-        return ImagePricing { per_image_usd: 0.04 };
+        return ImagePricing {
+            per_image_usd: 0.04,
+        };
     }
     if m.contains("glm-image") {
-        return ImagePricing { per_image_usd: 0.03 };
+        return ImagePricing {
+            per_image_usd: 0.03,
+        };
     }
     ImagePricing { per_image_usd: 0.0 }
 }
-
 
 /// Baseline pricing seeded into the `pricing` table on first run. Each row
 /// captures the public list price for a model `mogen-llm` talks to today.
@@ -320,13 +336,17 @@ pub const SEED: &[PricingSeed] = &[
         provider: "gemini",
         model: "gemini-2.5-flash-image",
         text: None,
-        image: Some(ImagePricing { per_image_usd: 0.039 }),
+        image: Some(ImagePricing {
+            per_image_usd: 0.039,
+        }),
     },
     PricingSeed {
         provider: "gemini",
         model: "imagen-4.0-generate-001",
         text: None,
-        image: Some(ImagePricing { per_image_usd: 0.04 }),
+        image: Some(ImagePricing {
+            per_image_usd: 0.04,
+        }),
     },
     // --- OpenAI.
     PricingSeed {
@@ -396,7 +416,28 @@ pub const SEED: &[PricingSeed] = &[
         provider: "zai",
         model: "glm-image",
         text: None,
-        image: Some(ImagePricing { per_image_usd: 0.03 }),
+        image: Some(ImagePricing {
+            per_image_usd: 0.03,
+        }),
+    },
+    // --- Xiaomi MiMo.
+    PricingSeed {
+        provider: "xiaomi",
+        model: "mimo-v2.5-pro",
+        text: Some(TextPricing::flat(0.435, 0.87, 0.0036)),
+        image: None,
+    },
+    PricingSeed {
+        provider: "xiaomi",
+        model: "mimo-v2.5",
+        text: Some(TextPricing::flat(0.14, 0.28, 0.0028)),
+        image: None,
+    },
+    PricingSeed {
+        provider: "xiaomi",
+        model: "mimo-v2-flash",
+        text: Some(TextPricing::flat(0.10, 0.30, 0.01)),
+        image: None,
     },
     // --- Ollama (local). Always zero.
     PricingSeed {
@@ -463,6 +504,21 @@ mod tests {
     }
 
     #[test]
+    fn xiaomi_pricing_matches_overseas_rates() {
+        let p = text_price_for_model("mimo-v2.5-pro");
+        assert!((p.input_per_mtok - 0.435).abs() < 1e-9);
+        assert!((p.output_per_mtok - 0.87).abs() < 1e-9);
+        assert!((p.cached_input_per_mtok - 0.0036).abs() < 1e-9);
+
+        let flash = text_price_for_model("mimo-v2-flash");
+        assert!((flash.input_per_mtok - 0.10).abs() < 1e-9);
+        assert!((flash.output_per_mtok - 0.30).abs() < 1e-9);
+
+        let hypothetical_flash_lite = text_price_for_model("mimo-v2.5-flash-lite");
+        assert!((hypothetical_flash_lite.input_per_mtok - 0.14).abs() < 1e-9);
+        assert!((hypothetical_flash_lite.output_per_mtok - 0.28).abs() < 1e-9);
+    }
+    #[test]
     fn unknown_model_costs_nothing() {
         let p = text_price_for_model("homebrewed-llama");
         assert_eq!(p, TextPricing::flat(0.0, 0.0, 0.0));
@@ -473,5 +529,6 @@ mod tests {
         assert!(SEED.iter().any(|r| r.model == "gemini-pro-latest"));
         assert!(SEED.iter().any(|r| r.model == "gemini-2.5-flash-image"));
         assert!(SEED.iter().any(|r| r.provider == "openai"));
+        assert!(SEED.iter().any(|r| r.provider == "xiaomi"));
     }
 }

--- a/crates/mogen-llm/src/xiaomi.rs
+++ b/crates/mogen-llm/src/xiaomi.rs
@@ -1,0 +1,451 @@
+//! Xiaomi MiMo Open Platform client.
+//!
+//! Talks to `POST {base_url}/chat/completions` on Xiaomi's OpenAI-compatible
+//! API. The docs also expose an Anthropic-compatible endpoint, but the OpenAI
+//! surface is the better fit for MoGen: it accepts standard Bearer auth, uses
+//! the same image-url content parts as the existing OpenAI-style providers,
+//! and keeps system messages in the `messages` array instead of needing a
+//! separate Anthropic-style `system` field.
+
+use std::time::Duration;
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::types::{GenerateConfig, GenerateResponse, ThinkingLevel, Usage};
+
+/// Default heavy text model. MiMo-V2.5-Pro is Xiaomi's current reasoning/text
+/// flagship, with a 1M context window and 128K maximum output.
+pub const DEFAULT_MODEL: &str = "mimo-v2.5-pro";
+
+/// Default fast model used by Studio's Prompt Enhancer / Ask modal.
+pub const DEFAULT_FAST_MODEL: &str = "mimo-v2-flash";
+
+/// Vision-capable MiMo model. Triggered by Studio/CLI refinement paths when a
+/// screenshot or user reference image is attached.
+pub const DEFAULT_VISION_MODEL: &str = "mimo-v2.5";
+
+/// Xiaomi's defaults (32K–128K completion tokens on text models) are too high
+/// for MoGen's "emit one DSL file" contract, but the reasoning-enabled models
+/// still need more headroom than Flash or they can spend the whole cap on
+/// `reasoning_content` and never reach the final DSL. Use a provider-specific
+/// middle ground.
+const MAX_COMPLETION_TOKENS_DISABLED: u32 = 8_192;
+const MAX_COMPLETION_TOKENS_REASONING: u32 = 32_768;
+const REQUEST_TIMEOUT_DISABLED_SECS: u64 = 600;
+const REQUEST_TIMEOUT_REASONING_SECS: u64 = 1_800;
+
+const DEFAULT_BASE_URL: &str = "https://api.xiaomimimo.com/v1";
+
+#[derive(Debug, Error)]
+pub enum XiaomiError {
+    #[error("missing XIAOMI_API_KEY (set env var or pass --api-key)")]
+    MissingApiKey,
+    #[error("transport error: {0}")]
+    Transport(#[from] reqwest::Error),
+    #[error("API error ({status}): {message}")]
+    Api { status: u16, message: String },
+    #[error("empty response: model produced no choices or text")]
+    EmptyResponse,
+    #[error("budget exceeded: {used} input+output tokens exceeds --budget-tokens={budget}")]
+    BudgetExceeded { used: u32, budget: u32 },
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
+}
+
+pub struct XiaomiClient {
+    http: reqwest::blocking::Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl XiaomiClient {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self::with_base_url(api_key, DEFAULT_BASE_URL)
+    }
+
+    pub fn with_base_url(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
+        // Keep the client-level timeout unset. Xiaomi's reasoning-enabled
+        // models can legitimately run much longer than the fast/text-only
+        // paths, so `generate` applies the overall timeout per request based
+        // on the active thinking mode.
+        let http = reqwest::blocking::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .build()
+            .expect("reqwest client");
+        Self {
+            http,
+            api_key: api_key.into(),
+            base_url: base_url.into(),
+        }
+    }
+
+    pub fn from_env() -> Result<Self, XiaomiError> {
+        let key = std::env::var("XIAOMI_API_KEY").map_err(|_| XiaomiError::MissingApiKey)?;
+        if key.trim().is_empty() {
+            return Err(XiaomiError::MissingApiKey);
+        }
+        Ok(Self::new(key))
+    }
+
+    pub fn generate(&self, cfg: &GenerateConfig) -> Result<GenerateResponse, XiaomiError> {
+        if self.api_key.trim().is_empty() {
+            return Err(XiaomiError::MissingApiKey);
+        }
+
+        let url = format!("{}/chat/completions", self.base_url);
+        let body = build_request(cfg);
+
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .timeout(request_timeout(cfg))
+            .json(&body)
+            .send()?;
+        let status = resp.status();
+
+        let bytes = resp.bytes()?;
+
+        if std::env::var("MOGEN_DEBUG_HTTP").ok().as_deref() == Some("1") {
+            let preview = String::from_utf8_lossy(&bytes);
+            let preview = if preview.len() > 4096 {
+                &preview[..4096]
+            } else {
+                &preview
+            };
+            eprintln!(
+                "[mogen xiaomi] model={} status={} body={}",
+                cfg.model, status, preview
+            );
+        }
+
+        if !status.is_success() {
+            let message = parse_error_message(&bytes);
+            return Err(XiaomiError::Api {
+                status: status.as_u16(),
+                message,
+            });
+        }
+
+        let parsed: RawChatResponse = serde_json::from_slice(&bytes)
+            .map_err(|e| XiaomiError::InvalidResponse(e.to_string()))?;
+
+        let text = parsed
+            .choices
+            .into_iter()
+            .find_map(|c| c.message.content)
+            .ok_or(XiaomiError::EmptyResponse)?;
+
+        if text.trim().is_empty() {
+            return Err(XiaomiError::EmptyResponse);
+        }
+
+        let usage = parsed
+            .usage
+            .map(|u| Usage {
+                prompt_tokens: u.prompt_tokens,
+                response_tokens: u.completion_tokens,
+                total_tokens: u.total_tokens,
+                cached_tokens: u
+                    .prompt_tokens_details
+                    .and_then(|d| d.cached_tokens)
+                    .unwrap_or(0),
+            })
+            .unwrap_or_default();
+
+        if let Some(budget) = cfg.budget_tokens {
+            if usage.total_tokens > budget {
+                return Err(XiaomiError::BudgetExceeded {
+                    used: usage.total_tokens,
+                    budget,
+                });
+            }
+        }
+
+        Ok(GenerateResponse { text, usage })
+    }
+}
+
+fn requested_thinking_type(cfg: &GenerateConfig) -> &'static str {
+    match cfg.thinking_level.unwrap_or(ThinkingLevel::High) {
+        // Xiaomi only exposes enabled/disabled, not budget tiers. Treat
+        // Low/Medium as "skip CoT" so fast/cheap calls behave like the other
+        // providers' lower reasoning settings; High/XHigh leave CoT on.
+        ThinkingLevel::Low | ThinkingLevel::Medium => "disabled",
+        ThinkingLevel::High | ThinkingLevel::XHigh => "enabled",
+    }
+}
+
+fn max_completion_tokens(cfg: &GenerateConfig) -> u32 {
+    if requested_thinking_type(cfg) == "enabled" {
+        MAX_COMPLETION_TOKENS_REASONING
+    } else {
+        MAX_COMPLETION_TOKENS_DISABLED
+    }
+}
+
+/// Xiaomi's server-side thinking can hold a request open for much longer than
+/// the no-CoT path. Give reasoning-enabled calls more wall-clock headroom so
+/// Studio generation doesn't fail at the generic 10-minute cap, while still
+/// letting low/medium-thinking requests fail fast on a truly stalled server.
+fn request_timeout(cfg: &GenerateConfig) -> Duration {
+    if requested_thinking_type(cfg) == "enabled" {
+        Duration::from_secs(REQUEST_TIMEOUT_REASONING_SECS)
+    } else {
+        Duration::from_secs(REQUEST_TIMEOUT_DISABLED_SECS)
+    }
+}
+
+fn build_request(cfg: &GenerateConfig) -> serde_json::Value {
+    let mut messages: Vec<serde_json::Value> = Vec::new();
+    if let Some(sys) = &cfg.system_instruction {
+        messages.push(serde_json::json!({ "role": "system", "content": sys }));
+    }
+    for turn in &cfg.history {
+        messages.push(serde_json::json!({
+            "role": turn.role.chat_str(),
+            "content": turn.text,
+        }));
+    }
+
+    // Xiaomi's vision docs use the same OpenAI-compatible content-part shape
+    // as OpenAI itself: image_url parts first, text last. Text-only calls keep
+    // the cheaper plain-string content shape.
+    if cfg.user_images.is_empty() {
+        messages.push(serde_json::json!({
+            "role": "user",
+            "content": cfg.user_prompt,
+        }));
+    } else {
+        let mut parts: Vec<serde_json::Value> = Vec::with_capacity(cfg.user_images.len() + 1);
+        for img in &cfg.user_images {
+            let url = format!(
+                "data:{};base64,{}",
+                img.mime_type,
+                STANDARD.encode(&img.data),
+            );
+            parts.push(serde_json::json!({
+                "type": "image_url",
+                "image_url": { "url": url },
+            }));
+        }
+        parts.push(serde_json::json!({
+            "type": "text",
+            "text": cfg.user_prompt,
+        }));
+        messages.push(serde_json::json!({
+            "role": "user",
+            "content": parts,
+        }));
+    }
+
+    let thinking_type = requested_thinking_type(cfg);
+    let mut req = serde_json::json!({
+        "model": cfg.model,
+        "messages": messages,
+        "max_completion_tokens": max_completion_tokens(cfg),
+        "stream": false,
+        "thinking": { "type": thinking_type },
+    });
+
+    if let Some(t) = cfg.temperature {
+        // Match the Z.ai workaround: serialise the shortest decimal for f32
+        // values so provider-side schema validators never see a widened
+        // artifact such as 0.30000001192092896.
+        let t_str = format!("{}", t);
+        let t_f64: f64 = t_str.parse().unwrap_or_else(|_| f64::from(t));
+        req["temperature"] = serde_json::json!(t_f64);
+    }
+
+    // Xiaomi's documented OpenAI-compatible schema does not list `seed`. Keep
+    // the DSL `meta(seed=...)` contract on the MoGen side, but do not send the
+    // field over the wire.
+
+    req
+}
+
+fn parse_error_message(bytes: &[u8]) -> String {
+    if let Ok(v) = serde_json::from_slice::<serde_json::Value>(bytes) {
+        if let Some(msg) = v
+            .get("error")
+            .and_then(|e| e.get("message"))
+            .and_then(|m| m.as_str())
+        {
+            return msg.to_string();
+        }
+        if let Some(msg) = v.get("message").and_then(|m| m.as_str()) {
+            return msg.to_string();
+        }
+    }
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+#[derive(Debug, Deserialize)]
+struct RawChatResponse {
+    #[serde(default)]
+    choices: Vec<RawChoice>,
+    #[serde(default)]
+    usage: Option<RawUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawChoice {
+    message: RawMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMessage {
+    #[serde(default)]
+    content: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct RawUsage {
+    #[serde(default)]
+    prompt_tokens: u32,
+    #[serde(default)]
+    completion_tokens: u32,
+    #[serde(default)]
+    total_tokens: u32,
+    #[serde(default)]
+    prompt_tokens_details: Option<RawPromptDetails>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct RawPromptDetails {
+    #[serde(default)]
+    cached_tokens: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ImageInput, Role, ThinkingLevel, Turn};
+
+    #[test]
+    fn request_body_includes_system_message() {
+        let mut cfg = GenerateConfig::new("hello");
+        cfg.model = DEFAULT_MODEL.into();
+        cfg.system_instruction = Some("be helpful".into());
+        let body = build_request(&cfg);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "be helpful");
+        assert_eq!(messages.last().unwrap()["role"], "user");
+        assert_eq!(messages.last().unwrap()["content"], "hello");
+        assert_eq!(body["model"], DEFAULT_MODEL);
+    }
+
+    #[test]
+    fn request_body_threads_history_with_assistant_role() {
+        let mut cfg = GenerateConfig::new("again");
+        cfg.model = DEFAULT_MODEL.into();
+        cfg.history.push(Turn {
+            role: Role::User,
+            text: "make a chair".into(),
+        });
+        cfg.history.push(Turn {
+            role: Role::Model,
+            text: "scene { box }".into(),
+        });
+        let body = build_request(&cfg);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[1]["role"], "assistant");
+    }
+
+    #[test]
+    fn request_body_omits_seed_and_maps_thinking_to_xiaomi_toggle() {
+        let mut cfg = GenerateConfig::new("x");
+        cfg.model = DEFAULT_MODEL.into();
+        cfg.seed = Some(7);
+        cfg.temperature = Some(0.3);
+        cfg.thinking_level = Some(ThinkingLevel::High);
+        let body = build_request(&cfg);
+        assert!(
+            body.get("seed").is_none(),
+            "seed must stay out of Xiaomi payload: {body}"
+        );
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert_eq!(serde_json::to_string(&body["temperature"]).unwrap(), "0.3");
+        assert_eq!(
+            body["max_completion_tokens"],
+            MAX_COMPLETION_TOKENS_REASONING
+        );
+        assert_eq!(body["stream"], false);
+    }
+
+    #[test]
+    fn low_thinking_disables_cot_and_uses_small_cap() {
+        let mut cfg = GenerateConfig::new("x");
+        cfg.model = DEFAULT_FAST_MODEL.into();
+        cfg.thinking_level = Some(ThinkingLevel::Low);
+        let body = build_request(&cfg);
+        assert_eq!(body["thinking"]["type"], "disabled");
+        assert_eq!(
+            body["max_completion_tokens"],
+            MAX_COMPLETION_TOKENS_DISABLED
+        );
+    }
+
+    #[test]
+    fn high_thinking_uses_extended_timeout() {
+        let mut cfg = GenerateConfig::new("x");
+        cfg.model = DEFAULT_MODEL.into();
+        cfg.thinking_level = Some(ThinkingLevel::High);
+        assert_eq!(
+            request_timeout(&cfg),
+            Duration::from_secs(REQUEST_TIMEOUT_REASONING_SECS)
+        );
+    }
+
+    #[test]
+    fn medium_thinking_uses_default_timeout() {
+        let mut cfg = GenerateConfig::new("x");
+        cfg.model = DEFAULT_MODEL.into();
+        cfg.thinking_level = Some(ThinkingLevel::Medium);
+        assert_eq!(
+            request_timeout(&cfg),
+            Duration::from_secs(REQUEST_TIMEOUT_DISABLED_SECS)
+        );
+    }
+
+    #[test]
+    fn user_image_becomes_image_url_part_before_text() {
+        let mut cfg = GenerateConfig::new("describe this");
+        cfg.model = DEFAULT_VISION_MODEL.into();
+        cfg.user_images.push(ImageInput {
+            mime_type: "image/png".into(),
+            data: vec![0x01, 0x02, 0x03],
+        });
+        let body = build_request(&cfg);
+        let messages = body["messages"].as_array().unwrap();
+        let user = messages.last().unwrap();
+        assert_eq!(user["role"], "user");
+        let parts = user["content"]
+            .as_array()
+            .expect("content array on vision turn");
+        assert_eq!(parts.len(), 2, "got: {body}");
+        assert_eq!(parts[0]["type"], "image_url");
+        assert_eq!(parts[0]["image_url"]["url"], "data:image/png;base64,AQID");
+        assert_eq!(parts[1]["type"], "text");
+        assert_eq!(parts[1]["text"], "describe this");
+    }
+
+    #[test]
+    fn parse_error_message_extracts_nested_field() {
+        let raw = br#"{"error":{"message":"invalid api key","type":"auth"}}"#;
+        assert_eq!(parse_error_message(raw), "invalid api key");
+    }
+
+    #[test]
+    fn default_models_match_mimo_series() {
+        assert_eq!(DEFAULT_MODEL, "mimo-v2.5-pro");
+        assert_eq!(DEFAULT_FAST_MODEL, "mimo-v2-flash");
+        assert_eq!(DEFAULT_VISION_MODEL, "mimo-v2.5");
+    }
+}

--- a/crates/mogen-llm/tests/mock_server.rs
+++ b/crates/mogen-llm/tests/mock_server.rs
@@ -27,7 +27,10 @@ impl MockServer {
         let port = server.server_addr().to_ip().expect("ipv4").port();
 
         let responses = Arc::new(Mutex::new(
-            responses.into_iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            responses
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>(),
         ));
         let requests = Arc::new(Mutex::new(Vec::<String>::new()));
 
@@ -47,17 +50,21 @@ impl MockServer {
                         q.remove(0)
                     }
                 };
-                let response = tiny_http::Response::from_string(payload)
-                    .with_header(
-                        "Content-Type: application/json"
-                            .parse::<tiny_http::Header>()
-                            .unwrap(),
-                    );
+                let response = tiny_http::Response::from_string(payload).with_header(
+                    "Content-Type: application/json"
+                        .parse::<tiny_http::Header>()
+                        .unwrap(),
+                );
                 let _ = req.respond(response);
             }
         });
 
-        Self { port, responses, requests, _handle: handle }
+        Self {
+            port,
+            responses,
+            requests,
+            _handle: handle,
+        }
     }
 
     fn base_url(&self) -> String {
@@ -126,8 +133,16 @@ fn repair_loop_succeeds_on_second_attempt() {
     let reqs = server.requests.lock().unwrap();
     assert_eq!(reqs.len(), 2);
     let second = &reqs[1];
-    assert!(second.contains("E0101"), "expected diagnostic code in repair turn: {}", second);
-    assert!(second.contains("wombat"), "expected prior DSL inlined in user turn: {}", second);
+    assert!(
+        second.contains("E0101"),
+        "expected diagnostic code in repair turn: {}",
+        second
+    );
+    assert!(
+        second.contains("wombat"),
+        "expected prior DSL inlined in user turn: {}",
+        second
+    );
     assert!(
         !second.contains("\"role\":\"model\""),
         "repair turn should not carry prior model history: {}",
@@ -145,7 +160,11 @@ fn repair_loop_respects_max_iters_and_returns_last_attempt() {
     let outcome = generate_with_repair(
         &client,
         GenerateConfig::new("anything"),
-        &RepairConfig { max_iters: 1, on_iteration: None, allow_edit_mode: false },
+        &RepairConfig {
+            max_iters: 1,
+            on_iteration: None,
+            allow_edit_mode: false,
+        },
     )
     .expect("request ok");
 
@@ -187,13 +206,23 @@ fn user_images_become_inline_data_parts_on_the_user_turn() {
         // Three bytes the test can spot once base64-encoded ("AQID").
         data: vec![0x01, 0x02, 0x03],
     });
-    let _ = generate_with_repair(&client, cfg, &RepairConfig { max_iters: 0, on_iteration: None, allow_edit_mode: false })
-        .expect("request ok");
+    let _ = generate_with_repair(
+        &client,
+        cfg,
+        &RepairConfig {
+            max_iters: 0,
+            on_iteration: None,
+            allow_edit_mode: false,
+        },
+    )
+    .expect("request ok");
 
     let reqs = server.requests.lock().unwrap();
     assert_eq!(reqs.len(), 1);
     let body: serde_json::Value = serde_json::from_str(&reqs[0]).expect("valid JSON");
-    let parts = body["contents"][0]["parts"].as_array().expect("parts array");
+    let parts = body["contents"][0]["parts"]
+        .as_array()
+        .expect("parts array");
     // Image part comes first, text part second — vision-prompt convention.
     assert_eq!(parts.len(), 2, "got: {body}");
     assert_eq!(parts[0]["inline_data"]["mime_type"], "image/png");
@@ -209,8 +238,7 @@ fn api_error_surfaces_with_status_and_message() {
     let port = server.server_addr().to_ip().unwrap().port();
     thread::spawn(move || {
         for req in server.incoming_requests() {
-            let body =
-                r#"{"error":{"message":"API key not valid","status":"INVALID_ARGUMENT"}}"#;
+            let body = r#"{"error":{"message":"API key not valid","status":"INVALID_ARGUMENT"}}"#;
             let resp = tiny_http::Response::from_string(body)
                 .with_status_code(400)
                 .with_header(
@@ -222,10 +250,8 @@ fn api_error_surfaces_with_status_and_message() {
         }
     });
 
-    let client = GeminiClient::with_base_url(
-        "test-key",
-        format!("http://127.0.0.1:{}/v1beta", port),
-    );
+    let client =
+        GeminiClient::with_base_url("test-key", format!("http://127.0.0.1:{}/v1beta", port));
     let err = client
         .generate(&GenerateConfig::new("x"))
         .expect_err("should fail");
@@ -244,15 +270,11 @@ fn planner_then_coder_threads_plan_into_user_turn() {
     // contract end-to-end against the real client + repair stack.
     let plan_text = "## Subject\nA tall wooden stool with four legs.\n\n## Parts\n- seat (top)\n- four legs splayed slightly outward";
     let coder_dsl = "scene { box \"seat\" (size=[0.4, 0.05, 0.4]) }";
-    let server = MockServer::start(vec![
-        &candidate_body(plan_text),
-        &candidate_body(coder_dsl),
-    ]);
+    let server = MockServer::start(vec![&candidate_body(plan_text), &candidate_body(coder_dsl)]);
     let client = LlmClient::with_base_url(Provider::Gemini, "test-key", server.base_url());
 
     let base = mogen_llm::GenerateConfig::new("a wooden stool");
-    let plan = mogen_llm::generate_plan(&client, &base, "a wooden stool")
-        .expect("plan call ok");
+    let plan = mogen_llm::generate_plan(&client, &base, "a wooden stool").expect("plan call ok");
     assert!(plan.plan.contains("four legs"));
 
     let coder_user_prompt = mogen_llm::compose_coder_prompt("a wooden stool", &plan.plan);
@@ -261,7 +283,11 @@ fn planner_then_coder_threads_plan_into_user_turn() {
     let outcome = generate_with_repair(
         &client,
         coder_cfg,
-        &RepairConfig { max_iters: 0, on_iteration: None, allow_edit_mode: false },
+        &RepairConfig {
+            max_iters: 0,
+            on_iteration: None,
+            allow_edit_mode: false,
+        },
     )
     .expect("coder call ok");
     assert!(outcome.is_ok(), "diagnostics: {:?}", outcome.diagnostics);
@@ -307,7 +333,11 @@ fn visual_refine_attaches_image_and_dsl() {
     let outcome = mogen_llm::visual_refine(
         &client,
         &base,
-        &RepairConfig { max_iters: 0, on_iteration: None, allow_edit_mode: false },
+        &RepairConfig {
+            max_iters: 0,
+            on_iteration: None,
+            allow_edit_mode: false,
+        },
         registry,
         "a wooden stool",
         previous_dsl,
@@ -371,8 +401,16 @@ fn zai_vision_uses_image_url_content() {
         // Three bytes that base64-encode to "AQID".
         data: vec![0x01, 0x02, 0x03],
     });
-    let _ = generate_with_repair(&client, cfg, &RepairConfig { max_iters: 0, on_iteration: None, allow_edit_mode: false })
-        .expect("request ok");
+    let _ = generate_with_repair(
+        &client,
+        cfg,
+        &RepairConfig {
+            max_iters: 0,
+            on_iteration: None,
+            allow_edit_mode: false,
+        },
+    )
+    .expect("request ok");
 
     let reqs = server.requests.lock().unwrap();
     assert_eq!(reqs.len(), 1);
@@ -381,15 +419,14 @@ fn zai_vision_uses_image_url_content() {
     let messages = body["messages"].as_array().expect("messages array");
     let user = messages.last().expect("user turn");
     assert_eq!(user["role"], "user");
-    let parts = user["content"].as_array().expect("content array on vision turn");
+    let parts = user["content"]
+        .as_array()
+        .expect("content array on vision turn");
     assert_eq!(parts.len(), 2, "got: {body}");
     assert_eq!(parts[0]["type"], "text");
     assert_eq!(parts[0]["text"], "describe");
     assert_eq!(parts[1]["type"], "image_url");
-    assert_eq!(
-        parts[1]["image_url"]["url"],
-        "data:image/png;base64,AQID"
-    );
+    assert_eq!(parts[1]["image_url"]["url"], "data:image/png;base64,AQID");
 }
 
 #[test]
@@ -402,8 +439,7 @@ fn fireworks_vision_uses_image_url_content() {
     // OpenAI-compatible Chat Completions surface.
     let dsl = "scene { box \"b\" (size=[1,1,1]) }";
     let server = MockServer::start(vec![&zai_chat_body(dsl)]);
-    let client =
-        LlmClient::with_base_url(Provider::Fireworks, "test-key", server.base_url());
+    let client = LlmClient::with_base_url(Provider::Fireworks, "test-key", server.base_url());
 
     let mut cfg = GenerateConfig::new("describe");
     cfg.model = "accounts/fireworks/routers/kimi-k2p6".to_string();
@@ -412,8 +448,16 @@ fn fireworks_vision_uses_image_url_content() {
         // Three bytes that base64-encode to "AQID".
         data: vec![0x01, 0x02, 0x03],
     });
-    let _ = generate_with_repair(&client, cfg, &RepairConfig { max_iters: 0, on_iteration: None, allow_edit_mode: false })
-        .expect("request ok");
+    let _ = generate_with_repair(
+        &client,
+        cfg,
+        &RepairConfig {
+            max_iters: 0,
+            on_iteration: None,
+            allow_edit_mode: false,
+        },
+    )
+    .expect("request ok");
 
     let reqs = server.requests.lock().unwrap();
     assert_eq!(reqs.len(), 1);
@@ -422,12 +466,63 @@ fn fireworks_vision_uses_image_url_content() {
     let messages = body["messages"].as_array().expect("messages array");
     let user = messages.last().expect("user turn");
     assert_eq!(user["role"], "user");
-    let parts = user["content"].as_array().expect("content array on vision turn");
+    let parts = user["content"]
+        .as_array()
+        .expect("content array on vision turn");
     assert_eq!(parts.len(), 2, "got: {body}");
     assert_eq!(parts[0]["type"], "text");
     assert_eq!(parts[0]["text"], "describe");
     assert_eq!(parts[1]["type"], "image_url");
     assert_eq!(parts[1]["image_url"]["url"], "data:image/png;base64,AQID");
+}
+
+#[test]
+fn xiaomi_vision_uses_image_url_content() {
+    // Xiaomi MiMo's OpenAI-compatible vision docs use
+    // `content: [{type:"image_url"}, {type:"text"}]` against `mimo-v2.5`.
+    // Pin the provider-specific ordering and model routing shape without
+    // hitting the real API.
+    let dsl = "scene { box \"b\" (size=[1,1,1]) }";
+    let server = MockServer::start(vec![&zai_chat_body(dsl)]);
+    let client = LlmClient::with_base_url(Provider::Xiaomi, "test-key", server.base_url());
+
+    let mut cfg = GenerateConfig::new("describe");
+    cfg.model = mogen_llm::XIAOMI_DEFAULT_VISION_MODEL.to_string();
+    cfg.user_images.push(ImageInput {
+        mime_type: "image/png".into(),
+        // Three bytes that base64-encode to "AQID".
+        data: vec![0x01, 0x02, 0x03],
+    });
+    let _ = generate_with_repair(
+        &client,
+        cfg,
+        &RepairConfig {
+            max_iters: 0,
+            on_iteration: None,
+            allow_edit_mode: false,
+        },
+    )
+    .expect("request ok");
+
+    let reqs = server.requests.lock().unwrap();
+    assert_eq!(reqs.len(), 1);
+    let body: serde_json::Value = serde_json::from_str(&reqs[0]).expect("valid JSON");
+    assert_eq!(body["model"], mogen_llm::XIAOMI_DEFAULT_VISION_MODEL);
+    let messages = body["messages"].as_array().expect("messages array");
+    let user = messages.last().expect("user turn");
+    assert_eq!(user["role"], "user");
+    let parts = user["content"]
+        .as_array()
+        .expect("content array on vision turn");
+    assert_eq!(parts.len(), 2, "got: {body}");
+    assert_eq!(parts[0]["type"], "image_url");
+    assert_eq!(parts[0]["image_url"]["url"], "data:image/png;base64,AQID");
+    assert_eq!(parts[1]["type"], "text");
+    assert_eq!(parts[1]["text"], "describe");
+    assert!(
+        body.get("seed").is_none(),
+        "Xiaomi payload must not include undocumented seed field: {body}"
+    );
 }
 
 #[test]
@@ -450,7 +545,10 @@ fn edit_mode_first_call_applies_search_replace_against_baseline() {
     .expect("request ok");
 
     assert!(outcome.is_ok(), "diagnostics: {:?}", outcome.diagnostics);
-    assert_eq!(outcome.call_count, 1, "edit mode should resolve in one call");
+    assert_eq!(
+        outcome.call_count, 1,
+        "edit mode should resolve in one call"
+    );
     assert!(
         outcome.dsl.contains("size=[2,2,2]"),
         "edit block should mutate the baseline: {}",

--- a/crates/mogen-studio/src/app/error_class.rs
+++ b/crates/mogen-studio/src/app/error_class.rs
@@ -2,7 +2,7 @@
 //! UI can swap in a class-specific affordance ("Open Settings", "Retry")
 //! instead of dumping the error's `Display` output verbatim.
 //!
-//! The mapping is provider-agnostic — all four backends funnel into the same
+//! The mapping is provider-agnostic — every backend funnels into the same
 //! [`ProviderError`] variants in `mogen-llm`, so the studio doesn't need to
 //! match on per-provider error enums.
 
@@ -35,7 +35,8 @@ pub(super) fn classify(err: &ProviderError) -> LlmErrorInfo {
             headline: "The connection timed out".into(),
             detail: format!(
                 "The provider did not respond in time. This usually means a slow or flaky \
-                 link, a captive portal, or a stalled server. Try again. ({s})"
+                 link, a captive portal, or a stalled server. Try again; if it keeps \
+                 happening, lower the Thinking setting or switch to a faster model. ({s})"
             ),
             class: LlmErrorClass::Network,
             retryable: true,
@@ -89,11 +90,10 @@ pub(super) fn classify(err: &ProviderError) -> LlmErrorInfo {
             if is_recitation {
                 LlmErrorInfo {
                     headline: "Model declined to produce content".into(),
-                    detail:
-                        "The provider's recitation filter rejected every attempt. Try a \
+                    detail: "The provider's recitation filter rejected every attempt. Try a \
                          different style description or rename/reword the material so the \
                          prompt does not resemble training data."
-                            .into(),
+                        .into(),
                     class: LlmErrorClass::ContentBlocked,
                     retryable: true,
                     action: None,
@@ -149,10 +149,9 @@ fn classify_api(status: u16, message: &str) -> LlmErrorInfo {
         401 | 403 if msg_lower.contains("api key") || msg_lower.contains("authentication") => {
             LlmErrorInfo {
                 headline: "API key rejected".into(),
-                detail:
-                    "The provider refused the request as unauthenticated. Open Preferences… \
+                detail: "The provider refused the request as unauthenticated. Open Preferences… \
                      and paste a valid key, or verify the matching environment variable is set."
-                        .into(),
+                    .into(),
                 class: LlmErrorClass::InvalidKey,
                 retryable: false,
                 action: None,
@@ -229,7 +228,10 @@ mod tests {
 
     #[test]
     fn classify_429_is_retryable() {
-        let err = ProviderError::Api { status: 429, message: "rate".into() };
+        let err = ProviderError::Api {
+            status: 429,
+            message: "rate".into(),
+        };
         let info = classify(&err);
         assert!(matches!(info.class, LlmErrorClass::RateLimited));
         assert!(info.retryable);
@@ -237,7 +239,10 @@ mod tests {
 
     #[test]
     fn classify_500_is_retryable() {
-        let err = ProviderError::Api { status: 503, message: "down".into() };
+        let err = ProviderError::Api {
+            status: 503,
+            message: "down".into(),
+        };
         let info = classify(&err);
         assert!(matches!(info.class, LlmErrorClass::ServerError));
         assert!(info.retryable);
@@ -245,7 +250,9 @@ mod tests {
 
     #[test]
     fn classify_missing_key_not_retryable() {
-        let info = classify(&ProviderError::MissingApiKey { var: "GEMINI_API_KEY" });
+        let info = classify(&ProviderError::MissingApiKey {
+            var: "GEMINI_API_KEY",
+        });
         assert!(!info.retryable);
         assert_eq!(info.class, LlmErrorClass::MissingKey);
         assert!(info.headline.contains("GEMINI_API_KEY"));
@@ -271,11 +278,12 @@ mod tests {
     }
 
     #[test]
-    fn classify_timeout_uses_specific_headline() {
+    fn classify_timeout_uses_specific_headline_and_hint() {
         let info = classify(&ProviderError::Timeout("operation timed out".into()));
         assert_eq!(info.class, LlmErrorClass::Network);
         assert!(info.retryable);
         assert!(info.headline.to_ascii_lowercase().contains("timed out"));
+        assert!(info.detail.contains("lower the Thinking setting"));
     }
 
     #[test]

--- a/crates/mogen-studio/src/app/pricing.rs
+++ b/crates/mogen-studio/src/app/pricing.rs
@@ -1,13 +1,11 @@
-//! Public Gemini pricing applied client-side so the studio can show a
-//! running cost estimate. Rates are the published US list prices for the
-//! model family and are approximate — the authoritative source is the
-//! user's Google Cloud invoice.
+//! Client-side pricing estimates for the Studio session footer and pricing
+//! editor. Rates are per million tokens and intentionally approximate — the
+//! authoritative source is the provider invoice.
 //!
-//! Rates are per million tokens. Input/output counts come from the API's
-//! `usageMetadata`; `cached` is billed at a reduced rate when a
-//! `cachedContents` resource is attached. The 2.5 Pro and 3.x Pro tiers
-//! switch to a higher "long context" rate once the prompt crosses 200k
-//! tokens — see [`LONG_CONTEXT_THRESHOLD`].
+//! Input/output counts come from provider usage metadata; `cached` is billed
+//! at a reduced rate when the provider reports cache hits. Gemini Pro tiers
+//! switch to a higher "long context" rate once the prompt crosses 200k tokens
+//! — see [`LONG_CONTEXT_THRESHOLD`].
 
 use mogen_llm::gemini::Usage;
 
@@ -64,8 +62,9 @@ pub(super) struct ImagePricing {
     pub per_image_usd: f64,
 }
 
-/// Match a model name against the price table. More-specific (Gemini 3.x)
-/// matchers run first so 2.5 prefix matches don't shadow them.
+/// Match a model name against the price table. More-specific matchers run
+/// first so provider model ids with overlapping substrings don't shadow each
+/// other (e.g. `mimo-v2.5-pro` is Xiaomi, not Gemini).
 pub(super) fn text_pricing(model: &str) -> TextPricing {
     let m = model.to_ascii_lowercase();
 
@@ -75,10 +74,7 @@ pub(super) fn text_pricing(model: &str) -> TextPricing {
     // landing on the right row.
     if m.contains("3.1-pro") || m.contains("3-pro") {
         // Gemini 3.1 Pro Preview, tiered at 200k.
-        return TextPricing::tiered(
-            (2.00, 12.00, 0.50),
-            (4.00, 18.00, 1.00),
-        );
+        return TextPricing::tiered((2.00, 12.00, 0.50), (4.00, 18.00, 1.00));
     }
     if m.contains("3.5-flash") {
         // Gemini 3.5 Flash (GA May 2026): $1.50 in / $9 out per million.
@@ -93,19 +89,31 @@ pub(super) fn text_pricing(model: &str) -> TextPricing {
     }
 
     // --- Gemini 2.5 Pro (tiered at 200k).
-    if m.starts_with("gemini-pro") || m.contains("2.5-pro") || m.contains("2-5-pro") {
-        return TextPricing::tiered(
-            (1.25, 10.00, 0.125),
-            (2.50, 15.00, 0.25),
-        );
+    if m.starts_with("gemini-pro")
+        || (m.starts_with("gemini") && (m.contains("2.5-pro") || m.contains("2-5-pro")))
+    {
+        return TextPricing::tiered((1.25, 10.00, 0.125), (2.50, 15.00, 0.25));
     }
     // --- Gemini 2.5 Flash-Lite (cheapest text tier).
-    if m.contains("flash-lite") {
+    if m.starts_with("gemini") && m.contains("flash-lite") {
         return TextPricing::flat(0.10, 0.40, 0.01);
     }
     // --- Gemini 2.5 Flash / flash-latest.
-    if m.starts_with("gemini-flash") || m.contains("2.5-flash") || m.contains("2-5-flash") {
+    if m.starts_with("gemini-flash")
+        || (m.starts_with("gemini") && (m.contains("2.5-flash") || m.contains("2-5-flash")))
+    {
         return TextPricing::flat(0.30, 2.50, 0.03);
+    }
+
+    // --- Xiaomi MiMo. Overseas pay-as-you-go rates.
+    if m.contains("mimo-v2.5-pro") || m.contains("mimo-v2-pro") {
+        return TextPricing::flat(0.435, 0.87, 0.0036);
+    }
+    if m.contains("mimo-v2.5") || m.contains("mimo-v2-omni") {
+        return TextPricing::flat(0.14, 0.28, 0.0028);
+    }
+    if m.contains("mimo-v2-flash") {
+        return TextPricing::flat(0.10, 0.30, 0.01);
     }
 
     // Unknown — zero-cost fallback keeps the meter honest instead of
@@ -118,11 +126,15 @@ pub(super) fn text_pricing(model: &str) -> TextPricing {
 pub(super) fn image_pricing(model: &str) -> ImagePricing {
     let m = model.to_ascii_lowercase();
     if m.contains("flash-image") || m.contains("nano-banana") {
-        return ImagePricing { per_image_usd: 0.039 };
+        return ImagePricing {
+            per_image_usd: 0.039,
+        };
     }
     // `imagen-4.0-generate-*`: $0.04 per image (1:1, standard quality).
     if m.contains("imagen") {
-        return ImagePricing { per_image_usd: 0.04 };
+        return ImagePricing {
+            per_image_usd: 0.04,
+        };
     }
     ImagePricing { per_image_usd: 0.0 }
 }
@@ -239,6 +251,19 @@ mod tests {
         assert!((p.output_per_million_usd - 9.00).abs() < 1e-9);
         assert!((p.cached_input_per_million_usd - 0.15).abs() < 1e-9);
         assert!(!p.is_tiered());
+    }
+
+    #[test]
+    fn xiaomi_pricing_matches_overseas_rates() {
+        let p = text_pricing("mimo-v2.5-pro");
+        assert!((p.input_per_million_usd - 0.435).abs() < 1e-9);
+        assert!((p.output_per_million_usd - 0.87).abs() < 1e-9);
+        assert!((p.cached_input_per_million_usd - 0.0036).abs() < 1e-9);
+        assert!(!p.is_tiered());
+
+        let flash = text_pricing("mimo-v2-flash");
+        assert!((flash.input_per_million_usd - 0.10).abs() < 1e-9);
+        assert!((flash.output_per_million_usd - 0.30).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/mogen-studio/src/app/ui_dialogs/prefs.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/prefs.rs
@@ -83,11 +83,7 @@ pub(super) fn model_presets(slot: ProviderSlot) -> &'static [&'static str] {
             "phi4",
             "gemma3",
         ],
-        ProviderSlot::ClaudeCode => &[
-            "sonnet",
-            "haiku",
-            "opus",
-        ],
+        ProviderSlot::ClaudeCode => &["sonnet", "haiku", "opus"],
         ProviderSlot::Fireworks => &[
             "accounts/fireworks/routers/kimi-k2p6",
             "accounts/fireworks/routers/kimi-k2p6-turbo",
@@ -100,6 +96,7 @@ pub(super) fn model_presets(slot: ProviderSlot) -> &'static [&'static str] {
             "glm-4.5-air",
             "glm-4.5-flash",
         ],
+        ProviderSlot::Xiaomi => &["mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-flash"],
         // Model ids are server-defined for a local OpenAI-compatible host —
         // there's no canonical preset list. `local-model` is the library
         // default that many single-model servers (llama.cpp, some LM Studio
@@ -124,11 +121,8 @@ impl MogenStudioApp {
             .order(egui::Order::Background)
             .fixed_pos(egui::pos2(0.0, 0.0))
             .show(ctx, |ui| {
-                ui.painter().rect_filled(
-                    screen,
-                    0.0,
-                    egui::Color32::from_black_alpha(96),
-                );
+                ui.painter()
+                    .rect_filled(screen, 0.0, egui::Color32::from_black_alpha(96));
             });
 
         // Adapt the dialog footprint to the host window. On a small
@@ -141,8 +135,7 @@ impl MogenStudioApp {
         let max_h = (avail_h - 64.0).max(320.0);
         let default_w = max_w.min(560.0);
 
-        let active_tab_color =
-            crate::app::style::accent_primary(&ctx.style().visuals);
+        let active_tab_color = crate::app::style::accent_primary(&ctx.style().visuals);
 
         egui::Window::new("Options")
             .open(&mut open)
@@ -194,12 +187,10 @@ impl MogenStudioApp {
                     .id_salt(("prefs_body", self.prefs_active_tab))
                     .auto_shrink([false, false])
                     .max_height(body_height)
-                    .show(ui, |ui| {
-                        match self.prefs_active_tab {
-                            PrefsTab::Llm => self.prefs_tab_llm(ui),
-                            PrefsTab::Appearance => self.prefs_tab_appearance(ui, ctx),
-                            PrefsTab::Privacy => self.prefs_tab_privacy(ui),
-                        }
+                    .show(ui, |ui| match self.prefs_active_tab {
+                        PrefsTab::Llm => self.prefs_tab_llm(ui),
+                        PrefsTab::Appearance => self.prefs_tab_appearance(ui, ctx),
+                        PrefsTab::Privacy => self.prefs_tab_privacy(ui),
                     });
 
                 ui.add_space(8.0);
@@ -207,62 +198,61 @@ impl MogenStudioApp {
                 ui.add_space(4.0);
                 // Right-aligned cluster, primary Save on the right.
                 ui.horizontal(|ui| {
-                    ui.with_layout(
-                        egui::Layout::right_to_left(egui::Align::Center),
-                        |ui| {
-                            let save = ui.add(
-                                crate::app::style::primary_button(ui, "Save"),
-                            );
-                            if save.clicked() {
-                        // The Gemini key uses an editor-buffered draft so the
-                        // user can clear/re-paste without instantly mutating
-                        // settings; commit it on Save. Other providers' keys
-                        // are written directly into settings as the user
-                        // types because they don't share that legacy draft.
-                        self.settings.gemini_api_key =
-                            self.options_api_key_draft.trim().to_string();
-                        // Trim whitespace from per-provider keys / URL on
-                        // save so users can paste with surrounding spaces.
-                        self.settings.openai_api_key =
-                            self.settings.openai_api_key.trim().to_string();
-                        self.settings.anthropic_api_key =
-                            self.settings.anthropic_api_key.trim().to_string();
-                        self.settings.ollama_api_key =
-                            self.settings.ollama_api_key.trim().to_string();
-                        self.settings.ollama_base_url =
-                            self.settings.ollama_base_url.trim().to_string();
-                        self.settings.claude_code_path =
-                            self.settings.claude_code_path.trim().to_string();
-                        self.settings.zai_api_key =
-                            self.settings.zai_api_key.trim().to_string();
-                        self.settings.fireworks_api_key =
-                            self.settings.fireworks_api_key.trim().to_string();
-                        self.settings.openai_compat_api_key =
-                            self.settings.openai_compat_api_key.trim().to_string();
-                        self.settings.openai_compat_base_url =
-                            self.settings.openai_compat_base_url.trim().to_string();
-                        match self.settings.save() {
-                            Ok(()) => {
-                                let active = self.settings.provider();
-                                let msg = match active {
-                                    Provider::Gemini if self.settings.gemini_api_key.is_empty() => {
-                                        "options: cleared saved Gemini API key".to_string()
-                                    }
-                                    _ => "options: settings saved".to_string(),
-                                };
-                                self.active_mut().status = msg;
-                                close_after = true;
-                            }
-                            Err(e) => {
-                                self.active_mut().status = format!("options: save failed: {e}");
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        let save = ui.add(crate::app::style::primary_button(ui, "Save"));
+                        if save.clicked() {
+                            // The Gemini key uses an editor-buffered draft so the
+                            // user can clear/re-paste without instantly mutating
+                            // settings; commit it on Save. Other providers' keys
+                            // are written directly into settings as the user
+                            // types because they don't share that legacy draft.
+                            self.settings.gemini_api_key =
+                                self.options_api_key_draft.trim().to_string();
+                            // Trim whitespace from per-provider keys / URL on
+                            // save so users can paste with surrounding spaces.
+                            self.settings.openai_api_key =
+                                self.settings.openai_api_key.trim().to_string();
+                            self.settings.anthropic_api_key =
+                                self.settings.anthropic_api_key.trim().to_string();
+                            self.settings.ollama_api_key =
+                                self.settings.ollama_api_key.trim().to_string();
+                            self.settings.ollama_base_url =
+                                self.settings.ollama_base_url.trim().to_string();
+                            self.settings.claude_code_path =
+                                self.settings.claude_code_path.trim().to_string();
+                            self.settings.zai_api_key =
+                                self.settings.zai_api_key.trim().to_string();
+                            self.settings.fireworks_api_key =
+                                self.settings.fireworks_api_key.trim().to_string();
+                            self.settings.xiaomi_api_key =
+                                self.settings.xiaomi_api_key.trim().to_string();
+                            self.settings.openai_compat_api_key =
+                                self.settings.openai_compat_api_key.trim().to_string();
+                            self.settings.openai_compat_base_url =
+                                self.settings.openai_compat_base_url.trim().to_string();
+                            match self.settings.save() {
+                                Ok(()) => {
+                                    let active = self.settings.provider();
+                                    let msg = match active {
+                                        Provider::Gemini
+                                            if self.settings.gemini_api_key.is_empty() =>
+                                        {
+                                            "options: cleared saved Gemini API key".to_string()
+                                        }
+                                        _ => "options: settings saved".to_string(),
+                                    };
+                                    self.active_mut().status = msg;
+                                    close_after = true;
+                                }
+                                Err(e) => {
+                                    self.active_mut().status = format!("options: save failed: {e}");
+                                }
                             }
                         }
-                            }
-                            if ui.button("Cancel").clicked() {
-                                close_after = true;
-                            }
-                        },
-                    );
+                        if ui.button("Cancel").clicked() {
+                            close_after = true;
+                        }
+                    });
                 });
             });
         if !open || close_after {
@@ -347,8 +337,7 @@ impl MogenStudioApp {
             } else {
                 login_button_label.to_string()
             };
-            let login_btn =
-                ui.add_enabled(!any_in_flight, egui::Button::new(login_label));
+            let login_btn = ui.add_enabled(!any_in_flight, egui::Button::new(login_label));
             if login_btn.clicked() {
                 let ctx = ui.ctx().clone();
                 self.start_oauth_login_for(ctx, config);
@@ -356,9 +345,7 @@ impl MogenStudioApp {
             if stored.is_some() {
                 if ui
                     .add_enabled(!any_in_flight, egui::Button::new("Sign out"))
-                    .on_hover_text(
-                        "Delete the local OAuth token for this provider.",
-                    )
+                    .on_hover_text("Delete the local OAuth token for this provider.")
                     .clicked()
                 {
                     self.start_oauth_logout_for(config);
@@ -378,11 +365,7 @@ impl MogenStudioApp {
             .show_ui(ui, |ui| {
                 for t in THEMES {
                     let selected = t == current_theme;
-                    if ui
-                        .selectable_label(selected, theme_label(t))
-                        .clicked()
-                        && !selected
-                    {
+                    if ui.selectable_label(selected, theme_label(t)).clicked() && !selected {
                         new_theme = Some(t);
                     }
                 }
@@ -419,11 +402,7 @@ impl MogenStudioApp {
             .show_ui(ui, |ui| {
                 for (val, label) in presets {
                     let selected = val == current_fps;
-                    if ui
-                        .selectable_label(selected, label)
-                        .clicked()
-                        && !selected
-                    {
+                    if ui.selectable_label(selected, label).clicked() && !selected {
                         new_fps = Some(val);
                     }
                 }

--- a/crates/mogen-studio/src/app/ui_dialogs/prefs/llm.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/prefs/llm.rs
@@ -73,11 +73,7 @@ impl MogenStudioApp {
                     .show_ui(ui, |ui| {
                         for slot in PROVIDER_SLOTS {
                             let selected = slot == current_slot;
-                            if ui
-                                .selectable_label(selected, slot.label())
-                                .clicked()
-                                && !selected
-                            {
+                            if ui.selectable_label(selected, slot.label()).clicked() && !selected {
                                 self.settings.set_provider_slot(slot);
                             }
                         }
@@ -104,11 +100,7 @@ impl MogenStudioApp {
                     .show_ui(ui, |ui| {
                         for p in IMAGE_PROVIDERS {
                             let selected = p == current_image;
-                            if ui
-                                .selectable_label(selected, p.label())
-                                .clicked()
-                                && !selected
-                            {
+                            if ui.selectable_label(selected, p.label()).clicked() && !selected {
                                 self.settings.set_image_provider(p);
                             }
                         }
@@ -131,9 +123,7 @@ impl MogenStudioApp {
                              will surface a 'wrong client' error if used for \
                              textures)"
                         }
-                        Some(Credential::Zai(_)) => {
-                            "Auto → Z.ai (unusual settings combination)"
-                        }
+                        Some(Credential::Zai(_)) => "Auto → Z.ai (unusual settings combination)",
                         None => {
                             "Auto → no credential resolved — texture \
                              generation will fail. Sign in to Antigravity or \
@@ -255,6 +245,13 @@ impl MogenStudioApp {
                      the `glm-image` texture path when you set Image \
                      provider → Z.ai.",
                 ),
+                Provider::Xiaomi => (
+                    "Xiaomi MiMo API key",
+                    "Used by Generate / Modify / Animate / Ask. Default \
+                     model is `mimo-v2.5-pro` via Xiaomi's OpenAI-compatible \
+                     chat API. `mimo-v2.5` is used automatically for image \
+                     inputs.",
+                ),
                 Provider::OpenAiCompat => (
                     "OpenAI-compatible API key (optional)",
                     "Optional bearer token for a local OpenAI-compatible \
@@ -273,25 +270,19 @@ impl MogenStudioApp {
                     Provider::Ollama => &mut self.settings.ollama_api_key,
                     Provider::Fireworks => &mut self.settings.fireworks_api_key,
                     Provider::Zai => &mut self.settings.zai_api_key,
+                    Provider::Xiaomi => &mut self.settings.xiaomi_api_key,
                     Provider::OpenAiCompat => &mut self.settings.openai_compat_api_key,
                     Provider::ClaudeCode => unreachable!(),
                 };
-                crate::app::text_menu::text_edit_with_menu(
-                    ui,
-                    key_id,
-                    key_buf,
-                    |ui, text| {
-                        ui.add(
-                            egui::TextEdit::singleline(text)
-                                .password(true)
-                                .hint_text(style::placeholder(
-                                    "paste key (leave blank to clear)",
-                                ))
-                                .desired_width(f32::INFINITY)
-                                .id(key_id),
-                        )
-                    },
-                );
+                crate::app::text_menu::text_edit_with_menu(ui, key_id, key_buf, |ui, text| {
+                    ui.add(
+                        egui::TextEdit::singleline(text)
+                            .password(true)
+                            .hint_text(style::placeholder("paste key (leave blank to clear)"))
+                            .desired_width(f32::INFINITY)
+                            .id(key_id),
+                    )
+                });
 
                 if matches!(active_provider, Provider::Ollama) {
                     ui.add_space(6.0);
@@ -408,7 +399,10 @@ impl MogenStudioApp {
                             .unwrap_or_else(|| active_provider.default_fast_model()),
                     )
                 } else {
-                    (active_provider.default_model(), active_provider.default_fast_model())
+                    (
+                        active_provider.default_model(),
+                        active_provider.default_fast_model(),
+                    )
                 };
                 let presets = model_presets(active_slot);
 
@@ -437,10 +431,7 @@ impl MogenStudioApp {
                     .width(preset_w)
                     .show_ui(ui, |ui| {
                         for m in presets {
-                            if ui
-                                .selectable_label(thinking_draft == *m, *m)
-                                .clicked()
-                            {
+                            if ui.selectable_label(thinking_draft == *m, *m).clicked() {
                                 thinking_draft = (*m).to_string();
                             }
                         }
@@ -453,13 +444,9 @@ impl MogenStudioApp {
                 ui.add_space(6.0);
 
                 // --- fast model: same row pattern ---
-                ui.label("Fast model").on_hover_text(
-                    "Used for low-stakes text rewrites like the Prompt Enhancer.",
-                );
-                let mut fast_draft = self
-                    .settings
-                    .fast_model_field(active_provider)
-                    .to_string();
+                ui.label("Fast model")
+                    .on_hover_text("Used for low-stakes text rewrites like the Prompt Enhancer.");
+                let mut fast_draft = self.settings.fast_model_field(active_provider).to_string();
                 ui.horizontal(|ui| {
                     let preset_w = 96.0;
                     let avail = ui.available_width().max(preset_w + 60.0);
@@ -502,12 +489,9 @@ impl MogenStudioApp {
                     // figure without expanding the breakdown.
                     let typical_in = 5_000.0_f64;
                     let typical_out = 3_000.0_f64;
-                    let typical_cost = typical_in
-                        * thinking_price.input_per_million_usd
+                    let typical_cost = typical_in * thinking_price.input_per_million_usd
                         / 1_000_000.0
-                        + typical_out
-                            * thinking_price.output_per_million_usd
-                            / 1_000_000.0;
+                        + typical_out * thinking_price.output_per_million_usd / 1_000_000.0;
                     ui.add_space(8.0);
                     ui.label(
                         egui::RichText::new(format!(
@@ -566,13 +550,7 @@ impl MogenStudioApp {
                                         );
                                     }
                                     if fast_price.input_per_million_usd > 0.0 {
-                                        price_grid_row(
-                                            ui,
-                                            "Fast",
-                                            &fast_model,
-                                            fast_price,
-                                            false,
-                                        );
+                                        price_grid_row(ui, "Fast", &fast_model, fast_price, false);
                                         if fast_price.is_tiered() {
                                             price_grid_row(
                                                 ui,
@@ -586,10 +564,7 @@ impl MogenStudioApp {
                                     if img_price.per_image_usd > 0.0 {
                                         ui.label("Image");
                                         ui.label(img_model);
-                                        ui.label(format!(
-                                            "${:.3}/image",
-                                            img_price.per_image_usd,
-                                        ));
+                                        ui.label(format!("${:.3}/image", img_price.per_image_usd,));
                                         ui.label("");
                                         ui.label("");
                                         ui.end_row();
@@ -649,14 +624,13 @@ impl MogenStudioApp {
                 .gemini_temperature
                 .unwrap_or(mogen_llm::gemini::DEFAULT_TEMPERATURE);
             ui.horizontal(|ui| {
-                let resp = ui.add(
-                    egui::Slider::new(&mut temp, 0.0..=2.0)
-                        .max_decimals(2)
-                        .text("°"),
-                )
-                .on_hover_text(
-                    "0 = deterministic, 2 = chaotic. Default 0.3.",
-                );
+                let resp = ui
+                    .add(
+                        egui::Slider::new(&mut temp, 0.0..=2.0)
+                            .max_decimals(2)
+                            .text("°"),
+                    )
+                    .on_hover_text("0 = deterministic, 2 = chaotic. Default 0.3.");
                 if resp.changed() {
                     self.settings.gemini_temperature = Some(temp);
                 }
@@ -682,11 +656,7 @@ impl MogenStudioApp {
                 .max_repair_iters
                 .unwrap_or(DEFAULT_MAX_REPAIR_ITERS);
             if ui
-                .add(
-                    egui::DragValue::new(&mut iters)
-                        .range(0..=5)
-                        .speed(0.1),
-                )
+                .add(egui::DragValue::new(&mut iters).range(0..=5).speed(0.1))
                 .on_hover_text("Range 0–5.")
                 .changed()
             {
@@ -713,10 +683,11 @@ impl MogenStudioApp {
                         .desired_width(160.0),
                 );
                 let trimmed = seed_str.trim().to_string();
-                let parse_result =
-                    if trimmed.is_empty() { Ok(None) } else {
-                        trimmed.parse::<u64>().map(Some)
-                    };
+                let parse_result = if trimmed.is_empty() {
+                    Ok(None)
+                } else {
+                    trimmed.parse::<u64>().map(Some)
+                };
                 if resp.changed() {
                     self.settings.seed_override = match &parse_result {
                         Ok(v) => *v,
@@ -728,8 +699,7 @@ impl MogenStudioApp {
                     .on_hover_text("Pick a random seed now")
                     .clicked()
                 {
-                    self.settings.seed_override =
-                        Some(crate::app::util::pick_default_seed());
+                    self.settings.seed_override = Some(crate::app::util::pick_default_seed());
                 }
                 if ui
                     .small_button("Clear")
@@ -742,8 +712,7 @@ impl MogenStudioApp {
                 // didn't take effect — matches the new_prompt dialog.
                 if !trimmed.is_empty() && parse_result.is_err() {
                     ui.label(
-                        egui::RichText::new("not a valid u64")
-                            .color(ui.visuals().warn_fg_color),
+                        egui::RichText::new("not a valid u64").color(ui.visuals().warn_fg_color),
                     );
                 }
             });

--- a/crates/mogen-studio/src/app/ui_wizard/session.rs
+++ b/crates/mogen-studio/src/app/ui_wizard/session.rs
@@ -51,7 +51,9 @@ impl MogenStudioApp {
         };
         let (tx, rx) = std::sync::mpsc::channel();
         let prompt_draft = state.prompt.clone();
-        let status = "Choose where wizard artefacts (objects, references, state.json) will be saved.".to_string();
+        let status =
+            "Choose where wizard artefacts (objects, references, state.json) will be saved."
+                .to_string();
         self.wizard = Some(WizardSession {
             state,
             rx,
@@ -548,6 +550,7 @@ impl MogenStudioApp {
     pub(in crate::app) fn build_wizard_run_config(&self) -> WizardRunConfig {
         WizardRunConfig {
             model: self.settings.provider_model(),
+            provider: self.settings.provider(),
             thinking: self.settings.thinking_level(),
             temperature: self.settings.temperature(),
             max_repair_iters: self.settings.max_repair_iters(),
@@ -561,7 +564,9 @@ impl MogenStudioApp {
         }
     }
 
-    pub(in crate::app) fn resolve_wizard_text_client(&mut self) -> Option<(mogen_llm::LlmClient, Arc<String>)> {
+    pub(in crate::app) fn resolve_wizard_text_client(
+        &mut self,
+    ) -> Option<(mogen_llm::LlmClient, Arc<String>)> {
         let slot = self.settings.provider_slot();
         let provider = slot.to_provider();
         let cred = self.resolve_credential()?;
@@ -581,9 +586,7 @@ impl MogenStudioApp {
             Credential::GeminiOAuth(bundle) => Some(ImageClient::Gemini(
                 mogen_llm::GeminiClient::from_oauth(bundle),
             )),
-            Credential::ApiKey(key) => Some(ImageClient::Gemini(
-                mogen_llm::GeminiClient::new(key),
-            )),
+            Credential::ApiKey(key) => Some(ImageClient::Gemini(mogen_llm::GeminiClient::new(key))),
         }
     }
 

--- a/crates/mogen-studio/src/app/ui_wizard/workers.rs
+++ b/crates/mogen-studio/src/app/ui_wizard/workers.rs
@@ -23,7 +23,9 @@ use super::{claim_pending_batch, object_missing, reference_missing, WizardBusy, 
 impl MogenStudioApp {
     pub(in crate::app) fn start_wizard_brief(&mut self, ctx: &egui::Context) {
         let Some((client, sys)) = self.resolve_wizard_text_client() else {
-            self.wizard_set_error("Provider credentials missing — open Preferences and sign in.".into());
+            self.wizard_set_error(
+                "Provider credentials missing — open Preferences and sign in.".into(),
+            );
             return;
         };
         let provider = self.settings.provider_slot().to_provider();
@@ -52,7 +54,7 @@ impl MogenStudioApp {
         if has_image && !provider.supports_images() {
             session.error = Some(format!(
                 "{} can't read images — switch to a vision provider (Gemini, OpenAI, \
-                 Anthropic…) in Preferences, or clear the source image.",
+                 Xiaomi MiMo, Z.ai, Fireworks, or Claude Code) in Preferences, or clear the source image.",
                 provider.label()
             ));
             return;
@@ -81,7 +83,9 @@ impl MogenStudioApp {
 
     pub(in crate::app) fn start_wizard_manifest(&mut self, ctx: &egui::Context) {
         let Some((client, sys)) = self.resolve_wizard_text_client() else {
-            self.wizard_set_error("Provider credentials missing — open Preferences and sign in.".into());
+            self.wizard_set_error(
+                "Provider credentials missing — open Preferences and sign in.".into(),
+            );
             return;
         };
         let cfg = self.build_wizard_run_config();
@@ -122,7 +126,8 @@ impl MogenStudioApp {
                 s.auto_continue_refs = false;
             }
             self.wizard_set_error(
-                "Image generation needs a Gemini or Z.ai credential — check Preferences › Image.".into(),
+                "Image generation needs a Gemini or Z.ai credential — check Preferences › Image."
+                    .into(),
             );
             return;
         };
@@ -194,7 +199,10 @@ impl MogenStudioApp {
         let Some(session) = self.wizard.as_mut() else {
             return;
         };
-        let out = session.state.references_dir().join(format!("{}.png", obj.id));
+        let out = session
+            .state
+            .references_dir()
+            .join(format!("{}.png", obj.id));
         let tx = session.tx.clone();
         let ctx_clone = ctx.clone();
         let id = obj.id.clone();
@@ -211,7 +219,8 @@ impl MogenStudioApp {
     pub(in crate::app) fn start_wizard_one_reference(&mut self, ctx: &egui::Context, id: String) {
         let Some(client) = self.resolve_wizard_image_client() else {
             self.wizard_set_error(
-                "Image generation needs a Gemini or Z.ai credential — check Preferences › Image.".into(),
+                "Image generation needs a Gemini or Z.ai credential — check Preferences › Image."
+                    .into(),
             );
             return;
         };
@@ -262,7 +271,9 @@ impl MogenStudioApp {
             if let Some(s) = self.wizard.as_mut() {
                 s.auto_continue_objects = false;
             }
-            self.wizard_set_error("Provider credentials missing — open Preferences and sign in.".into());
+            self.wizard_set_error(
+                "Provider credentials missing — open Preferences and sign in.".into(),
+            );
             return;
         }
         let cfg = self.build_wizard_run_config();
@@ -343,7 +354,11 @@ impl MogenStudioApp {
         });
     }
 
-    pub(in crate::app) fn start_wizard_regenerate_object(&mut self, ctx: &egui::Context, id: String) {
+    pub(in crate::app) fn start_wizard_regenerate_object(
+        &mut self,
+        ctx: &egui::Context,
+        id: String,
+    ) {
         let cfg = self.build_wizard_run_config();
         // Drop the existing .mog and reserve the worker slot up-front so the
         // regenerated object can't collide with an auto-continue tick that
@@ -399,7 +414,9 @@ impl MogenStudioApp {
 
     pub(in crate::app) fn start_wizard_object_review(&mut self, ctx: &egui::Context, id: String) {
         let Some((client, sys)) = self.resolve_wizard_text_client() else {
-            self.wizard_set_error("Provider credentials missing — open Preferences and sign in.".into());
+            self.wizard_set_error(
+                "Provider credentials missing — open Preferences and sign in.".into(),
+            );
             return;
         };
         let provider = self.settings.provider_slot().to_provider();
@@ -423,9 +440,14 @@ impl MogenStudioApp {
         // reference image as a stand-in so the review stage works even
         // before the user has rebuilt thumbnails. (A rendered thumbnail
         // can replace this once thumb_path is wired up.)
-        let img_path = obj.thumb_path.clone().or_else(|| obj.reference_image.clone());
+        let img_path = obj
+            .thumb_path
+            .clone()
+            .or_else(|| obj.reference_image.clone());
         let Some(img_path) = img_path else {
-            session.error = Some(format!("No image available for {id} — generate a reference first."));
+            session.error = Some(format!(
+                "No image available for {id} — generate a reference first."
+            ));
             return;
         };
         let Ok(image_bytes) = std::fs::read(&img_path) else {
@@ -447,7 +469,9 @@ impl MogenStudioApp {
 
     pub(in crate::app) fn start_wizard_scene_review(&mut self, ctx: &egui::Context) {
         let Some((client, sys)) = self.resolve_wizard_text_client() else {
-            self.wizard_set_error("Provider credentials missing — open Preferences and sign in.".into());
+            self.wizard_set_error(
+                "Provider credentials missing — open Preferences and sign in.".into(),
+            );
             return;
         };
         let provider = self.settings.provider_slot().to_provider();
@@ -463,13 +487,15 @@ impl MogenStudioApp {
             return;
         };
         let Some(thumb) = session.state.scene_thumb.clone() else {
-            session.error = Some(
-                "No scene screenshot yet — assemble + render the scene first.".into(),
-            );
+            session.error =
+                Some("No scene screenshot yet — assemble + render the scene first.".into());
             return;
         };
         let Ok(bytes) = std::fs::read(&thumb) else {
-            session.error = Some(format!("Couldn't read scene screenshot at {}", thumb.display()));
+            session.error = Some(format!(
+                "Couldn't read scene screenshot at {}",
+                thumb.display()
+            ));
             return;
         };
         let mime = guess_image_mime(&thumb);
@@ -499,8 +525,7 @@ impl MogenStudioApp {
                 return;
             };
             let Some(asm_path) = session.state.assembly_path.clone() else {
-                session.error =
-                    Some("No assembly file to edit — build the scene first.".into());
+                session.error = Some("No assembly file to edit — build the scene first.".into());
                 return;
             };
             let manifest = session.state.manifest.clone();

--- a/crates/mogen-studio/src/app/util/llm.rs
+++ b/crates/mogen-studio/src/app/util/llm.rs
@@ -6,9 +6,9 @@ use mogen_llm::{
     apply_style_to_prompt, cacheable_block, default_cache_path, embed_seed_header,
     format_imports_preserve_block, generate_edits_with_repair, generate_with_repair, inline_block,
     parse_prompt_header, parse_seed_header, parse_style_header, repair_message,
-    resolve_or_create_cache, stamp_style_header, summarize_imports, validate_text,
-    GenerateConfig, GoogleCredential, ImageInput, LlmClient, OAuthBundle, Provider, RepairConfig,
-    StdlibIndex, Style, ThinkingLevel, Usage, DEFAULT_TTL_SECONDS, EDIT_BLOCK_INSTRUCTIONS,
+    resolve_or_create_cache, stamp_style_header, summarize_imports, validate_text, GenerateConfig,
+    GoogleCredential, ImageInput, LlmClient, OAuthBundle, Provider, RepairConfig, StdlibIndex,
+    Style, ThinkingLevel, Usage, DEFAULT_TTL_SECONDS, EDIT_BLOCK_INSTRUCTIONS,
 };
 
 use crate::app::error_class::classify;
@@ -83,8 +83,7 @@ fn attach_system_instruction(
                 DEFAULT_TTL_SECONDS,
             ) {
                 Ok(name) => {
-                    let idx =
-                        StdlibIndex::from_registry(mogen_dsl::stdlib_registry());
+                    let idx = StdlibIndex::from_registry(mogen_dsl::stdlib_registry());
                     cfg.cached_content = Some(name);
                     cfg.system_instruction = Some(inline_block(&idx));
                     return;
@@ -98,6 +97,17 @@ fn attach_system_instruction(
         }
     }
     cfg.system_instruction = Some((**sys_instr).clone());
+}
+
+fn apply_provider_vision_model_override(cfg: &mut GenerateConfig, provider: Provider) {
+    if cfg.user_images.is_empty() {
+        return;
+    }
+    if provider == Provider::Zai {
+        cfg.model = mogen_llm::ZAI_DEFAULT_VISION_MODEL.to_string();
+    } else if provider == Provider::Xiaomi {
+        cfg.model = mogen_llm::XIAOMI_DEFAULT_VISION_MODEL.to_string();
+    }
 }
 
 /// Resolved credential for one LLM call. Carries either an API key (any
@@ -137,9 +147,9 @@ impl Credential {
     pub(in crate::app) fn api_key_or_empty(&self) -> String {
         match self {
             Credential::ApiKey(k) => k.clone(),
-            Credential::Zai(_)
-            | Credential::GeminiOAuth(_)
-            | Credential::AntigravityOAuth(_) => String::new(),
+            Credential::Zai(_) | Credential::GeminiOAuth(_) | Credential::AntigravityOAuth(_) => {
+                String::new()
+            }
         }
     }
 }
@@ -187,18 +197,22 @@ pub(in crate::app) fn build_provider_client(
         (Provider::Gemini, Credential::AntigravityOAuth(bundle)) => {
             LlmClient::gemini_from_credential(GoogleCredential::AntigravityOAuth(bundle))
         }
-        (Provider::ClaudeCode, cred) => {
-            LlmClient::with_base_url(provider, cred.api_key_or_empty(), &endpoints.claude_code_path)
-        }
+        (Provider::ClaudeCode, cred) => LlmClient::with_base_url(
+            provider,
+            cred.api_key_or_empty(),
+            &endpoints.claude_code_path,
+        ),
         (Provider::Zai, cred) => {
             LlmClient::with_base_url(provider, cred.api_key_or_empty(), &endpoints.zai_base_url)
         }
         (Provider::Ollama, cred) if !endpoints.ollama_base_url.trim().is_empty() => {
-            LlmClient::with_base_url(provider, cred.api_key_or_empty(), &endpoints.ollama_base_url)
+            LlmClient::with_base_url(
+                provider,
+                cred.api_key_or_empty(),
+                &endpoints.ollama_base_url,
+            )
         }
-        (Provider::OpenAiCompat, cred)
-            if !endpoints.openai_compat_base_url.trim().is_empty() =>
-        {
+        (Provider::OpenAiCompat, cred) if !endpoints.openai_compat_base_url.trim().is_empty() => {
             LlmClient::with_base_url(
                 provider,
                 cred.api_key_or_empty(),
@@ -479,6 +493,12 @@ pub(in crate::app) fn run_llm(
         // keeps the visual reference while it fixes validator errors.
         cfg.user_images.push(img);
     }
+    // Provider-specific vision auto-swaps. Some providers expose separate
+    // text and image-understanding model ids, while the Studio's dropdown
+    // stores the text default. When an image is attached, route every pass
+    // (planner and coder) through the documented vision model so the user
+    // doesn't have to remember a hidden model switch.
+    apply_provider_vision_model_override(&mut cfg, provider);
 
     // Architect (planner) pass. Only meaningful when (a) the user opted in,
     // (b) the call is Generate, and (c) there's a text prompt to plan
@@ -487,8 +507,7 @@ pub(in crate::app) fn run_llm(
     // Mirrors `crates/mogen/src/commands/generate.rs:109-130` (the CLI's
     // `--plan` two-phase shape).
     let plan_prompt_text = prompt.trim().to_string();
-    let want_plan =
-        kind == LlmKind::Generate && run_cfg.plan && !plan_prompt_text.is_empty();
+    let want_plan = kind == LlmKind::Generate && run_cfg.plan && !plan_prompt_text.is_empty();
     let mut prefix_usage = Usage::default();
     let mut prefix_calls: u32 = 0;
     if want_plan {
@@ -502,10 +521,7 @@ pub(in crate::app) fn run_llm(
             Ok(po) => {
                 prefix_usage = po.usage.clone();
                 prefix_calls = 1;
-                cfg.user_prompt = mogen_llm::compose_coder_prompt(
-                    &plan_prompt_text,
-                    &po.plan,
-                );
+                cfg.user_prompt = mogen_llm::compose_coder_prompt(&plan_prompt_text, &po.plan);
             }
             Err(e) => {
                 let info = classify(&e);
@@ -514,7 +530,7 @@ pub(in crate::app) fn run_llm(
                     diagnostics: Vec::new(),
                     usage: prefix_usage,
                     calls: prefix_calls,
-                    model: run_cfg.model,
+                    model: cfg.model.clone(),
                     image_calls: 0,
                     retry_prompt: Some(prompt),
                     error: Some(info),
@@ -524,16 +540,7 @@ pub(in crate::app) fn run_llm(
         }
     }
 
-    // Z.ai vision auto-swap. The Studio's per-provider model dropdown
-    // pins a *text* model id (`glm-5.1`); when the user attaches an
-    // image we have to route through `glm-5v-turbo` instead — the text
-    // models can't see the image and the call would 400 on a
-    // mismatched-input shape. The override is intentional and silent;
-    // a future user staring at "why isn't my custom model used?" should
-    // find this comment.
-    if provider == Provider::Zai && !cfg.user_images.is_empty() {
-        cfg.model = mogen_llm::ZAI_DEFAULT_VISION_MODEL.to_string();
-    }
+    let effective_model = cfg.model.clone();
 
     send_progress(LlmProgress::Status(format!(
         "calling {} ({}) — thinking={:?}",
@@ -587,21 +594,16 @@ pub(in crate::app) fn run_llm(
                 "done — {} call(s), {} tokens",
                 total_calls, total_usage.total_tokens
             )));
-            let wrapped = embed_seed_header(
-                &outcome.dsl,
-                seed,
-                &header_prompt,
-                Some(run_cfg.thinking),
-            );
             let wrapped =
-                mogen_dsl::stamp_mogen_version(&wrapped, env!("CARGO_PKG_VERSION"));
+                embed_seed_header(&outcome.dsl, seed, &header_prompt, Some(run_cfg.thinking));
+            let wrapped = mogen_dsl::stamp_mogen_version(&wrapped, env!("CARGO_PKG_VERSION"));
             let wrapped = stamp_style_header(&wrapped, effective_style);
             LlmOutcome {
                 dsl: wrapped,
                 diagnostics: outcome.diagnostics,
                 usage: total_usage,
                 calls: total_calls,
-                model: run_cfg.model,
+                model: effective_model,
                 image_calls: 0,
                 retry_prompt: Some(prompt),
                 error: None,
@@ -615,7 +617,7 @@ pub(in crate::app) fn run_llm(
                 diagnostics: Vec::new(),
                 usage: prefix_usage,
                 calls: prefix_calls,
-                model: run_cfg.model,
+                model: effective_model,
                 image_calls: 0,
                 retry_prompt: Some(prompt),
                 error: Some(info),
@@ -631,4 +633,33 @@ pub(in crate::app) fn pick_default_seed() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos() as u64)
         .unwrap_or(0x5EED)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xiaomi_image_calls_use_vision_model_before_planning() {
+        let mut cfg = GenerateConfig::new("describe");
+        cfg.model = "mimo-v2.5-pro".into();
+        cfg.user_images.push(ImageInput {
+            mime_type: "image/png".into(),
+            data: vec![1],
+        });
+
+        apply_provider_vision_model_override(&mut cfg, Provider::Xiaomi);
+
+        assert_eq!(cfg.model, mogen_llm::XIAOMI_DEFAULT_VISION_MODEL);
+    }
+
+    #[test]
+    fn text_only_calls_keep_configured_model() {
+        let mut cfg = GenerateConfig::new("describe");
+        cfg.model = "mimo-v2.5-pro".into();
+
+        apply_provider_vision_model_override(&mut cfg, Provider::Xiaomi);
+
+        assert_eq!(cfg.model, "mimo-v2.5-pro");
+    }
 }

--- a/crates/mogen-studio/src/app/wizard/pipeline.rs
+++ b/crates/mogen-studio/src/app/wizard/pipeline.rs
@@ -9,11 +9,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use mogen_core::subtree_local_aabb;
-use mogen_llm::{
-    apply_style_to_prompt, generate_with_repair, embed_seed_header, GenerateConfig, LlmClient,
-    RepairConfig, Style, ThinkingLevel,
-};
 use mogen_llm::image_client::{ImageClient, ImageError};
+use mogen_llm::{
+    apply_style_to_prompt, embed_seed_header, generate_with_repair, GenerateConfig, LlmClient,
+    Provider, RepairConfig, Style, ThinkingLevel,
+};
 
 use crate::app::util::{Credential, ProviderEndpoints};
 
@@ -26,12 +26,24 @@ use super::state::{
 #[derive(Clone)]
 pub struct WizardRunConfig {
     pub model: String,
+    pub provider: Provider,
     pub thinking: ThinkingLevel,
     pub temperature: f32,
     pub max_repair_iters: u32,
     pub seed: u64,
     pub style: Option<Style>,
     pub session_id: String,
+}
+
+fn apply_vision_model_if_needed(gc: &mut GenerateConfig, cfg: &WizardRunConfig) {
+    if gc.user_images.is_empty() {
+        return;
+    }
+    if cfg.provider == Provider::Zai {
+        gc.model = mogen_llm::ZAI_DEFAULT_VISION_MODEL.to_string();
+    } else if cfg.provider == Provider::Xiaomi {
+        gc.model = mogen_llm::XIAOMI_DEFAULT_VISION_MODEL.to_string();
+    }
 }
 
 /// Stage 1: produce a one-paragraph "scene brief" from the user's free-form
@@ -99,8 +111,12 @@ pub fn run_brief(
         },
     };
     if let (Some(data), Some(mime)) = (source_bytes, source_mime) {
-        gc.user_images.push(mogen_llm::ImageInput { mime_type: mime, data });
+        gc.user_images.push(mogen_llm::ImageInput {
+            mime_type: mime,
+            data,
+        });
     }
+    apply_vision_model_if_needed(&mut gc, &cfg);
     let resp = client.generate(&gc).map_err(|e| e.to_string())?;
     Ok(resp.text.trim().to_string())
 }
@@ -159,8 +175,12 @@ pub fn run_manifest(
         },
     };
     if let (Some(data), Some(mime)) = (source_bytes, source_mime) {
-        gc.user_images.push(mogen_llm::ImageInput { mime_type: mime, data });
+        gc.user_images.push(mogen_llm::ImageInput {
+            mime_type: mime,
+            data,
+        });
     }
+    apply_vision_model_if_needed(&mut gc, &cfg);
     let resp = client.generate(&gc).map_err(|e| e.to_string())?;
     parse_manifest_json(&resp.text)
 }
@@ -178,15 +198,17 @@ pub fn run_reference_image(
     seed: u64,
 ) -> Result<PathBuf, String> {
     if let Some(parent) = out_path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
+        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
     }
     // Image-to-image only when a source photo is present AND the backend can
     // actually consume input images (Gemini yes, Z.ai no). Otherwise fall back
     // to text-to-image so a scene still gets references either way.
     let inputs: Vec<mogen_llm::ImageInput> = match (source_bytes, source_mime) {
         (Some(data), Some(mime)) if image_client.supports_image_input() => {
-            vec![mogen_llm::ImageInput { mime_type: mime, data }]
+            vec![mogen_llm::ImageInput {
+                mime_type: mime,
+                data,
+            }]
         }
         _ => Vec::new(),
     };
@@ -267,8 +289,7 @@ pub fn run_object_mog(
     cfg: WizardRunConfig,
 ) -> Result<ObjectGenResult, String> {
     if let Some(parent) = out_path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
+        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
     }
     let header_prompt = format!("{} — {}", obj.name, obj.prompt);
     let user = format!(
@@ -316,8 +337,12 @@ pub fn run_object_mog(
         },
     };
     if let (Some(data), Some(mime)) = (reference_bytes, reference_mime) {
-        gc.user_images.push(mogen_llm::ImageInput { mime_type: mime, data });
+        gc.user_images.push(mogen_llm::ImageInput {
+            mime_type: mime,
+            data,
+        });
     }
+    apply_vision_model_if_needed(&mut gc, &cfg);
     let repair = RepairConfig {
         max_iters: cfg.max_repair_iters,
         on_iteration: None,
@@ -379,6 +404,7 @@ pub fn run_object_review(
         mime_type: image_mime,
         data: image_bytes,
     });
+    apply_vision_model_if_needed(&mut gc, &cfg);
     gc.spend_context = mogen_llm::CallContext {
         operation: "Generate".into(),
         scene_path: None,
@@ -406,8 +432,8 @@ pub fn run_scene_review(
     iteration: u32,
     cfg: WizardRunConfig,
 ) -> Result<SceneReview, String> {
-    let manifest_json = serde_json::to_string_pretty(&manifest)
-        .map_err(|e| format!("serialise manifest: {e}"))?;
+    let manifest_json =
+        serde_json::to_string_pretty(&manifest).map_err(|e| format!("serialise manifest: {e}"))?;
     let user = format!(
         "You are reviewing an isometric render of a 3D scene generated for this prompt:\n\n\
          \"{prompt}\"\n\n\
@@ -435,6 +461,7 @@ pub fn run_scene_review(
         mime_type: image_mime,
         data: image_bytes,
     });
+    apply_vision_model_if_needed(&mut gc, &cfg);
     gc.spend_context = mogen_llm::CallContext {
         operation: "Generate".into(),
         scene_path: None,
@@ -492,8 +519,9 @@ fn compute_position_guide(dsl: &str, _id: &str) -> Option<PositionGuide> {
 /// (models sometimes wrap their answer in ```json … ``` even when told not to).
 fn parse_manifest_json(text: &str) -> Result<Vec<ObjectEntry>, String> {
     let cleaned = strip_markdown_fences(text);
-    let value: serde_json::Value = serde_json::from_str(&cleaned)
-        .map_err(|e| format!("manifest is not valid JSON: {e}\n\n--- raw response ---\n{cleaned}"))?;
+    let value: serde_json::Value = serde_json::from_str(&cleaned).map_err(|e| {
+        format!("manifest is not valid JSON: {e}\n\n--- raw response ---\n{cleaned}")
+    })?;
     let arr = value
         .get("objects")
         .and_then(|v| v.as_array())
@@ -619,6 +647,45 @@ pub(crate) fn strip_markdown_fences(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_config(provider: Provider, model: &str) -> WizardRunConfig {
+        WizardRunConfig {
+            model: model.to_string(),
+            provider,
+            thinking: ThinkingLevel::High,
+            temperature: 0.3,
+            max_repair_iters: 0,
+            seed: 1,
+            style: None,
+            session_id: String::new(),
+        }
+    }
+
+    #[test]
+    fn wizard_image_calls_use_provider_vision_model() {
+        let cfg = test_config(Provider::Xiaomi, "mimo-v2.5-pro");
+        let mut gc = GenerateConfig::new("describe");
+        gc.model = cfg.model.clone();
+        gc.user_images.push(mogen_llm::ImageInput {
+            mime_type: "image/png".into(),
+            data: vec![1],
+        });
+
+        apply_vision_model_if_needed(&mut gc, &cfg);
+
+        assert_eq!(gc.model, mogen_llm::XIAOMI_DEFAULT_VISION_MODEL);
+    }
+
+    #[test]
+    fn wizard_text_calls_keep_configured_model() {
+        let cfg = test_config(Provider::Xiaomi, "mimo-v2.5-pro");
+        let mut gc = GenerateConfig::new("describe");
+        gc.model = cfg.model.clone();
+
+        apply_vision_model_if_needed(&mut gc, &cfg);
+
+        assert_eq!(gc.model, "mimo-v2.5-pro");
+    }
 
     #[test]
     fn strips_json_fence() {

--- a/crates/mogen-studio/src/settings.rs
+++ b/crates/mogen-studio/src/settings.rs
@@ -277,6 +277,18 @@ pub struct Settings {
     /// Z.ai fast-model override. Empty → [`mogen_llm::zai_chat::DEFAULT_FAST_MODEL`].
     #[serde(default)]
     pub zai_chat_fast_model: String,
+    /// Xiaomi MiMo API key. Empty → fall back to the `XIAOMI_API_KEY` env var.
+    #[serde(default)]
+    pub xiaomi_api_key: String,
+
+    /// Xiaomi MiMo thinking-model override. Empty → [`mogen_llm::xiaomi::DEFAULT_MODEL`]
+    /// (`mimo-v2.5-pro`).
+    #[serde(default)]
+    pub xiaomi_model: String,
+
+    /// Xiaomi MiMo fast-model override. Empty → [`mogen_llm::xiaomi::DEFAULT_FAST_MODEL`].
+    #[serde(default)]
+    pub xiaomi_fast_model: String,
 
     /// Persisted 3D viewport background colour, as `[r, g, b]` 0..=255. `None`
     /// falls back to [`DEFAULT_VIEWER_BG_RGB`] — a neutral charcoal that
@@ -550,8 +562,7 @@ impl Settings {
     /// field, then saves settings.json so any in-memory mutations
     /// alongside the sign-out also land.
     pub fn clear_moghub_session(&mut self) -> Result<(), String> {
-        moghub_session::clear_session()
-            .map_err(|e| format!("remove moghub session: {e}"))?;
+        moghub_session::clear_session().map_err(|e| format!("remove moghub session: {e}"))?;
         self.moghub_session.clear();
         self.save()
     }

--- a/crates/mogen-studio/src/settings/provider_slot.rs
+++ b/crates/mogen-studio/src/settings/provider_slot.rs
@@ -26,6 +26,9 @@ pub enum ProviderSlot {
     /// model is `glm-5.1`. The same API key drives the `glm-image` texture
     /// path — see [`super::ImageProvider::ZAI`].
     Zai,
+    /// Xiaomi MiMo Open Platform. OpenAI-compatible Chat Completions; default
+    /// model is `mimo-v2.5-pro`, with `mimo-v2.5` used for image inputs.
+    Xiaomi,
     /// Generic OpenAI-compatible local server (llama.cpp, LM Studio, any
     /// `/v1/chat/completions` host). The user supplies an arbitrary base URL
     /// in Preferences; routes through [`Provider::OpenAiCompat`]. Keyless by
@@ -46,6 +49,7 @@ impl ProviderSlot {
             ProviderSlot::Fireworks => "fireworks",
             ProviderSlot::Zai => "zai",
             ProviderSlot::OpenAiCompat => "openai-compat",
+            ProviderSlot::Xiaomi => "xiaomi",
         }
     }
 
@@ -60,6 +64,7 @@ impl ProviderSlot {
             ProviderSlot::Fireworks => "Fireworks AI Firepass",
             ProviderSlot::Zai => "Z.ai (GLM)",
             ProviderSlot::OpenAiCompat => "OpenAI-compatible (local)",
+            ProviderSlot::Xiaomi => "Xiaomi MiMo",
         }
     }
 
@@ -77,6 +82,7 @@ impl ProviderSlot {
             "claude-code" | "claude_code" | "claudecode" | "cc" => Some(Self::ClaudeCode),
             "fireworks" | "fireworks-ai" | "firepass" | "kimi" => Some(Self::Fireworks),
             "zai" | "z-ai" | "z.ai" | "zhipu" | "glm" => Some(Self::Zai),
+            "xiaomi" | "mimo" | "xiaomimimo" | "xiaomi-mimo" | "xiaomi_mimo" => Some(Self::Xiaomi),
             "openai-compat" | "openai-compatible" | "openai_compat" | "local-openai"
             | "lmstudio" | "lm-studio" | "llamacpp" | "llama-cpp" | "llama.cpp" => {
                 Some(Self::OpenAiCompat)
@@ -98,6 +104,7 @@ impl ProviderSlot {
             ProviderSlot::Fireworks => Provider::Fireworks,
             ProviderSlot::Zai => Provider::Zai,
             ProviderSlot::OpenAiCompat => Provider::OpenAiCompat,
+            ProviderSlot::Xiaomi => Provider::Xiaomi,
         }
     }
 
@@ -116,9 +123,9 @@ impl Default for ProviderSlot {
 
 /// Order in which provider slots appear in the Options dropdown. Both
 /// Gemini auth modes are listed up front because Gemini is the historical
-/// default and the only image-capable backend; the OAuth slot is the path
-/// users with paid Antigravity plans will reach for.
-pub const PROVIDER_SLOTS: [ProviderSlot; 9] = [
+/// default; the OAuth slot is the path users with paid Antigravity plans
+/// will reach for.
+pub const PROVIDER_SLOTS: [ProviderSlot; 10] = [
     ProviderSlot::GeminiApiKey,
     ProviderSlot::GeminiOAuth,
     ProviderSlot::OpenAI,
@@ -128,6 +135,7 @@ pub const PROVIDER_SLOTS: [ProviderSlot; 9] = [
     ProviderSlot::ClaudeCode,
     ProviderSlot::Fireworks,
     ProviderSlot::Zai,
+    ProviderSlot::Xiaomi,
 ];
 
 /// Default thinking model when the active slot is `GeminiOAuth` and no

--- a/crates/mogen-studio/src/settings/providers.rs
+++ b/crates/mogen-studio/src/settings/providers.rs
@@ -40,6 +40,7 @@ impl Settings {
             ProviderSlot::ClaudeCode => "",
             ProviderSlot::Fireworks => self.fireworks_api_key.as_str(),
             ProviderSlot::Zai => self.zai_api_key.as_str(),
+            ProviderSlot::Xiaomi => self.xiaomi_api_key.as_str(),
             ProviderSlot::OpenAiCompat => self.openai_compat_api_key.as_str(),
         };
         let trimmed = raw.trim();
@@ -127,6 +128,7 @@ impl Settings {
             Provider::Ollama => &self.ollama_model,
             Provider::Fireworks => &self.fireworks_model,
             Provider::Zai => &self.zai_chat_model,
+            Provider::Xiaomi => &self.xiaomi_model,
             Provider::OpenAiCompat => &self.openai_compat_model,
             _ => "",
         }
@@ -141,6 +143,7 @@ impl Settings {
             Provider::Ollama => &self.ollama_fast_model,
             Provider::Fireworks => &self.fireworks_fast_model,
             Provider::Zai => &self.zai_chat_fast_model,
+            Provider::Xiaomi => &self.xiaomi_fast_model,
             Provider::OpenAiCompat => &self.openai_compat_fast_model,
             _ => "",
         }
@@ -156,6 +159,7 @@ impl Settings {
             Provider::Ollama => Some(&mut self.ollama_model),
             Provider::Fireworks => Some(&mut self.fireworks_model),
             Provider::Zai => Some(&mut self.zai_chat_model),
+            Provider::Xiaomi => Some(&mut self.xiaomi_model),
             Provider::OpenAiCompat => Some(&mut self.openai_compat_model),
             _ => None,
         }
@@ -170,6 +174,7 @@ impl Settings {
             Provider::Ollama => Some(&mut self.ollama_fast_model),
             Provider::Fireworks => Some(&mut self.fireworks_fast_model),
             Provider::Zai => Some(&mut self.zai_chat_fast_model),
+            Provider::Xiaomi => Some(&mut self.xiaomi_fast_model),
             Provider::OpenAiCompat => Some(&mut self.openai_compat_fast_model),
             _ => None,
         }

--- a/crates/mogen/src/cli/cmd.rs
+++ b/crates/mogen/src/cli/cmd.rs
@@ -104,13 +104,13 @@ pub(crate) enum Cmd {
         seed: Option<u64>,
         /// LLM provider. For Gemini, credentials are resolved via `--auth`
         /// (default `auto`) and `mogen auth login` (gemini-cli or
-        /// Antigravity OAuth) or `GEMINI_API_KEY`. Other providers use the
-        /// matching `*_API_KEY` env var (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY`
-        /// / `OLLAMA_API_KEY`); Ollama is keyless by default.
+        /// Antigravity OAuth) or `GEMINI_API_KEY`. Other cloud providers use
+        /// their matching `*_API_KEY` env var (`OPENAI_API_KEY`,
+        /// `ANTHROPIC_API_KEY`, `XIAOMI_API_KEY`, ...); Ollama is keyless by default.
         #[arg(long, value_enum, default_value_t = ProviderArg::Auto)]
         provider: ProviderArg,
         /// Model name. When omitted, falls back to the provider's default
-        /// (Gemini Pro / GPT-4o / Claude Sonnet / llama3.1).
+        /// (Gemini Pro / GPT / Claude Sonnet / MiMo Pro / llama3.1).
         #[arg(long)]
         model: Option<String>,
         /// Print the generated DSL but skip compilation and GLB output.
@@ -163,7 +163,7 @@ pub(crate) enum Cmd {
         /// `N` times. Each iteration runs through the full validate +
         /// repair loop, so the final file is still guaranteed to compile.
         /// `0` (the default) skips refinement entirely. Requires a
-        /// vision-capable provider (currently Gemini only).
+        /// vision-capable provider.
         #[arg(long, default_value_t = 0, value_parser = clap::value_parser!(u32).range(0..=10))]
         auto_refine: u32,
     },

--- a/crates/mogen/src/cli/value_args.rs
+++ b/crates/mogen/src/cli/value_args.rs
@@ -103,6 +103,9 @@ pub(crate) enum ProviderArg {
     /// Z.ai (Zhipu) GLM family via the OpenAI-compatible chat endpoint.
     /// Default model is `glm-5.1`; set `ZAI_API_KEY`.
     Zai,
+    /// Xiaomi MiMo Open Platform via its OpenAI-compatible chat endpoint.
+    /// Default model is `mimo-v2.5-pro`; set `XIAOMI_API_KEY`.
+    Xiaomi,
 }
 
 impl From<ProviderArg> for Provider {
@@ -120,6 +123,7 @@ impl From<ProviderArg> for Provider {
             ProviderArg::ClaudeCode => Provider::ClaudeCode,
             ProviderArg::Fireworks => Provider::Fireworks,
             ProviderArg::Zai => Provider::Zai,
+            ProviderArg::Xiaomi => Provider::Xiaomi,
         }
     }
 }
@@ -139,7 +143,8 @@ impl From<ProviderArg> for crate::common::GeminiAuthMode {
             | ProviderArg::Ollama
             | ProviderArg::ClaudeCode
             | ProviderArg::Fireworks
-            | ProviderArg::Zai => GeminiAuthMode::Auto,
+            | ProviderArg::Zai
+            | ProviderArg::Xiaomi => GeminiAuthMode::Auto,
         }
     }
 }

--- a/crates/mogen/src/commands/generate.rs
+++ b/crates/mogen/src/commands/generate.rs
@@ -1,13 +1,13 @@
 use std::fs;
 use std::path::PathBuf;
 
+use crate::refine_render::render_dsl_to_png;
 use anyhow::{anyhow, bail, Context, Result};
 use mogen_llm::{
     apply_style_to_prompt, compose_coder_prompt, embed_seed_header, generate_plan,
     generate_with_repair, stamp_style_header, visual_refine, GenerateConfig, ImageInput, Provider,
     RepairConfig, Style, ThinkingLevel, Usage,
 };
-use crate::refine_render::render_dsl_to_png;
 
 use crate::commands::build::build;
 use crate::common::{
@@ -57,7 +57,6 @@ pub(crate) fn generate(args: GenerateArgs) -> Result<()> {
 
     // Visual refinement requires a vision-capable provider — bail early so
     // the user doesn't burn tokens on a Coder pass that can't be refined.
-    // Today that's Gemini only.
     if args.auto_refine > 0 && !provider.supports_images() {
         bail!(
             "--auto-refine requires a vision-capable provider; {} does not support image input",
@@ -115,7 +114,13 @@ pub(crate) fn generate(args: GenerateArgs) -> Result<()> {
     // Generate has no prior file to read a header from; use CLI or library default.
     let effective_thinking = args.thinking.unwrap_or(ThinkingLevel::High);
     cfg.thinking_level = Some(effective_thinking);
-    attach_system_instruction(&mut cfg, &client, args.cached_content, args.no_cache, "generate");
+    attach_system_instruction(
+        &mut cfg,
+        &client,
+        args.cached_content,
+        args.no_cache,
+        "generate",
+    );
 
     let provider_label = provider.label();
 
@@ -135,9 +140,7 @@ pub(crate) fn generate(args: GenerateArgs) -> Result<()> {
         let plan_outcome = match generate_plan(&client, &cfg, &args.prompt) {
             Ok(o) => o,
             Err(e) => {
-                pb.abandon_with_message(format!(
-                    "generate: {provider_label} planner error — {e}"
-                ));
+                pb.abandon_with_message(format!("generate: {provider_label} planner error — {e}"));
                 return Err(anyhow!("{}: planner: {e}", provider_label.to_lowercase()));
             }
         };
@@ -197,10 +200,7 @@ pub(crate) fn generate(args: GenerateArgs) -> Result<()> {
         let registry = mogen_dsl::stdlib_registry();
         for iter in 0..args.auto_refine {
             let label = format!("refine {}/{}", iter + 1, args.auto_refine);
-            let mut pb = Spinner::new(
-                &format!("generate: rendering for {label}"),
-                LLM_FLAVORS,
-            );
+            let mut pb = Spinner::new(&format!("generate: rendering for {label}"), LLM_FLAVORS);
 
             let png = match render_dsl_to_png(&outcome.dsl, resolved_dsl_out.as_deref()) {
                 Ok(bytes) => bytes,
@@ -237,14 +237,16 @@ pub(crate) fn generate(args: GenerateArgs) -> Result<()> {
                 data: png,
             };
 
-            // Z.ai vision auto-swap. The Coder pass on Z.ai runs against
-            // a text model (`glm-5.1` by default); the Reviewer needs to
-            // read the rendered PNG, so it has to route through
-            // `glm-5v-turbo` instead. Mirrors the Studio-side override
-            // in `app/util/llm.rs::run_llm_refine`.
+            // Provider-specific vision auto-swaps. Some providers expose
+            // separate text and image-understanding model ids; route the
+            // Reviewer through the documented vision model when it needs to
+            // read the rendered PNG. Mirrors the Studio-side override in
+            // `app/util/llm.rs::run_llm`.
             let mut refine_cfg = cfg.clone();
             if provider == Provider::Zai {
                 refine_cfg.model = mogen_llm::ZAI_DEFAULT_VISION_MODEL.to_string();
+            } else if provider == Provider::Xiaomi {
+                refine_cfg.model = mogen_llm::XIAOMI_DEFAULT_VISION_MODEL.to_string();
             }
             let refined = match visual_refine(
                 &client,
@@ -306,7 +308,10 @@ pub(crate) fn generate(args: GenerateArgs) -> Result<()> {
         // Print diagnostics so the user knows what the LLM missed.
         let filename = "<generated>".to_string();
         if args.dry_run {
-            eprintln!("{}", mogen_validate::render_json(&filename, &outcome.diagnostics));
+            eprintln!(
+                "{}",
+                mogen_validate::render_json(&filename, &outcome.diagnostics)
+            );
             println!("{}", wrapped);
         } else {
             mogen_validate::render_human(&filename, &wrapped, &outcome.diagnostics);
@@ -336,8 +341,7 @@ pub(crate) fn generate(args: GenerateArgs) -> Result<()> {
     let out_path = resolved_out.expect("out checked above");
     let dsl_path = resolved_dsl_out.expect("dsl_out resolved above for non-dry-run");
 
-    fs::write(&dsl_path, &wrapped)
-        .with_context(|| format!("writing {}", dsl_path.display()))?;
+    fs::write(&dsl_path, &wrapped).with_context(|| format!("writing {}", dsl_path.display()))?;
 
     // Reuse the regular build path so the user gets the same progress line.
     build(dsl_path, out_path, None)

--- a/crates/mogen/src/commands/mcp.rs
+++ b/crates/mogen/src/commands/mcp.rs
@@ -25,7 +25,9 @@ use std::path::PathBuf;
 use anyhow::Result;
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{CallToolResult, Content, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo},
+    model::{
+        CallToolResult, Content, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
+    },
     schemars, tool, tool_handler, tool_router,
     transport::stdio,
     ErrorData as McpError, ServerHandler, ServiceExt,
@@ -135,7 +137,7 @@ fn push_path_opt(args: &mut Vec<String>, name: &str, value: Option<PathBuf>) {
 struct LlmCommon {
     /// LLM provider. One of `auto`, `gemini`, `gemini-oauth`,
     /// `antigravity`, `openai`, `anthropic`, `ollama`, `claude-code`,
-    /// `fireworks`, `zai`. Defaults to `auto`.
+    /// `fireworks`, `zai`, `xiaomi`. Defaults to `auto`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     provider: Option<String>,
     /// Model name. Provider default applies when omitted.
@@ -560,13 +562,17 @@ pub(crate) struct MogenMcp {
 #[tool_router]
 impl MogenMcp {
     pub(crate) fn new() -> Self {
-        Self { tool_router: Self::tool_router() }
+        Self {
+            tool_router: Self::tool_router(),
+        }
     }
 
     // -- pipeline ----------------------------------------------------------
 
-    #[tool(description = "Compile a .mog DSL file to a binary scene container (GLB or FBX). \
-        The output extension picks the format unless `format` is set explicitly.")]
+    #[tool(
+        description = "Compile a .mog DSL file to a binary scene container (GLB or FBX). \
+        The output extension picks the format unless `format` is set explicitly."
+    )]
     async fn build(
         &self,
         Parameters(p): Parameters<BuildArgs>,
@@ -582,11 +588,17 @@ impl MogenMcp {
         &self,
         Parameters(p): Parameters<InputOnly>,
     ) -> Result<CallToolResult, McpError> {
-        run_mogen(vec!["parse".to_string(), p.input.to_string_lossy().into_owned()]).await
+        run_mogen(vec![
+            "parse".to_string(),
+            p.input.to_string_lossy().into_owned(),
+        ])
+        .await
     }
 
-    #[tool(description = "Validate a .mog file (semantic + reference checks). Returns \
-        diagnostics; tool result is marked as error iff any diagnostic is a hard error.")]
+    #[tool(
+        description = "Validate a .mog file (semantic + reference checks). Returns \
+        diagnostics; tool result is marked as error iff any diagnostic is a hard error."
+    )]
     async fn check(
         &self,
         Parameters(p): Parameters<CheckArgs>,
@@ -601,27 +613,41 @@ impl MogenMcp {
         &self,
         Parameters(p): Parameters<DumpSceneArgs>,
     ) -> Result<CallToolResult, McpError> {
-        let mut args = vec!["dump-scene".to_string(), p.input.to_string_lossy().into_owned()];
+        let mut args = vec![
+            "dump-scene".to_string(),
+            p.input.to_string_lossy().into_owned(),
+        ];
         push_flag(&mut args, "--json", p.json);
         run_mogen(args).await
     }
 
-    #[tool(description = "Read a .glb file and print its structure (chunks, accessors, meshes, \
-        materials, animations, skins).")]
+    #[tool(
+        description = "Read a .glb file and print its structure (chunks, accessors, meshes, \
+        materials, animations, skins)."
+    )]
     async fn inspect(
         &self,
         Parameters(p): Parameters<InputOnly>,
     ) -> Result<CallToolResult, McpError> {
-        run_mogen(vec!["inspect".to_string(), p.input.to_string_lossy().into_owned()]).await
+        run_mogen(vec![
+            "inspect".to_string(),
+            p.input.to_string_lossy().into_owned(),
+        ])
+        .await
     }
 
-    #[tool(description = "Render a PNG preview of a .mog via the headless GL pipeline. Suitable \
-        to feed back into moghub_publish as a thumbnail.")]
+    #[tool(
+        description = "Render a PNG preview of a .mog via the headless GL pipeline. Suitable \
+        to feed back into moghub_publish as a thumbnail."
+    )]
     async fn thumbnail(
         &self,
         Parameters(p): Parameters<ThumbnailArgs>,
     ) -> Result<CallToolResult, McpError> {
-        let mut args = vec!["thumbnail".to_string(), p.input.to_string_lossy().into_owned()];
+        let mut args = vec![
+            "thumbnail".to_string(),
+            p.input.to_string_lossy().into_owned(),
+        ];
         push_path_opt(&mut args, "--out", p.out);
         push_opt(&mut args, "--size", p.size);
         push_opt(&mut args, "--yaw", p.yaw);
@@ -632,8 +658,10 @@ impl MogenMcp {
 
     // -- LLM-driven ---------------------------------------------------------
 
-    #[tool(description = "Generate a .mog from a natural-language prompt via the configured LLM \
-        provider, validate, and compile to GLB. Uses mogen's own LLM credentials.")]
+    #[tool(
+        description = "Generate a .mog from a natural-language prompt via the configured LLM \
+        provider, validate, and compile to GLB. Uses mogen's own LLM credentials."
+    )]
     async fn generate(
         &self,
         Parameters(p): Parameters<GenerateArgs>,
@@ -647,14 +675,20 @@ impl MogenMcp {
         run_mogen(args).await
     }
 
-    #[tool(description = "Modify an existing .mog with a natural-language prompt, validate, and \
+    #[tool(
+        description = "Modify an existing .mog with a natural-language prompt, validate, and \
         recompile. Default mode emits SEARCH/REPLACE edit blocks; set `rewrite=true` to force a \
-        full rewrite.")]
+        full rewrite."
+    )]
     async fn modify(
         &self,
         Parameters(p): Parameters<ModifyArgs>,
     ) -> Result<CallToolResult, McpError> {
-        let mut args = vec!["modify".to_string(), p.input.to_string_lossy().into_owned(), p.prompt];
+        let mut args = vec![
+            "modify".to_string(),
+            p.input.to_string_lossy().into_owned(),
+            p.prompt,
+        ];
         push_path_opt(&mut args, "--out", p.out);
         push_path_opt(&mut args, "--dsl-out", p.dsl_out);
         push_flag(&mut args, "--plan", p.plan);
@@ -664,22 +698,30 @@ impl MogenMcp {
         run_mogen(args).await
     }
 
-    #[tool(description = "Add or edit animations on an existing .mog via the LLM. Restricted to \
-        animation declarations (joint, clip/track, spin, open_close, wave, flap, idle).")]
+    #[tool(
+        description = "Add or edit animations on an existing .mog via the LLM. Restricted to \
+        animation declarations (joint, clip/track, spin, open_close, wave, flap, idle)."
+    )]
     async fn animate(
         &self,
         Parameters(p): Parameters<AnimateArgs>,
     ) -> Result<CallToolResult, McpError> {
-        let mut args = vec!["animate".to_string(), p.input.to_string_lossy().into_owned(), p.prompt];
+        let mut args = vec![
+            "animate".to_string(),
+            p.input.to_string_lossy().into_owned(),
+            p.prompt,
+        ];
         push_path_opt(&mut args, "--out", p.out);
         push_path_opt(&mut args, "--dsl-out", p.dsl_out);
         p.common.push(&mut args);
         run_mogen(args).await
     }
 
-    #[tool(description = "Repair validation errors in an existing .mog via the LLM. Runs the \
+    #[tool(
+        description = "Repair validation errors in an existing .mog via the LLM. Runs the \
         validator first, feeds each diagnostic back to the model, and re-validates. No-op if the \
-        file already validates.")]
+        file already validates."
+    )]
     async fn repair(
         &self,
         Parameters(p): Parameters<RepairArgs>,
@@ -692,14 +734,19 @@ impl MogenMcp {
         run_mogen(args).await
     }
 
-    #[tool(description = "Generate PBR textures for every material in a .mog (LLM-drawn albedo \
+    #[tool(
+        description = "Generate PBR textures for every material in a .mog (LLM-drawn albedo \
         + locally-derived normal / metallic-roughness / occlusion). Gemini-only. PNGs are \
-        written next to the .mog and the matching texture attrs spliced into the source.")]
+        written next to the .mog and the matching texture attrs spliced into the source."
+    )]
     async fn textures(
         &self,
         Parameters(p): Parameters<TexturesArgs>,
     ) -> Result<CallToolResult, McpError> {
-        let mut args = vec!["textures".to_string(), p.input.to_string_lossy().into_owned()];
+        let mut args = vec![
+            "textures".to_string(),
+            p.input.to_string_lossy().into_owned(),
+        ];
         push_path_opt(&mut args, "--out", p.out);
         push_path_opt(&mut args, "--glb", p.glb);
         push_path_opt(&mut args, "--textures-dir", p.textures_dir);
@@ -712,7 +759,11 @@ impl MogenMcp {
         push_opt(&mut args, "--zai-api-key", p.zai_api_key);
         push_flag(&mut args, "--no-pbr", p.no_pbr);
         push_flag(&mut args, "--no-normal", p.no_normal);
-        push_flag(&mut args, "--no-metallic-roughness", p.no_metallic_roughness);
+        push_flag(
+            &mut args,
+            "--no-metallic-roughness",
+            p.no_metallic_roughness,
+        );
         push_flag(&mut args, "--no-occlusion", p.no_occlusion);
         push_opt(&mut args, "--texture-size", p.texture_size);
         run_mogen(args).await
@@ -720,8 +771,10 @@ impl MogenMcp {
 
     // -- ops / bench --------------------------------------------------------
 
-    #[tool(description = "Download the latest release from GitHub and replace the running mogen \
-        binary in place. Without `yes=true`, only checks and prints what it would do.")]
+    #[tool(
+        description = "Download the latest release from GitHub and replace the running mogen \
+        binary in place. Without `yes=true`, only checks and prints what it would do."
+    )]
     async fn update(
         &self,
         Parameters(p): Parameters<UpdateArgs>,
@@ -733,8 +786,10 @@ impl MogenMcp {
         run_mogen(args).await
     }
 
-    #[tool(description = "Run a suite of prompts through `generate` and report success rate and \
-        mean token cost. Does not write GLBs.")]
+    #[tool(
+        description = "Run a suite of prompts through `generate` and report success rate and \
+        mean token cost. Does not write GLBs."
+    )]
     async fn bench(
         &self,
         Parameters(p): Parameters<BenchArgs>,
@@ -779,8 +834,10 @@ impl MogenMcp {
         run_mogen(args).await
     }
 
-    #[tool(description = "Print full detail for a MoGHub model. Reference is `<user>/<slug>` \
-        or `@<user>/<slug>`.")]
+    #[tool(
+        description = "Print full detail for a MoGHub model. Reference is `<user>/<slug>` \
+        or `@<user>/<slug>`."
+    )]
     async fn moghub_info(
         &self,
         Parameters(p): Parameters<MoghubRefArgs>,
@@ -791,8 +848,10 @@ impl MogenMcp {
         run_mogen(args).await
     }
 
-    #[tool(description = "Download a MoGHub model's `.mog` files into a directory. Defaults to \
-        the latest version.")]
+    #[tool(
+        description = "Download a MoGHub model's `.mog` files into a directory. Defaults to \
+        the latest version."
+    )]
     async fn moghub_download(
         &self,
         Parameters(p): Parameters<MoghubDownloadArgs>,
@@ -861,9 +920,11 @@ impl MogenMcp {
         run_mogen(args).await
     }
 
-    #[tool(description = "Publish a `.mog` to MoGHub. Bundles every locally imported `.mog` \
+    #[tool(
+        description = "Publish a `.mog` to MoGHub. Bundles every locally imported `.mog` \
         plus referenced PNG/JPG/JPEG/WebP textures. Re-publishing a file with a prior MoGHub \
-        stamp appends a version unless `new=true`.")]
+        stamp appends a version unless `new=true`."
+    )]
     async fn moghub_publish(
         &self,
         Parameters(p): Parameters<MoghubPublishArgs>,
@@ -901,13 +962,10 @@ impl ServerHandler for MogenMcp {
         info.server_info = Implementation::from_build_env();
         info.server_info.name = env!("CARGO_PKG_NAME").to_string();
         info.server_info.version = env!("CARGO_PKG_VERSION").to_string();
-        info.server_info = info
-            .server_info
-            .with_title("MoGen")
-            .with_description(
-                "Procedural 3D model generator. Compiles `.mog` DSL to glTF/FBX and \
+        info.server_info = info.server_info.with_title("MoGen").with_description(
+            "Procedural 3D model generator. Compiles `.mog` DSL to glTF/FBX and \
                 drives an LLM-backed generation pipeline.",
-            );
+        );
         info.instructions = Some(
             "MoGen MCP server. Exposes every `mogen` CLI subcommand as a tool. \
             Use `build` / `check` / `parse` / `dump_scene` / `inspect` / `thumbnail` for \

--- a/crates/mogen/src/commands/modify.rs
+++ b/crates/mogen/src/commands/modify.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 
+use crate::refine_render::render_dsl_to_png;
 use anyhow::{anyhow, bail, Context, Result};
 use mogen_llm::{
     apply_style_to_prompt, compose_coder_prompt, embed_seed_header, format_imports_preserve_block,
@@ -9,7 +10,6 @@ use mogen_llm::{
     summarize_imports, visual_refine, GenerateConfig, ImageInput, Provider, RepairConfig, Style,
     ThinkingLevel, Usage, EDIT_BLOCK_INSTRUCTIONS,
 };
-use crate::refine_render::render_dsl_to_png;
 
 use crate::commands::build::build;
 use crate::common::{
@@ -109,10 +109,8 @@ pub(crate) fn modify(args: ModifyArgs) -> Result<()> {
     // `use "X"` will be in its local frame so composition prompts ("position
     // the items on the scene") don't end up with overlapping or floating
     // placements.
-    let imports_block = format_imports_preserve_block(&summarize_imports(
-        &existing,
-        args.input.parent(),
-    ));
+    let imports_block =
+        format_imports_preserve_block(&summarize_imports(&existing, args.input.parent()));
     let imports_block = match imports_block {
         Some(s) => format!("{s}\n"),
         None => String::new(),
@@ -141,9 +139,7 @@ pub(crate) fn modify(args: ModifyArgs) -> Result<()> {
         let plan_outcome = match generate_plan(&client, &planner_cfg, &args.prompt) {
             Ok(o) => o,
             Err(e) => {
-                pb.abandon_with_message(format!(
-                    "modify: {provider_label} planner error — {e}"
-                ));
+                pb.abandon_with_message(format!("modify: {provider_label} planner error — {e}"));
                 return Err(anyhow!("{}: planner: {e}", provider_label.to_lowercase()));
             }
         };
@@ -166,7 +162,8 @@ pub(crate) fn modify(args: ModifyArgs) -> Result<()> {
     // `--rewrite` opts back into the legacy full-file path.
     let edit_mode = !args.rewrite;
     let trimmed_existing = existing.trim_end();
-    let shared_constraints = "Make the smallest edit that satisfies the request. Do not rename, reorder, \
+    let shared_constraints =
+        "Make the smallest edit that satisfies the request. Do not rename, reorder, \
 reformat, or restyle parts the modification does not touch — preserve their \
 names, materials, transforms, connectors, attaches, joints, clips, and \
 tracks verbatim. Do not \"improve\" unrelated geometry.\n\n\
@@ -229,7 +226,13 @@ Existing file:\n\n{existing}",
         scene_path: Some(args.input.display().to_string()),
         session_id: None,
     };
-    attach_system_instruction(&mut cfg, &client, args.cached_content, args.no_cache, "modify");
+    attach_system_instruction(
+        &mut cfg,
+        &client,
+        args.cached_content,
+        args.no_cache,
+        "modify",
+    );
 
     let total_attempts = args.max_repair_iters + 1;
     let mut pb = Spinner::new(
@@ -291,10 +294,7 @@ Existing file:\n\n{existing}",
         );
         for iter in 0..args.auto_refine {
             let label = format!("refine {}/{}", iter + 1, args.auto_refine);
-            let mut pb = Spinner::new(
-                &format!("modify: rendering for {label}"),
-                LLM_FLAVORS,
-            );
+            let mut pb = Spinner::new(&format!("modify: rendering for {label}"), LLM_FLAVORS);
 
             let png = match render_dsl_to_png(&outcome.dsl, Some(&resolved_dsl_out)) {
                 Ok(bytes) => bytes,
@@ -328,14 +328,16 @@ Existing file:\n\n{existing}",
                 data: png,
             };
 
-            // Z.ai vision auto-swap. The Modify pass on Z.ai runs against
-            // a text model (`glm-5.1` by default); the Reviewer needs to
-            // read the rendered PNG, so it has to route through
-            // `glm-5v-turbo` instead. Mirrors the Studio-side override
-            // in `app/util/llm.rs::run_llm_refine`.
+            // Provider-specific vision auto-swaps. Some providers expose
+            // separate text and image-understanding model ids; route the
+            // Reviewer through the documented vision model when it needs to
+            // read the rendered PNG. Mirrors the Studio-side override in
+            // `app/util/llm.rs::run_llm`.
             let mut refine_cfg = cfg.clone();
             if provider == Provider::Zai {
                 refine_cfg.model = mogen_llm::ZAI_DEFAULT_VISION_MODEL.to_string();
+            } else if provider == Provider::Xiaomi {
+                refine_cfg.model = mogen_llm::XIAOMI_DEFAULT_VISION_MODEL.to_string();
             }
             let refined = match visual_refine(
                 &client,
@@ -425,8 +427,7 @@ Existing file:\n\n{existing}",
     let dsl_path = resolved_dsl_out;
     let out_path = resolved_out;
 
-    fs::write(&dsl_path, &wrapped)
-        .with_context(|| format!("writing {}", dsl_path.display()))?;
+    fs::write(&dsl_path, &wrapped).with_context(|| format!("writing {}", dsl_path.display()))?;
 
     build(dsl_path, out_path, None)
 }

--- a/crates/mogen/src/main.rs
+++ b/crates/mogen/src/main.rs
@@ -30,7 +30,29 @@ struct Cli {
     cmd: Cmd,
 }
 
+#[cfg(windows)]
 fn main() -> ExitCode {
+    // The clap command graph is large enough that debug Windows builds can
+    // overflow the 1 MiB process-main stack while constructing help/version
+    // output. Run the real entry point on an explicit stack so `cargo run`
+    // and release binaries behave the same.
+    let worker = std::thread::Builder::new()
+        .name("mogen-main".to_string())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(run)
+        .expect("spawn mogen main thread");
+    match worker.join() {
+        Ok(code) => code,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
+#[cfg(not(windows))]
+fn main() -> ExitCode {
+    run()
+}
+
+fn run() -> ExitCode {
     let cli = Cli::parse();
 
     // Spend tracker (issue 60). Best-effort — failures are silent so

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,8 +34,8 @@ A few flag patterns repeat across every LLM-driven subcommand
 
 | flag | meaning |
 |---|---|
-| `--api-key <KEY>` | Override `GEMINI_API_KEY` for this invocation. |
-| `--model <NAME>` | Gemini model id. Default `gemini-pro-latest` for text. For `textures`, the default depends on credentials: `gemini-3-pro-image-preview` when authenticated via OAuth (paid plan), otherwise `gemini-2.5-flash-image`. Pass `gemini-3.1-flash-image-preview` (or any other image model) to override. |
+| `--api-key <KEY>` | Override the active provider's API-key env var for this invocation (`GEMINI_API_KEY`, `OPENAI_API_KEY`, `XIAOMI_API_KEY`, etc.). |
+| `--model <NAME>` | Provider model id. Defaults to the selected provider's text model (`gemini-pro-latest`, `mimo-v2.5-pro`, etc.). For `textures`, the default depends on credentials: `gemini-3-pro-image-preview` when authenticated via OAuth (paid plan), otherwise `gemini-2.5-flash-image`. Pass `gemini-3.1-flash-image-preview` (or any other image model) to override. |
 | `--temperature <N>` | Sampling temperature. Library default is `0.3` when omitted. |
 | `--thinking <low\|medium\|high\|xhigh>` | Cap server-side reasoning. `low` = 512 tokens, `medium` = 2048, `high` = 8192 (default), `xhigh` = 24576 (slowest, most careful). |
 | `--style <ps1\|n64\|low-poly\|high-detail\|arcade\|voxel\|cel-shaded\|stylized-fantasy\|cyberpunk\|pixel-art>` | Visual-style hint. Prepends a "## Style" guidance block to the prompt and stamps `meta(style="…")` into the saved DSL. Sticky across `modify` / `animate` / `repair` runs — once stamped, those subcommands inherit the style from the file unless `--style` is passed again to override. Omit to send the prompt unchanged. |
@@ -401,10 +401,10 @@ mogen bench [--prompts <file>] [common LLM flags]
 | flag | meaning |
 |---|---|
 | `--prompts` | File with one prompt per line. `#` starts a comment. Defaults to `benches/prompts.txt`. |
-| `--model` | Gemini model id. Default `gemini-pro-latest`. |
+| `--model` | Provider model id. Defaults to the selected provider's text model. |
 | `--max-repair-iters` | Default `2`. |
 | `--budget-tokens` | Per-prompt token cap. |
-| `--api-key` | Override `GEMINI_API_KEY`. |
+| `--api-key` | Override the active provider's API-key env var. |
 | `--no-cache` | Disable the system-instruction cache. |
 | `--thinking` | Default `high`. |
 
@@ -583,7 +583,8 @@ mogen moghub publish examples/furniture/chair.mog --new --visibility unlisted  #
 
 | variable | meaning |
 |---|---|
-| `GEMINI_API_KEY` | Required by `generate` / `modify` / `animate` / `repair` / `textures` / `bench` unless `--api-key` is passed. |
+| `GEMINI_API_KEY` | Default provider key for `generate` / `modify` / `animate` / `repair` / `bench`; also used by `textures` unless OAuth or Z.ai image generation is selected. |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `FIREWORKS_API_KEY` / `ZAI_API_KEY` / `XIAOMI_API_KEY` | API keys for the matching `--provider` value; `--api-key` overrides them for one call. |
 | `MOGEN_CACHE_DIR` | Where the system-instruction cache is stored. Defaults to `$HOME/.cache/mogen/`. |
 | `MOGEN_GOLDENS_UPDATE` | When set during tests, regenerates the golden snapshots used by the validator and exporter test suites. |
 | `MOGEN_GLTF_VALIDATOR` | Path to an external glTF validator binary. When set, the build pipeline runs the output GLB through it as an additional smoke check. |

--- a/docs/studio.md
+++ b/docs/studio.md
@@ -245,9 +245,10 @@ path. It's safe to edit by hand — Studio reloads on next launch.
 
 | key | meaning |
 |---|---|
-| `gemini_api_key` | API key used by every LLM action. |
-| `gemini_model` | Heavy model id. Empty → `gemini-pro-latest`. |
-| `gemini_fast_model` | Fast model id used for low-stakes rewrites (Prompt Enhancer). Empty → `gemini-flash-latest`. |
+| `gemini_api_key` | Gemini API key used by Gemini API-key LLM actions and Gemini texture generation. |
+| `openai_api_key` / `anthropic_api_key` / `fireworks_api_key` / `zai_api_key` / `xiaomi_api_key` | API keys for the matching text provider. Empty fields fall back to that provider's env var. |
+| `gemini_model` / `openai_model` / `anthropic_model` / `fireworks_model` / `zai_chat_model` / `xiaomi_model` | Heavy model id for the matching provider. Empty → provider default. |
+| `gemini_fast_model` / `openai_fast_model` / `anthropic_fast_model` / `fireworks_fast_model` / `zai_chat_fast_model` / `xiaomi_fast_model` | Fast model id used for low-stakes rewrites (Prompt Enhancer). Empty → provider fast default. |
 | `gemini_temperature` | Sampling temperature. `null` → library default (`0.3`). |
 | `thinking_level` | `low` / `medium` / `high` / `xhigh`. Empty → library default (`high`). |
 | `max_repair_iters` | LLM repair budget. `null` → library default (`2`). |


### PR DESCRIPTION
## Summary
Adds first-class Xiaomi MiMo support across the CLI, library, and Studio using Xiaomi's OpenAI-compatible `/v1/chat/completions` endpoint.

## What changed
- add `Provider::Xiaomi` / `--provider xiaomi` with aliases like `mimo`, `xiaomimimo`, and `xiaomi-mimo`
- add a dedicated `mogen-llm::xiaomi` client with Xiaomi defaults (`mimo-v2.5-pro`, `mimo-v2-flash`, `mimo-v2.5`), Bearer auth via `XIAOMI_API_KEY`, Xiaomi-specific thinking mapping, and longer timeout headroom for reasoning-enabled requests
- keep Xiaomi image-backed review/planner paths on the documented vision model in both CLI and Studio
- wire Xiaomi into Studio settings, provider slots, pricing tables, timeout guidance, and wizard routing
- document the provider in the README and CLI/Studio docs
- add Xiaomi request-shape, pricing, timeout, and vision-routing tests
- increase the Windows debug CLI entry stack so `cargo run -p mogen -- ...` stays usable with the larger command graph

## Verification
- `cargo check`
- `cargo test -p mogen-llm xiaomi`
- `cargo test -p mogen-studio classify_timeout_uses_specific_headline_and_hint`
- `cargo test -p mogen-studio xiaomi_image_calls_use_vision_model_before_planning`
- `cargo test -p mogen-studio text_only_calls_keep_configured_model`
- `cargo test -p mogen-studio wizard_image_calls_use_provider_vision_model`
- `cargo test -p mogen-studio wizard_text_calls_keep_configured_model`
- `cargo test -p mogen-studio xiaomi_pricing_matches_overseas_rates`
- `cargo run -p mogen -- generate "a single small blue cube" --provider xiaomi --model mimo-v2-flash --thinking medium --dry-run --max-repair-iters 1`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — this is a local CLI/desktop provider integration with no server-side deployment surface.