### PR TITLE
Fix cave rock UV shearing with per-triangle triplanar projection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "mogen"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-anim"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "glam 0.30.10",
  "mogen-core",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "glam 0.30.10",
  "serde",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-dsl"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "glam 0.30.10",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-export"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "fbxcel",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-geom"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "earcutr",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-llm"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-moghub-client"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "mogen-registry",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-registry"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "mogen-core",
@@ -2780,7 +2780,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-render"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "glam 0.30.10",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-studio"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "arboard",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-update"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2843,7 +2843,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-validate"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "codespan-reporting 0.12.0",
  "mogen-core",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "mogen-wasm"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 
 [workspace.dependencies]

--- a/crates/mogen-dsl/src/lower/cave/emit.rs
+++ b/crates/mogen-dsl/src/lower/cave/emit.rs
@@ -169,28 +169,70 @@ fn bind_rock_material(id: NodeId, origin: Option<&std::path::Path>, graph: &mut 
 /// projects onto, giving consistent stone detail at any block size.
 const ROCK_UV_TILE: f32 = 5.0;
 
-/// Recompute the rock's UVs with a per-vertex triplanar projection: each vertex
-/// projects onto the world plane its normal most faces (XZ for floors/ceilings,
-/// XY or ZY for walls), scaled so the texture tiles every `tile` metres. This
-/// replaces the flat XZ planar UVs that stretch vertically on cavity walls.
+/// Recompute the rock's UVs with a per-*triangle* triplanar projection: each
+/// face projects all three of its vertices onto the world plane its geometric
+/// normal most faces (XZ for floors/ceilings, XY or ZY for walls), scaled so
+/// the texture tiles every `tile` metres.
+///
+/// The plane is chosen once per triangle (from the face normal) rather than
+/// per vertex. A per-vertex choice lets a single triangle straddle two regimes
+/// — one vertex on XZ, another on XY — and the exporter then interpolates two
+/// incompatible projections across the face, shearing the texture into chevron
+/// streaks along the wandering plane boundary. Picking per face keeps every
+/// triangle's UVs internally consistent, so the only seams left are the hard
+/// breaks where differently-projected faces meet (~45°), which the tileable
+/// REPEAT maps hide.
+///
+/// Selecting per face means a vertex shared by faces on different planes needs
+/// two different UVs, so the mesh is unwelded into independent triangles. The
+/// smooth per-vertex normals are preserved (duplicated), so only the vertex
+/// count grows — shading and watertight geometry are unchanged.
 fn triplanar_uvs(mesh: &mut Mesh, tile: f32) {
     let inv = 1.0 / tile.max(1e-3);
-    mesh.uvs = mesh
-        .positions
-        .iter()
-        .zip(&mesh.normals)
-        .map(|(p, n)| {
-            let (ax, ay, az) = (n[0].abs(), n[1].abs(), n[2].abs());
+    let n_tris = mesh.indices.len() / 3;
+    let mut positions = Vec::with_capacity(n_tris * 3);
+    let mut normals = Vec::with_capacity(n_tris * 3);
+    let mut uvs = Vec::with_capacity(n_tris * 3);
+    let mut indices = Vec::with_capacity(n_tris * 3);
+
+    for tri in mesh.indices.chunks_exact(3) {
+        let [i0, i1, i2] = [tri[0] as usize, tri[1] as usize, tri[2] as usize];
+        let (p0, p1, p2) = (
+            Vec3::from(mesh.positions[i0]),
+            Vec3::from(mesh.positions[i1]),
+            Vec3::from(mesh.positions[i2]),
+        );
+        // Geometric (face) normal — robust against the per-vertex smooth
+        // normals disagreeing across the triangle. Degenerate tris fall back
+        // to XZ; their zero area makes the choice invisible anyway.
+        let fn_ = (p1 - p0).cross(p2 - p0).normalize_or_zero();
+        let (ax, ay, az) = (fn_.x.abs(), fn_.y.abs(), fn_.z.abs());
+        let project = |p: Vec3| -> [f32; 2] {
             let (u, v) = if ay >= ax && ay >= az {
-                (p[0], p[2]) // floor / ceiling
+                (p.x, p.z) // floor / ceiling
             } else if ax >= az {
-                (p[2], p[1]) // wall facing ±X
+                (p.z, p.y) // wall facing ±X
             } else {
-                (p[0], p[1]) // wall facing ±Z
+                (p.x, p.y) // wall facing ±Z
             };
             [u * inv, v * inv]
-        })
-        .collect();
+        };
+
+        let base = positions.len() as u32;
+        for &i in &[i0, i1, i2] {
+            positions.push(mesh.positions[i]);
+            normals.push(mesh.normals[i]);
+        }
+        uvs.push(project(p0));
+        uvs.push(project(p1));
+        uvs.push(project(p2));
+        indices.extend_from_slice(&[base, base + 1, base + 2]);
+    }
+
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.uvs = uvs;
+    mesh.indices = indices;
 }
 
 /// Displace every vertex along its normal by low-frequency value noise. The

--- a/crates/mogen-dsl/src/lower/cave/emit.rs
+++ b/crates/mogen-dsl/src/lower/cave/emit.rs
@@ -129,6 +129,9 @@ fn strip_outer_hull(mesh: &Mesh, layout: &CaveLayout, cfg: &CaveCfg, res: u32) -
 /// compact vertex range so the exporter sees no orphaned vertices.
 fn compact(src: &Mesh, indices: &[u32]) -> Mesh {
     use std::collections::HashMap;
+    debug_assert!(src.joints.is_empty(), "compact: joints would be lost");
+    debug_assert!(src.weights.is_empty(), "compact: weights would be lost");
+    debug_assert!(src.colors.is_empty(), "compact: colors would be lost");
     let mut remap: HashMap<u32, u32> = HashMap::new();
     let mut out = Mesh::default();
     let has_uv = !src.uvs.is_empty();
@@ -193,7 +196,19 @@ fn triplanar_uvs(mesh: &mut Mesh, tile: f32) {
     let mut positions = Vec::with_capacity(n_tris * 3);
     let mut normals = Vec::with_capacity(n_tris * 3);
     let mut uvs = Vec::with_capacity(n_tris * 3);
+    let mut colors: Vec<[f32; 4]> = if mesh.colors.is_empty() {
+        Vec::new()
+    } else {
+        Vec::with_capacity(n_tris * 3)
+    };
     let mut indices = Vec::with_capacity(n_tris * 3);
+
+    // Cave rock is always static and never receives a gradient bake, so the
+    // per-vertex ancillary buffers should be empty.  Assert here so a future
+    // caller that populates them finds out before the unweld silently drops
+    // the data.
+    debug_assert!(mesh.joints.is_empty(), "triplanar_uvs: joints would be lost by unweld");
+    debug_assert!(mesh.weights.is_empty(), "triplanar_uvs: weights would be lost by unweld");
 
     for tri in mesh.indices.chunks_exact(3) {
         let [i0, i1, i2] = [tri[0] as usize, tri[1] as usize, tri[2] as usize];
@@ -205,8 +220,8 @@ fn triplanar_uvs(mesh: &mut Mesh, tile: f32) {
         // Geometric (face) normal — robust against the per-vertex smooth
         // normals disagreeing across the triangle. Degenerate tris fall back
         // to XZ; their zero area makes the choice invisible anyway.
-        let fn_ = (p1 - p0).cross(p2 - p0).normalize_or_zero();
-        let (ax, ay, az) = (fn_.x.abs(), fn_.y.abs(), fn_.z.abs());
+        let face_normal = (p1 - p0).cross(p2 - p0).normalize_or_zero();
+        let (ax, ay, az) = (face_normal.x.abs(), face_normal.y.abs(), face_normal.z.abs());
         let project = |p: Vec3| -> [f32; 2] {
             let (u, v) = if ay >= ax && ay >= az {
                 (p.x, p.z) // floor / ceiling
@@ -222,6 +237,9 @@ fn triplanar_uvs(mesh: &mut Mesh, tile: f32) {
         for &i in &[i0, i1, i2] {
             positions.push(mesh.positions[i]);
             normals.push(mesh.normals[i]);
+            if !colors.is_empty() {
+                colors.push(mesh.colors[i]);
+            }
         }
         uvs.push(project(p0));
         uvs.push(project(p1));
@@ -232,6 +250,7 @@ fn triplanar_uvs(mesh: &mut Mesh, tile: f32) {
     mesh.positions = positions;
     mesh.normals = normals;
     mesh.uvs = uvs;
+    mesh.colors = colors;
     mesh.indices = indices;
 }
 

--- a/crates/mogen-dsl/src/lower/cave/tests.rs
+++ b/crates/mogen-dsl/src/lower/cave/tests.rs
@@ -541,3 +541,67 @@ cave "spring" (seed=1, size=[18, 8, 18], chambers=4, resolution=40, pools=2)
         .iter()
         .any(|n| n.role.as_deref() == Some("pool") && n.material == Some(water)));
 }
+
+#[test]
+fn cave_rock_has_valid_triplanar_uvs() {
+    let g = lower_src(BASIC);
+    let mesh = g
+        .nodes
+        .iter()
+        .find(|n| n.role.as_deref() == Some("cave_rock"))
+        .and_then(|n| n.mesh.as_ref())
+        .expect("cave_rock mesh");
+
+    // After per-triangle unwelding, UVs and positions must be parallel.
+    assert!(
+        mesh.has_uvs(),
+        "cave rock must have UV data (triplanar_uvs not applied?)"
+    );
+
+    // Full unweld: every triangle gets its own 3 vertices, so vertex count is
+    // always a multiple of 3 and equals 3 × triangle-count.
+    assert_eq!(
+        mesh.positions.len() % 3,
+        0,
+        "unwelded rock should have positions.len() divisible by 3"
+    );
+    assert_eq!(
+        mesh.positions.len(),
+        mesh.indices.len(),
+        "unwelded rock: vertex count must equal index count"
+    );
+
+    // Per-triangle UV-plane consistency: the two UVs produced by projecting
+    // a shared vertex from the same face normal must be equal to within
+    // floating-point rounding.  Verify by re-deriving each face's dominant
+    // axis and confirming all three vertex UVs are compatible.
+    let inv = 1.0_f32 / 5.0; // ROCK_UV_TILE = 5.0
+    for tri in mesh.indices.chunks_exact(3) {
+        let [i0, i1, i2] = [tri[0] as usize, tri[1] as usize, tri[2] as usize];
+        let p = |i: usize| glam::Vec3::from(mesh.positions[i]);
+        let (p0, p1, p2) = (p(i0), p(i1), p(i2));
+        let face_n = (p1 - p0).cross(p2 - p0).normalize_or_zero();
+        let (ax, ay, az) = (face_n.x.abs(), face_n.y.abs(), face_n.z.abs());
+        // What the project closure would have produced for each vertex:
+        let expected = |pt: glam::Vec3| -> [f32; 2] {
+            let (u, v) = if ay >= ax && ay >= az {
+                (pt.x, pt.z)
+            } else if ax >= az {
+                (pt.z, pt.y)
+            } else {
+                (pt.x, pt.y)
+            };
+            [u * inv, v * inv]
+        };
+        for (i, pt) in [(i0, p0), (i1, p1), (i2, p2)] {
+            let got = mesh.uvs[i];
+            let want = expected(pt);
+            assert!(
+                (got[0] - want[0]).abs() < 1e-5 && (got[1] - want[1]).abs() < 1e-5,
+                "vertex {i} UV mismatch: got {:?}, want {:?}",
+                got,
+                want
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The cave rock's triplanar UV mapping smeared the stone texture into chevron/contour streaks on cavity walls. This switches the projection from per-vertex to per-triangle, eliminating the artifact.

## What changed

`triplanar_uvs` in `crates/mogen-dsl/src/lower/cave/emit.rs` now selects the projection plane **once per triangle** from the geometric face normal, instead of letting each vertex pick its own plane.

To allow a vertex shared between faces on different planes to carry two different UVs, the rock mesh is unwelded into independent triangles. Positions and smooth per-vertex normals are duplicated, so shading and watertight geometry are unchanged — only the vertex buffer grows.

## Why

The old per-vertex selection let a single triangle straddle two regimes (e.g. one vertex projecting onto XZ, another onto XY). The exporter then interpolated two incompatible projections across the face, shearing the texture along the wandering plane boundary. On a noisy surface-nets mesh, adjacent vertices flip planes constantly, producing the visible chevron pattern.

Picking per face keeps every triangle's UVs internally consistent. The only seams left are the hard ~45° breaks where differently-projected faces meet, which the tileable REPEAT maps hide well.

## Notes for reviewer

- Single-channel baked triplanar can't blend three projections the way a shader can; this fixes the intra-triangle shear, which was the actual artifact.
- Vertex count for the rock mesh grows (full unweld). Geometry/normals are byte-identical otherwise, so determinism is preserved.
- Worth eyeballing the rendered result in Studio — verified at the pipeline level (32 cave tests pass, example builds clean with UVs intact) but not visually rendered.

## Test plan

- [x] `cargo test -p mogen-dsl cave` — 32 passed
- [x] `mogen build examples/procgen/cave.mog` builds clean with UVs present
- [ ] Visual confirmation in MoGen Studio that chevron streaking is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)