### PR TITLE
Building: per-floor stair/elevator POIs, roof overhang, watertight floor slabs

### DIFF
--- a/crates/mogen-dsl/src/lower/building/config.rs
+++ b/crates/mogen-dsl/src/lower/building/config.rs
@@ -25,10 +25,11 @@ pub(super) enum Style {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum Roof {
     Flat,
-    /// Gable along the longer axis (the v1 axis-aligned implementation treats
-    /// `pitched` as a synonym of `gabled`: sloped end-faces would require non-
-    /// axis-aligned vertices we have nowhere to round-trip through).
+    /// Gable along the longer axis, eaves flush with the perimeter walls.
     Gabled,
+    /// Same gable profile as [`Roof::Gabled`] but with the eaves overhanging
+    /// the walls (the slopes continue past the wall line and droop below the
+    /// wall top); the vertical gable end-walls stay flush.
     Pitched,
     Hipped,
     Mansard,
@@ -92,6 +93,11 @@ pub(super) struct BuildingCfg {
     pub windows: u32,
     pub skylights: u32,
     pub roof: Roof,
+    /// Horizontal projection of the roof eaves past the perimeter walls, in
+    /// metres. `None` lets the roof kind choose its default (`pitched` → a
+    /// modest overhang, `gabled` → flush). `Some` overrides for any sloped
+    /// roof. Only consumed by the gable/pitched path today.
+    pub roof_overhang: Option<f32>,
     pub ceiling_height: f32,
     pub door_w: f32,
     pub door_h: f32,
@@ -147,6 +153,7 @@ pub(super) fn read_cfg(node: &Node) -> Result<BuildingCfg> {
         Some("shed") => Roof::Shed,
         Some(other) => bail!("unsupported building roof \"{other}\""),
     };
+    let roof_overhang = node.attr_number("roof_overhang").filter(|v| *v >= 0.0);
     let mat_style = attr_str(node, "mat_style").unwrap_or_default();
 
     let floor_area = cfg::scalar(node, "floor_area", 120.0, 4.0);
@@ -236,6 +243,7 @@ pub(super) fn read_cfg(node: &Node) -> Result<BuildingCfg> {
         windows,
         skylights,
         roof,
+        roof_overhang,
         ceiling_height,
         door_w,
         door_h,

--- a/crates/mogen-dsl/src/lower/building/emit/circulation/elevator.rs
+++ b/crates/mogen-dsl/src/lower/building/emit/circulation/elevator.rs
@@ -91,7 +91,6 @@ pub(super) fn emit_elevator(
     );
     emit_elevator_stop_pois(
         cfg,
-        storeys,
         bottom_storey,
         top_storey,
         y_centre,
@@ -106,10 +105,8 @@ pub(super) fn emit_elevator(
 /// stops on that floor. Lets an engine drop its own elevator model and know
 /// each floor's stop height. Anchored at the shaft centre on the storey's
 /// floor surface, facing the (west) shaft door onto the adjacent room.
-#[allow(clippy::too_many_arguments)]
 fn emit_elevator_stop_pois(
     cfg: &BuildingCfg,
-    storeys: &[StoreyPlate],
     bottom_storey: i32,
     top_storey: i32,
     y_centre: f32,
@@ -121,11 +118,7 @@ fn emit_elevator_stop_pois(
     // Door is on the west (−X) face; point the marker's +Z forward at it.
     let facing = Quat::from_rotation_arc(Vec3::Z, Vec3::NEG_X);
     let mut markers: Vec<PoiMarker> = Vec::new();
-    for sp in storeys {
-        let s = sp.storey;
-        if s < bottom_storey || s > top_storey {
-            continue;
-        }
+    for s in bottom_storey..=top_storey {
         // Floor surface (world) sits at s*step; the group is centred at
         // y_centre, so the marker's group-local Y is s*step − y_centre.
         let local_y = s as f32 * step - y_centre;

--- a/crates/mogen-dsl/src/lower/building/emit/circulation/elevator.rs
+++ b/crates/mogen-dsl/src/lower/building/emit/circulation/elevator.rs
@@ -17,6 +17,7 @@ use crate::lower::building::config::BuildingCfg;
 use crate::lower::building::emit::openings::elevator_door_z;
 use crate::lower::building::emit::wall_build::wall_with_holes;
 use crate::lower::building::layout::{CellKind, Rect2, StoreyPlate};
+use crate::lower::poi::{emit_poi_group, PoiDebug, PoiMarker};
 
 /// Thickness of the N/E/S solid shaft walls and the per-storey west pieces.
 /// Kept thin to minimise visual weight while still providing a watertight
@@ -88,7 +89,77 @@ pub(super) fn emit_elevator(
         graph,
         &origin,
     );
+    emit_elevator_stop_pois(
+        cfg,
+        storeys,
+        bottom_storey,
+        top_storey,
+        y_centre,
+        shaft_group,
+        graph,
+        &origin,
+    );
     Ok(())
+}
+
+/// One transform-only POI per served storey marking where the elevator cab
+/// stops on that floor. Lets an engine drop its own elevator model and know
+/// each floor's stop height. Anchored at the shaft centre on the storey's
+/// floor surface, facing the (west) shaft door onto the adjacent room.
+#[allow(clippy::too_many_arguments)]
+fn emit_elevator_stop_pois(
+    cfg: &BuildingCfg,
+    storeys: &[StoreyPlate],
+    bottom_storey: i32,
+    top_storey: i32,
+    y_centre: f32,
+    group: NodeId,
+    graph: &mut SceneGraph,
+    origin: &Option<std::path::PathBuf>,
+) {
+    let step = cfg.ceiling_height + cfg.ceiling_thickness;
+    // Door is on the west (−X) face; point the marker's +Z forward at it.
+    let facing = Quat::from_rotation_arc(Vec3::Z, Vec3::NEG_X);
+    let mut markers: Vec<PoiMarker> = Vec::new();
+    for sp in storeys {
+        let s = sp.storey;
+        if s < bottom_storey || s > top_storey {
+            continue;
+        }
+        // Floor surface (world) sits at s*step; the group is centred at
+        // y_centre, so the marker's group-local Y is s*step − y_centre.
+        let local_y = s as f32 * step - y_centre;
+        markers.push(PoiMarker {
+            name_key: "elevator_stop".into(),
+            role: "elevator_stop".into(),
+            tags: vec![
+                "building".into(),
+                "poi".into(),
+                "elevator".into(),
+                "elevator_stop".into(),
+                format!("floor={s}"),
+            ],
+            transform: Transform::from_trs(Vec3::new(0.0, local_y, 0.0), facing, Vec3::ONE),
+            debug: Some(PoiDebug {
+                mat_name: "building_poi_elevator_stop".into(),
+                color: [0.80, 0.25, 0.95],
+                radius: 0.12,
+            }),
+        });
+    }
+    emit_poi_group(
+        graph,
+        group,
+        origin.as_deref(),
+        "elevator_stops",
+        &[
+            "building".into(),
+            "elevator".into(),
+            "points_of_interest".into(),
+        ],
+        cfg.debug_show_poi,
+        markers,
+    );
 }
 
 /// Per-storey west wall pieces for the elevator. Each piece is one

--- a/crates/mogen-dsl/src/lower/building/emit/circulation/stairs.rs
+++ b/crates/mogen-dsl/src/lower/building/emit/circulation/stairs.rs
@@ -14,6 +14,7 @@ use crate::ast::Node;
 use crate::lower::building::circulation::{CirculationCell, STAIR_ENTRY_DEPTH, STAIR_LANDING_DEPTH};
 use crate::lower::building::config::BuildingCfg;
 use crate::lower::building::layout::StoreyPlate;
+use crate::lower::poi::{emit_poi_group, PoiDebug, PoiMarker};
 use crate::module::expand_modules;
 
 /// Target riser height in metres. Used for step-count calculations in both
@@ -211,7 +212,67 @@ pub(super) fn emit_staircase(
     emit_shaft_enclosure(
         cell_w, cell_d, total_h, adj_n, adj_e, adj_s, enclosure, graph, &origin,
     );
+
+    emit_stair_access_pois(cfg, cell_d, bottom_storey, top_storey, step_h, stair_group, graph, &origin);
     Ok(())
+}
+
+/// One transform-only POI per storey marking where the staircase meets each
+/// floor — the south entry/exit platform that every storey's slab preserves.
+/// Lets an engine drop its own stair model and know each floor's access point.
+/// Faces the (west) shaft door onto the adjacent room.
+#[allow(clippy::too_many_arguments)]
+fn emit_stair_access_pois(
+    cfg: &BuildingCfg,
+    cell_d: f32,
+    bottom_storey: i32,
+    top_storey: i32,
+    step_h: f32,
+    group: NodeId,
+    graph: &mut SceneGraph,
+    origin: &Option<std::path::PathBuf>,
+) {
+    // Centre of the south entry platform in the stair group's local frame
+    // (the group is centred on the cell in XZ, with Y = 0).
+    let entry_z = -0.5 * cell_d + 0.5 * STAIR_ENTRY_DEPTH;
+    let facing = Quat::from_rotation_arc(Vec3::Z, Vec3::NEG_X);
+    let mut markers: Vec<PoiMarker> = Vec::new();
+    for s in bottom_storey..=top_storey {
+        markers.push(PoiMarker {
+            name_key: "stair_access".into(),
+            role: "stair_access".into(),
+            tags: vec![
+                "building".into(),
+                "poi".into(),
+                "staircase".into(),
+                "stair_access".into(),
+                format!("floor={s}"),
+            ],
+            transform: Transform::from_trs(
+                Vec3::new(0.0, s as f32 * step_h, entry_z),
+                facing,
+                Vec3::ONE,
+            ),
+            debug: Some(PoiDebug {
+                mat_name: "building_poi_stair_access".into(),
+                color: [0.30, 0.90, 0.45],
+                radius: 0.12,
+            }),
+        });
+    }
+    emit_poi_group(
+        graph,
+        group,
+        origin.as_deref(),
+        "stair_access_pois",
+        &[
+            "building".into(),
+            "staircase".into(),
+            "points_of_interest".into(),
+        ],
+        cfg.debug_show_poi,
+        markers,
+    );
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/mogen-dsl/src/lower/building/emit/circulation/stairs.rs
+++ b/crates/mogen-dsl/src/lower/building/emit/circulation/stairs.rs
@@ -213,7 +213,9 @@ pub(super) fn emit_staircase(
         cell_w, cell_d, total_h, adj_n, adj_e, adj_s, enclosure, graph, &origin,
     );
 
-    emit_stair_access_pois(cfg, cell_d, bottom_storey, top_storey, step_h, stair_group, graph, &origin);
+    emit_stair_access_pois(
+        cfg, cell_d, bottom_storey, top_storey, step_h, stair_group, graph, &origin,
+    );
     Ok(())
 }
 

--- a/crates/mogen-dsl/src/lower/building/emit/roof.rs
+++ b/crates/mogen-dsl/src/lower/building/emit/roof.rs
@@ -32,6 +32,13 @@ use super::StoreyCtx;
 /// tweak can land as a separate attr if authoring demand appears.
 const DEFAULT_PITCH_DEG: f32 = 30.0;
 
+/// Horizontal projection of `pitched` roof eaves past the perimeter walls.
+/// `gabled` stays flush to the walls (overhang 0); `pitched` continues the
+/// slope planes outward by this much on all sides — the classic
+/// eaves-overhang house silhouette. The ridge height is unchanged; the eaves
+/// extend out and droop below the wall top by `overhang * tan(pitch)`.
+const EAVE_OVERHANG: f32 = 0.4;
+
 pub(super) fn emit_roof(
     node: &Node,
     cfg: &BuildingCfg,
@@ -82,15 +89,26 @@ pub(super) fn emit_roof(
     match cfg.roof {
         Roof::Flat => unreachable!(),
         Roof::Shed => emit_shed(roof_group, graph, &origin, w, d, roof_h)?,
-        Roof::Pitched | Roof::Gabled => emit_gabled(
-            roof_group,
-            graph,
-            &origin,
-            w,
-            d,
-            roof_h,
-            cfg.wall_thickness,
-        )?,
+        Roof::Gabled | Roof::Pitched => {
+            // `roof_overhang` overrides the per-kind default: `pitched` is
+            // "gabled with overhanging eaves", `gabled` is flush.
+            let default_overhang = match cfg.roof {
+                Roof::Pitched => EAVE_OVERHANG,
+                _ => 0.0,
+            };
+            let overhang = cfg.roof_overhang.unwrap_or(default_overhang).max(0.0);
+            emit_gabled(
+                roof_group,
+                graph,
+                &origin,
+                w,
+                d,
+                roof_h,
+                cfg.wall_thickness,
+                overhang,
+                pitch,
+            )?
+        }
         Roof::Hipped => emit_hipped(roof_group, graph, &origin, w, d, roof_h)?,
         Roof::Mansard => emit_mansard(roof_group, graph, &origin, w, d, pitch)?,
     }
@@ -118,6 +136,13 @@ fn emit_shed(
 /// footprint is square the ridge defaults to the X axis (the wider /
 /// equal-length axis comes first alphabetically — keeps the gabled house
 /// example reproducible).
+///
+/// `overhang` projects the eaves outward past the perimeter walls on every
+/// side (the `pitched` variant; `gabled` passes 0). The slope planes are
+/// continued at the same `pitch`, so the ridge height is unchanged and the
+/// eaves droop below the wall top by `overhang * tan(pitch)`. The gable
+/// end-walls stay on the actual wall line (`x = ±w/2`), with the slopes
+/// overhanging them as a rake.
 fn emit_gabled(
     parent: NodeId,
     graph: &mut SceneGraph,
@@ -126,7 +151,19 @@ fn emit_gabled(
     d: f32,
     h: f32,
     wall_thickness: f32,
+    overhang: f32,
+    pitch: f32,
 ) -> Result<()> {
+    // Eave footprint = wall footprint grown by the overhang on each side.
+    // `drop` is how far the eave plane falls below the wall top to keep the
+    // slope continuous; the wedge gains that height so the ridge stays put.
+    let drop = overhang * pitch.tan();
+    let w_eave = w + 2.0 * overhang;
+    let d_eave = d + 2.0 * overhang;
+    let wedge_h = h + drop;
+    // Wedge-centre Y: lifts the wedge so its base (eave plane) lands at
+    // y = -drop. With overhang 0 this is the original 0.5*h (flush gable).
+    let eave_y = 0.5 * wedge_h - drop;
     // Ridge runs along the longer axis. Two wedges face each other across
     // the ridge — each is half-width on the short axis and sits over its
     // half of the footprint.
@@ -143,7 +180,7 @@ fn emit_gabled(
         //    ridge (z=0) — exactly the default wedge orientation, no rotation.
         //  - South half (z ∈ [-d/2, 0]): slope rises from south-eave (low z) to
         //    ridge — mirror the wedge along Z by rotating 180° around Y.
-        let wedge = [w, h, 0.5 * d];
+        let wedge = [w_eave, wedge_h, 0.5 * d_eave];
         let rot_north = Quat::IDENTITY;
         let rot_south = Quat::from_rotation_y(std::f32::consts::PI);
         (wedge, rot_south, rot_north, AxisAlong::X)
@@ -153,7 +190,7 @@ fn emit_gabled(
         //  - East half (x ∈ [0, w/2]): rotate -90° around Y so default +Z body
         //    swings to +X, slope rising from east-eave to ridge.
         //  - West half: rotate +90° around Y for the mirror.
-        let wedge = [d, h, 0.5 * w];
+        let wedge = [d_eave, wedge_h, 0.5 * w_eave];
         let rot_east = Quat::from_rotation_y(-std::f32::consts::FRAC_PI_2);
         let rot_west = Quat::from_rotation_y(std::f32::consts::FRAC_PI_2);
         (wedge, rot_west, rot_east, AxisAlong::Z)
@@ -162,13 +199,13 @@ fn emit_gabled(
     // Position the two wedges centred on their half-footprints.
     let (left_offset, right_offset) = match gable_axis {
         AxisAlong::X => (
-            // Left = negative Z half, centre at z = -d/4.
-            Vec3::new(0.0, 0.5 * h, -0.25 * d),
-            Vec3::new(0.0, 0.5 * h, 0.25 * d),
+            // Left = negative Z half, centre at z = -d_eave/4.
+            Vec3::new(0.0, eave_y, -0.25 * d_eave),
+            Vec3::new(0.0, eave_y, 0.25 * d_eave),
         ),
         AxisAlong::Z => (
-            Vec3::new(-0.25 * w, 0.5 * h, 0.0),
-            Vec3::new(0.25 * w, 0.5 * h, 0.0),
+            Vec3::new(-0.25 * w_eave, eave_y, 0.0),
+            Vec3::new(0.25 * w_eave, eave_y, 0.0),
         ),
     };
 
@@ -197,25 +234,34 @@ fn emit_gabled(
         slope_rot_right,
     );
 
-    // Gable end walls: triangular extrusions flush with the perimeter
-    // walls on the short axis. The contour is built in XZ (the extrude
-    // pipeline's natural plane) with the apex at Z=h; we then rotate it
-    // up via -90° around X so the apex ends up at +Y. For ridge_along_z
-    // we additionally rotate 90° around Y to swap the gable into the
-    // perpendicular plane.
+    // Gable end walls: triangular extrusions that cap the two ends of the
+    // ridge, flush with the perimeter walls perpendicular to the ridge. The
+    // contour is built in XZ (the extrude pipeline's natural plane) with the
+    // apex at Z=h; we then rotate it up via -90° around X so the apex ends up
+    // at +Y. For ridge_along_x the gable plane faces ±X, so we additionally
+    // rotate 90° around Y to swap the gable into the perpendicular plane; for
+    // ridge_along_z the up-rotated triangle already faces ±Z.
+    // With overhang the gable wall sits fully beneath the solid slope, so its
+    // slanted top faces are coplanar with the roof's outer slope surface and
+    // z-fight (a stitched line along the rake). Drop it a hair so those faces
+    // recede inside the solid wedge that backs them — no z-fight, and no hole
+    // because the wedge fills the sliver above. Flush gables (overhang 0)
+    // straddle the wedge's own end cap and need no tuck.
+    let gable_tuck = if overhang > 0.0 { 0.04 } else { 0.0 };
+    let gy = -gable_tuck;
     let up = Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2);
     let (gable_pos_a, gable_pos_b, gable_rot, gable_width) = match gable_axis {
         AxisAlong::X => (
-            Vec3::new(0.0, 0.0, 0.5 * d),
-            Vec3::new(0.0, 0.0, -0.5 * d),
-            up,
-            w,
-        ),
-        AxisAlong::Z => (
-            Vec3::new(0.5 * w, 0.0, 0.0),
-            Vec3::new(-0.5 * w, 0.0, 0.0),
+            Vec3::new(0.5 * w, gy, 0.0),
+            Vec3::new(-0.5 * w, gy, 0.0),
             Quat::from_rotation_y(std::f32::consts::FRAC_PI_2) * up,
             d,
+        ),
+        AxisAlong::Z => (
+            Vec3::new(0.0, gy, 0.5 * d),
+            Vec3::new(0.0, gy, -0.5 * d),
+            up,
+            w,
         ),
     };
     let triangle = gable_triangle(gable_width, h);

--- a/crates/mogen-dsl/src/lower/building/emit/shell.rs
+++ b/crates/mogen-dsl/src/lower/building/emit/shell.rs
@@ -144,38 +144,32 @@ fn emit_slab(
     let mesh = if holes_xz.is_empty() {
         base
     } else {
-        // The cutout is padded PER AXIS to avoid two failure modes at once:
+        // The cutout is inflated by a tiny epsilon on every XY edge — just
+        // enough to avoid coplanar-face artefacts in the CSG difference —
+        // and never more, so the cutout stops at the cell boundary.
         //
-        // 1. On axes where the hole touches the floorplate bounds (e.g. a
-        //    staircase in the east-side circulation column has its east
-        //    edge flush with `bounds.x_max`), the cutout must extend
-        //    through the perimeter wall thickness so the resulting slab
-        //    shows a clean U-shaped opening rather than a coplanar-face
-        //    sliver of intact slab clinging to the wall.
-        // 2. On interior axes the cutout must NOT inflate the hole, or
-        //    the slab loses a visible strip outside the actual cell —
-        //    e.g. the staircase entry strip narrows by `pad_xy`, leaving
-        //    a horizontal gap where neither the slab nor the top stair
-        //    tread is present at the user-facing y.
-        //
-        // The vertical inflation is small and symmetric so the cutout
-        // pokes through the top and bottom of the slab regardless.
+        // Crucially we must NOT extend the cutout outward through the
+        // perimeter wall thickness, even when a hole edge is flush with the
+        // floorplate bounds (e.g. the east-column staircase, whose east edge
+        // sits on `bounds.x_max` — the interior face of the east wall). The
+        // slab footprint runs a wall-thickness past `bounds` so its rim sits
+        // under the perimeter walls; that under-wall strip is the only thing
+        // bridging the gap between one storey's wall and the next, so its
+        // exposed edge is what seals the exterior envelope at each floor
+        // division. Punching the cutout through it (the old `exit_pad`)
+        // removed that strip wherever a stair/elevator touched a wall,
+        // opening a ceiling_thickness-tall hole straight through the
+        // building's outer shell — visible as a gap in the floor-line band.
+        // The strip is hidden behind the perimeter wall from inside the
+        // shaft, so keeping it costs nothing and keeps the shell watertight.
         let eps = 1e-3f32;
-        let exit_pad = wt + 0.01;
-        let bound_pad = |hole_edge: f32, slab_edge: f32| -> f32 {
-            if (hole_edge - slab_edge).abs() <= eps {
-                exit_pad
-            } else {
-                eps
-            }
-        };
         let cutouts: Vec<Mesh> = holes_xz
             .iter()
             .map(|r| {
-                let pad_xmin = bound_pad(r.x_min, bounds.x_min);
-                let pad_xmax = bound_pad(r.x_max, bounds.x_max);
-                let pad_zmin = bound_pad(r.z_min, bounds.z_min);
-                let pad_zmax = bound_pad(r.z_max, bounds.z_max);
+                let pad_xmin = eps;
+                let pad_xmax = eps;
+                let pad_zmin = eps;
+                let pad_zmax = eps;
                 let hw = (r.width() + pad_xmin + pad_xmax).max(1e-4);
                 let hd = (r.depth() + pad_zmin + pad_zmax).max(1e-4);
                 let hcx = 0.5 * ((r.x_min - pad_xmin) + (r.x_max + pad_xmax)) - cx;

--- a/crates/mogen-dsl/src/lower/building/layout/score.rs
+++ b/crates/mogen-dsl/src/lower/building/layout/score.rs
@@ -243,6 +243,7 @@ mod tests {
             windows: 0,
             skylights: 0,
             roof: Roof::Flat,
+            roof_overhang: None,
             ceiling_height: 2.6,
             door_w: 0.9,
             door_h: 2.1,

--- a/crates/mogen-dsl/src/lower/building/tests/multi_storey.rs
+++ b/crates/mogen-dsl/src/lower/building/tests/multi_storey.rs
@@ -1028,3 +1028,83 @@ fn debug_render_floor_isolates_a_single_storey() {
         wrapper.tags
     );
 }
+
+#[test]
+fn staircase_emits_one_access_poi_per_storey() {
+    let g = lower_src(MULTI_FLOOR_SRC);
+    // 3 storeys (b1, 0, 1) → one stair_access marker each.
+    let access = super::count_role(&g, "stair_access");
+    assert_eq!(
+        access, 3,
+        "expected one stair_access POI per storey, got {access}"
+    );
+    // Each marker is geometry-free and carries its signed floor index.
+    for n in g.nodes.iter().filter(|n| n.role.as_deref() == Some("stair_access")) {
+        assert_eq!(n.kind, "poi", "stair_access marker should be a poi node");
+        assert!(n.mesh.is_none(), "stair_access POI must stay geometry-free");
+        assert!(
+            n.tags.iter().any(|t| t.starts_with("floor=")),
+            "stair_access POI should carry a floor=<n> tag, got {:?}",
+            n.tags
+        );
+    }
+}
+
+#[test]
+fn elevator_emits_one_stop_poi_per_storey() {
+    let g = lower_src(MULTI_FLOOR_SRC);
+    // 3 served storeys (b1, 0, 1) → one elevator_stop marker each.
+    let stops = super::count_role(&g, "elevator_stop");
+    assert_eq!(
+        stops, 3,
+        "expected one elevator_stop POI per served storey, got {stops}"
+    );
+    for n in g.nodes.iter().filter(|n| n.role.as_deref() == Some("elevator_stop")) {
+        assert_eq!(n.kind, "poi", "elevator_stop marker should be a poi node");
+        assert!(n.mesh.is_none(), "elevator_stop POI must stay geometry-free");
+        assert!(
+            n.tags.iter().any(|t| t.starts_with("floor=")),
+            "elevator_stop POI should carry a floor=<n> tag, got {:?}",
+            n.tags
+        );
+    }
+}
+
+#[test]
+fn circulation_pois_land_on_floor_surfaces() {
+    // Both stair-access and elevator-stop markers should resolve to the
+    // floor datum of their storey (world Y = storey * step). The markers
+    // are nested under group transforms, so accumulate ancestor Y.
+    let g = lower_src(MULTI_FLOOR_SRC);
+    let step = 2.6 + 0.2; // ceiling_height + ceiling_thickness defaults.
+    let world_y = |mut idx: usize| -> f32 {
+        let mut y = 0.0;
+        loop {
+            y += g.nodes[idx].transform.translation.y;
+            match g.nodes[idx].parent {
+                Some(p) => idx = p.0 as usize,
+                None => break,
+            }
+        }
+        y
+    };
+    for (i, n) in g.nodes.iter().enumerate() {
+        let role = n.role.as_deref();
+        if role != Some("stair_access") && role != Some("elevator_stop") {
+            continue;
+        }
+        let floor: i32 = n
+            .tags
+            .iter()
+            .find_map(|t| t.strip_prefix("floor="))
+            .and_then(|s| s.parse().ok())
+            .expect("circulation POI missing floor=<n> tag");
+        let expected = floor as f32 * step;
+        let got = world_y(i);
+        assert!(
+            (got - expected).abs() < 1e-3,
+            "{:?} on floor {floor} should sit at world y={expected}, got {got}",
+            n.name
+        );
+    }
+}

--- a/crates/mogen-dsl/src/lower/building/tests/roof_and_cellar.rs
+++ b/crates/mogen-dsl/src/lower/building/tests/roof_and_cellar.rs
@@ -1,6 +1,20 @@
 use super::{count_kind, count_role, has_tag, lower_src, slab_ceiling_count, ROOFTEST_SRC};
 use mogen_core::SceneGraph;
 
+/// Max absolute XZ coordinate across all roof-slope mesh vertices (local
+/// frame, but slope nodes are only translated — not rotated about Y for
+/// ridge_along_x — so local X directly equals world X for that case).
+/// Used to compare overhang extent between `gabled` and `pitched`.
+fn max_slope_vertex_abs(g: &SceneGraph) -> f32 {
+    g.nodes
+        .iter()
+        .filter(|n| n.role.as_deref() == Some("roof"))
+        .filter_map(|n| n.mesh.as_ref())
+        .flat_map(|m| m.positions.iter())
+        .map(|p| p[0].abs().max(p[2].abs()))
+        .fold(0.0_f32, f32::max)
+}
+
 #[test]
 fn building_roof_gabled_smoke() {
     let src = ROOFTEST_SRC.replace("ROOFKIND", "gabled");
@@ -20,6 +34,48 @@ fn building_roof_gabled_smoke() {
         slab_ceiling_count(&g),
         0,
         "non-flat roof must not emit a top-storey ceiling slab"
+    );
+}
+
+#[test]
+fn pitched_roof_wedge_wider_than_gabled() {
+    // `pitched` defaults to EAVE_OVERHANG (0.4 m) past the perimeter walls;
+    // `gabled` is flush. The slope meshes must be measurably wider.
+    let gabled_ext = max_slope_vertex_abs(&lower_src(&ROOFTEST_SRC.replace("ROOFKIND", "gabled")));
+    let pitched_ext = max_slope_vertex_abs(&lower_src(&ROOFTEST_SRC.replace("ROOFKIND", "pitched")));
+    assert!(
+        pitched_ext > gabled_ext + 0.2,
+        "pitched slope ({pitched_ext:.3}) should extend past gabled ({gabled_ext:.3}) by ≥ 0.2 m"
+    );
+}
+
+#[test]
+fn roof_overhang_zero_forces_flush_pitched_roof() {
+    // `roof_overhang=0` on a `pitched` roof must override the default and
+    // produce the same slope extent as a plain `gabled` roof.
+    let gabled_ext = max_slope_vertex_abs(&lower_src(&ROOFTEST_SRC.replace("ROOFKIND", "gabled")));
+    let flush_src = ROOFTEST_SRC
+        .replace("ROOFKIND", "pitched")
+        .replace("roof=\"pitched\"", "roof=\"pitched\", roof_overhang=0");
+    let flush_ext = max_slope_vertex_abs(&lower_src(&flush_src));
+    assert!(
+        (flush_ext - gabled_ext).abs() < 1e-3,
+        "pitched with roof_overhang=0 ({flush_ext:.3}) must match gabled flush extent ({gabled_ext:.3})"
+    );
+}
+
+#[test]
+fn roof_overhang_applies_to_gabled_roof() {
+    // An explicit `roof_overhang` on a `gabled` roof (which defaults to 0)
+    // must widen the slopes by the specified amount.
+    let flush_ext = max_slope_vertex_abs(&lower_src(&ROOFTEST_SRC.replace("ROOFKIND", "gabled")));
+    let wide_src = ROOFTEST_SRC
+        .replace("ROOFKIND", "gabled")
+        .replace("roof=\"gabled\"", "roof=\"gabled\", roof_overhang=0.6");
+    let wide_ext = max_slope_vertex_abs(&lower_src(&wide_src));
+    assert!(
+        wide_ext > flush_ext + 0.4,
+        "gabled with roof_overhang=0.6 ({wide_ext:.3}) should extend past flush ({flush_ext:.3}) by ≥ 0.4 m"
     );
 }
 

--- a/crates/mogen-dsl/src/proc_schema.rs
+++ b/crates/mogen-dsl/src/proc_schema.rs
@@ -193,8 +193,8 @@ static BUILDING: ProcSchema = ProcSchema {
                 default: "flat",
                 options: &[
                     EnumOption { value: "flat", help: "Flat slab roof" },
-                    EnumOption { value: "gabled", help: "Two slopes meeting at a ridge" },
-                    EnumOption { value: "pitched", help: "Synonym of gabled (axis-aligned)" },
+                    EnumOption { value: "gabled", help: "Two slopes meeting at a ridge, eaves flush with the walls" },
+                    EnumOption { value: "pitched", help: "Gable with eaves overhanging the walls" },
                     EnumOption { value: "hipped", help: "Slopes on all four sides" },
                     EnumOption { value: "mansard", help: "Double-slope (steep lower) roof" },
                     EnumOption { value: "shed", help: "Single slope (lean-to)" },
@@ -202,6 +202,16 @@ static BUILDING: ProcSchema = ProcSchema {
             },
             group: Main,
             help: None,
+        },
+        ParamSpec {
+            attr: "roof_overhang",
+            label: "Roof overhang",
+            kind: ParamKind::Scalar { default: 0.0, speed: 0.01 },
+            group: Main,
+            help: Some(
+                "Eaves projection past the walls (m) for gabled/pitched roofs. \
+                 0 = flush; pitched defaults to a modest overhang when unset.",
+            ),
         },
         scalar("floor_area", "Floor area m\u{00b2}", 120.0, 1.0),
         int("rooms", "Rooms", 4, 1, 256),
@@ -256,7 +266,8 @@ static BUILDING: ProcSchema = ProcSchema {
             kind: ParamKind::Bool { default: false },
             group: Debug,
             help: Some(
-                "Give every furnishing POI marker a small bright sphere so the \
+                "Give every POI marker (furniture, openings, and per-floor \
+                 stair / elevator anchors) a small bright sphere so the \
                  otherwise geometry-free markers are visible in the preview.",
             ),
         },

--- a/docs/building.md
+++ b/docs/building.md
@@ -74,6 +74,7 @@ building "house" (
 | `windows` | `0` | int ≥ 0 | Total above-ground window count; the layout picks exterior wall edges and assigns a size class per window. |
 | `skylights` | `0` | int ≥ 0 | Top-floor ceiling holes. |
 | `roof` | `"flat"` | enum | `flat`, `pitched`, `gabled`, `hipped`, `mansard`, `shed`. |
+| `roof_overhang` | _unset_ | m | Eaves projection past the perimeter walls for `gabled`/`pitched`. Unset lets the kind choose: `gabled` flush (0), `pitched` a modest default. Set to override either (e.g. `roof_overhang=0` on a pitched roof, or a wide overhang on a gabled one). |
 | `ceiling_height` | `2.6` | m | Per-storey clear height. |
 | `door_w`, `door_h` | `0.9, 2.1` | m | Internal door opening size. External doors reuse the same dimensions in v1. |
 | `window_w`, `window_h` | `1.2, 1.4` | m | Window opening size (medium class). Small = 0.6×size, large = 1.4×size. |
@@ -87,7 +88,7 @@ building "house" (
 | `elevators` | `0` | int ≥ 0 | Vertical shafts spanning every storey. |
 | `staircases` | `0` | int ≥ 0 | Stairwells spanning adjacent storeys (≥1 if `floors_above + floors_below > 1`). |
 | `furnish` | `1` | bool (0/1) | Emit furnishing POI markers in each room (see [Furnishing markers](#furnishing-markers)). `0` leaves rooms as bare shells. Markers carry no geometry either way. |
-| `debug_show_poi` | `0` | bool (0/1) | Debug: give every furnishing and door/window marker a small emissive sphere so the geometry-free POIs are visible in a glTF viewer, colour-coded by category/role. |
+| `debug_show_poi` | `0` | bool (0/1) | Debug: give every furnishing, door/window, and per-floor stair/elevator marker a small emissive sphere so the geometry-free POIs are visible in a glTF viewer, colour-coded by category/role. |
 | `debug_hide_roof` | `0` | bool (0/1) | Debug: drop the top-storey ceiling slab (and its skylights) so the interior can be seen from above. |
 | `debug_render_floor` | _unset_ | signed int storey | Debug: render only the given storey index (`0` = ground, `1..` = upper, `-1..` = basement). The rendered floor gets no ceiling and vertical circulation is skipped. |
 
@@ -153,8 +154,16 @@ name (building)                       editable wrapper
     │   ├── door_0 (poi)              role=door, geometry-free
     │   └── window_0 (poi)            role=window, geometry-free
     └── circulation (group)
-        ├── stair_<n> (group)
+        ├── staircase_<n> (group)
+        │   ├── … flights / landings / shaft_walls
+        │   └── stair_access_pois (group)   per-floor stair POI markers
+        │       ├── stair_access_0 (poi)    role=stair_access, tag floor=<n>
+        │       └── …
         └── elevator_<n> (group)
+            ├── … shaft walls / per-storey west pieces
+            └── elevator_stops (group)      per-floor elevator POI markers
+                ├── elevator_stop_0 (poi)   role=elevator_stop, tag floor=<n>
+                └── …
 └── roof (group)                      style-driven; top-floor ceiling becomes roof
 ```
 
@@ -277,6 +286,40 @@ interior doors yellow, windows cyan). Skylights keep their existing
 `extras.slot` wrapper and are not given a POI marker. The opening's
 width/height still live on the module-instance group's `slot` block; the POI
 carries pose + role only, matching the furnishing-marker contract.
+
+## Stair & elevator POIs
+
+Vertical circulation is modelled as generic geometry (switchback flights, shaft
+walls, per-storey doors), but a game usually wants its *own* stairwell and
+elevator models. So each circulation cell also drops a **per-floor** set of
+points-of-interest — the same transform-only contract as the markers above —
+naming where every storey connects:
+
+- **Staircase** — a `stair_access_pois` group under `staircase_<n>`, with one
+  `stair_access` marker per storey (`bottom..=top`). Each sits at that floor's
+  south entry/exit platform (the intact strip of slab every storey preserves)
+  on the floor surface, facing the shaft door. Drop your own stair model and
+  use these to know where the run meets each floor.
+- **Elevator** — an `elevator_stops` group under `elevator_<n>`, with one
+  `elevator_stop` marker per served storey. Each is anchored at the shaft centre
+  on that floor's surface, facing the (west) shaft door — i.e. exactly **where
+  the cab should stop** and where the doors open. Place your own elevator model
+  at the bottom and drive it between these stop heights.
+
+Each marker is:
+
+- `kind = "poi"`, with **no mesh and no collider** by default;
+- `role` = `stair_access` or `elevator_stop`;
+- `tags` = `["building", "poi", "staircase", "stair_access", "floor=<n>"]` /
+  `["building", "poi", "elevator", "elevator_stop", "floor=<n>"]` — the
+  `floor=<n>` tag carries the signed storey index (basements negative) so an
+  importer can match a model to the right level without arithmetic;
+- a transform giving the floor-level pose with local **+Z** facing the shaft
+  door, matching the opening-marker convention.
+
+Like the other POIs these are always emitted (here gated only by the
+`staircases=` / `elevators=` counts) and stay geometry-free; `debug_show_poi=1`
+gives them a bright sphere (stair access green, elevator stops magenta).
 
 ---
 
@@ -430,7 +473,8 @@ in v1.
 | `roof=` | construction |
 |---|---|
 | `shed` | one `wedge_mesh` spanning the whole footprint, sloping south→north |
-| `pitched` / `gabled` | two `wedge_mesh` halves meeting at a ridge along the longer axis, plus two triangular end-walls extruded from `extrude_mesh` flush with the perimeter walls. `pitched` is a synonym of `gabled` in v1 — sloped end-faces would require non-axis-aligned vertices we have no representation for |
+| `gabled` | two `wedge_mesh` halves meeting at a ridge along the longer axis, plus two triangular end-walls extruded from `extrude_mesh` flush with the perimeter walls |
+| `pitched` | same gable profile as `gabled`, but the slope planes are continued past the wall line so the eaves overhang on all sides (and droop below the wall top by `overhang * tan(pitch)`). The ridge height is unchanged and the vertical gable end-walls stay flush; the slopes overhang them as a rake |
 | `hipped` | one `frustum_mesh` whose top edge collapses to an apex (square footprint) or a ridge along the longer axis (rectangular footprint) — four slopes from a single watertight mesh |
 | `mansard` | two stacked frustums: a steep ~60° lower tier and a shallow upper tier tapering to a short ridge (Second Empire profile) |
 

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -477,7 +477,8 @@ spec, supported styles/roof shapes, and tranche status.
 | `floors_below` | `0` | Basement storeys. |
 | `windows` | `0` | Total above-ground window count; distributed across above-ground storeys. Basements get none. |
 | `skylights` | `0` | Top-storey ceiling cutouts. |
-| `roof` | `"flat"` | Roof shape; T1-T2 only supports `flat`. |
+| `roof` | `"flat"` | Roof shape: `flat`, `pitched`, `gabled`, `hipped`, `mansard`, `shed`. |
+| `roof_overhang` | _unset_ | Eaves projection past the walls (m) for `gabled`/`pitched`. Unset → `gabled` flush, `pitched` modest default. |
 | `ceiling_height` | `2.6` | Clear height per storey (m). |
 | `door_w`, `door_h` | `0.9, 2.1` | Door opening dimensions (m). |
 | `window_w`, `window_h` | `1.2, 1.4` | Window opening dimensions (m, medium class). Small = ×0.6, large = ×1.4. |
@@ -515,6 +516,18 @@ building "house" (seed=4, style="apartment-block",
   adjacency "kitchen"  (adjacent_to=["living"])
 }
 ```
+
+Beyond geometry, `building` embeds **points of interest** as empty marker
+nodes (`role`/`tags` in glTF extras) so an engine can place its own content:
+`entrance` / `door` / `window` opening slots, per-room furniture markers when
+`furnish=1` (`bed`, `desk`, …), and per-floor **vertical-circulation** anchors
+— `stair_access` (one per storey, at each floor's stair entry platform) and
+`elevator_stop` (one per served storey, anchored at the shaft centre on the
+floor surface where the cab stops). Each circulation marker faces its shaft
+door and carries a `floor=<n>` tag, so you can drop your own stairwell /
+elevator models knowing exactly where each floor connects. `debug_show_poi=1`
+gives every marker a small bright `building_poi_<role>` sphere so the
+otherwise geometry-free anchors show in a preview.
 
 ### Cave
 

--- a/examples/procgen/building_in_terrain.mog
+++ b/examples/procgen/building_in_terrain.mog
@@ -1,0 +1,109 @@
+// Walkable terrain with a building dropped into a hole cut to its exact
+// footprint: you can roam the terrain, step in the front door, and take the
+// stairs down to a basement that sits *below* ground level without the terrain
+// surface ever showing through the floor — because the patch has a real void
+// punched where the building stands.
+//
+// The trick is making the void's rim coincide with the building's outer walls
+// so there is neither a gap (a moat you could see down into) nor an overhang
+// (terrain poking up inside the basement). Two facts make that exact:
+//
+//   1. A `building` footprint is a pure function of its inputs. The outer plate
+//      is  (w + 2*wall_thickness) x (d + 2*wall_thickness)  centred on `pos`,
+//      where the layout solver picks a sqrt(2) aspect:
+//          d = sqrt(floor_area / sqrt(2)),   w = sqrt(floor_area * sqrt(2)).
+//      With floor_area=120 and wall_thickness=0.2 that is an outer plate of
+//      13.42711 x 9.611559 m, i.e. walls at  x = +-6.713556,  z = +-4.805779.
+//
+//   2. `terrain` carves a `hole` by dropping every grid cell whose *centre*
+//      lands inside the footprint, so the void edge always falls on a terrain
+//      grid line. We therefore size the patch so a grid line lands exactly on
+//      each wall: the grid is `resolution` cells across `size`, so we pick
+//          size_x = wall_x / 16 * resolution     (a grid line 16 cells out)
+//          size_z = wall_z / 12 * resolution     (a grid line 12 cells out)
+//      and set the hole to the building's outer plate.
+//
+//      The cell counts (16, 12) are *multiples of 4* on purpose. A coarser LOD
+//      samples the grid at stride 2^level, and a cell is dropped only when its
+//      (now coarser) centre lands inside the footprint. If a wall sat on an odd
+//      grid line, the drop boundary would shift by up to a cell at LOD1/LOD2 —
+//      opening a thin ring gap around the building that appears only at
+//      distance (when a coarse LOD swaps in) and vanishes up close. Making each
+//      wall land on a line divisible by the coarsest stride
+//      `2^(lod_levels-1) = 4` keeps the rim on the wall *identically at every
+//      LOD*, so there is no LOD-swap gap. The patch centre (grid line 60) is
+//      itself a multiple of 4, so `60 +- {16,12}` stays aligned.
+//
+// A noise field is never flat, so a short, wide `road` centred on the plot
+// grades the build pad to a single height (its dirt tint reads as a graded
+// foundation apron) — that is what lets the ground floor meet the grass flush
+// on every side. `pos.y` on the building is then just that pad height.
+
+meta (
+  name = "building_in_terrain",
+  description = "A walkable terrain patch with a basement building set into a hole cut to its exact footprint",
+  tags = ["terrain", "building", "basement", "hole", "procedural", "environment"],
+  mogen_version = "0.1.8")
+
+material "grassland" (color=[0.34, 0.42, 0.24], roughness=0.95)
+material "plaster"   (color=[0.92, 0.91, 0.88], roughness=0.85)
+material "warm_wood" (color=[0.55, 0.38, 0.22], roughness=0.75)
+material "tile"      (color=[0.86, 0.86, 0.83], roughness=0.35)
+material "oak"       (color=[0.62, 0.45, 0.28], roughness=0.70)
+
+// --- the ground ------------------------------------------------------------
+// Gentle rolling relief you can roam; the build pad itself is flattened by the
+// road below. The patch is sized (see header) so grid lines fall exactly on
+// the building's outer walls.
+terrain "ground" (
+  seed=7,
+  size=[50.35167, 5, 48.057795], // width, max height, depth (metres) — see header
+  source="fbm",
+  octaves=3,
+  frequency=0.05,
+  persistence=0.4,
+  resolution=120,               // 120 cells across each axis (multiple of chunks)
+  chunks=6,
+  lod_levels=3,
+  smooth=4,
+  colliders="all",
+  mat="grassland",
+  pos=[0, 0, 0]
+) {
+  // Grade the build pad flat: a stubby, wide road centred on the plot forces
+  // the surrounding cells to one height and blends out over the shoulder.
+  road ( path=[[-2, 0], [2, 0]], width=18, shoulder=8 )
+
+  // Void for the building, cut to its outer plate. cap="open" leaves the
+  // bottom open so the basement plugs straight in; depth clears the basement
+  // floor so no terrain rim wall ever rises into the lower storey.
+  hole ( at=[0, 0], size=[13.42711, 9.611559], depth=8, cap="open" )
+}
+
+// --- the building ----------------------------------------------------------
+// Centred on the hole. floors_below=1 gives a basement; the staircase lets you
+// walk down into it. pos.y is set to the terrain's height at the centre so the
+// ground floor sits flush with the surrounding grass (tuned below).
+building "house" (
+  seed=4,
+  style="apartment-block",
+  floor_area=120,
+  wall_thickness=0.2,
+  rooms=10,
+  floors_above=2,
+  floors_below=1,
+  windows=12,
+  entrances=1,
+  staircases=1,
+  ceiling_height=2.6,
+  roof="pitched",
+  mat="plaster",
+  pos=[0, 1.14, 0] // pad height from the graded road — ground floor sits flush
+) {
+  room_type "bedroom" (kind=private, density=4, mat="warm_wood")
+  room_type "kitchen" (kind=service, density=2, mat="tile")
+  room_type "living"  (kind=public,  density=3, mat="oak")
+  room_type "storage" (kind=utility, density=2, mat="plaster")
+
+  adjacency "kitchen" (adjacent_to=["living"], away_from=["bedroom"])
+}

--- a/examples/procgen/gabled_house.mog
+++ b/examples/procgen/gabled_house.mog
@@ -5,6 +5,8 @@
 // skylight cutouts on non-flat roofs (the validator warns with W1114 if
 // you try).
 
+meta (mogen_version = "0.1.8")
+
 material "warm_wood" (color=[0.55, 0.38, 0.22], roughness=0.85)
 material "plaster"   (color=[0.94, 0.92, 0.88], roughness=0.85)
 material "tile"      (color=[0.90, 0.90, 0.88], roughness=0.40)
@@ -19,7 +21,7 @@ building "gabled_house" (
   entrances=1,
   windows=6,
   ceiling_height=2.6,
-  mat="plaster",
+  mat="plaster", debug_show_poi=1
 ) {
   room_type "bedroom" (kind=private, density=2, mat="warm_wood")
   room_type "living"  (kind=public,  density=2, mat="warm_wood")


### PR DESCRIPTION
## Summary

An all-in-one pass on the `building` generator bundling three related changes:

### Per-floor circulation POIs
Stairwells and elevator shafts now emit one transform-only POI **per floor**, so an engine can drop in its own stairwell/elevator models and know exactly where each floor connects (and, for the elevator, where the cab should stop):
- `stair_access` — one per storey, under `staircase_<n>` → `stair_access_pois`, at each floor's south entry/exit platform.
- `elevator_stop` — one per served storey, under `elevator_<n>` → `elevator_stops`, anchored at the shaft centre on the floor surface.
- Both face the shaft door (local +Z → −X), carry a `floor=<n>` tag (signed; basements negative), stay geometry-free and collider-free, and route through the shared `emit_poi_group` helper. `debug_show_poi=1` gives them a debug sphere (stair access green, elevator stops magenta).

### Roof overhang / real `pitched` roof
- `pitched` is now a true variant of `gabled` with **overhanging eaves**: the slope planes continue past the perimeter walls (ridge height unchanged, eaves droop below the wall top), giving the classic eaves silhouette. `gabled` stays flush.
- New `roof_overhang` attribute (metres) overrides the per-kind default for either roof.
- Gable end-walls are tucked a hair under the slopes when overhanging to avoid z-fighting on the rake.

### Watertight floor slabs
- Floor-slab cutouts for stair/elevator columns no longer punch through the under-wall slab strip when a shaft edge sits flush with the perimeter. That `exit_pad` had opened a `ceiling_thickness`-tall hole straight through the building's outer shell at every floor division (a visible gap in the floor-line band). Cutouts now inflate by only a coplanar-face epsilon.

### Examples & docs
- New `examples/procgen/building_in_terrain.mog`: a basement building set into a `terrain` hole cut to its exact footprint, with notes on keeping the void rim LOD-stable on the walls.
- `gabled_house.mog`: enable POI debug spheres.
- Updated `docs/dsl.md`, `docs/building.md`, and the building `ProcSchema` (new `roof_overhang` param, broadened `debug_show_poi` help, corrected roof enum help).

## Test plan
- [x] `cargo test --workspace` — green (412 dsl-lib tests incl. 3 new circulation-POI tests).
- [x] New tests assert one POI per storey for both kinds, geometry-free + `floor=` tag, and that markers resolve to the correct world floor heights.
- [x] `mogen check` clean on both `building_in_terrain.mog` (577 nodes) and `gabled_house.mog` (167 nodes).
- [ ] Visual spot-check of the pitched-roof overhang and basement-in-terrain seam in Studio / a glTF viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)