### PR TITLE
Studio: apply transform gizmo to all multi-selected nodes

### DIFF
--- a/crates/mogen-studio/src/viewer/state/gizmo.rs
+++ b/crates/mogen-studio/src/viewer/state/gizmo.rs
@@ -51,6 +51,28 @@ pub struct GizmoDrag {
     /// track header at `binding.span` rather than synthesising a `pos=` /
     /// `rot=` on the bone.
     pub track_binding: Option<TrackBinding>,
+    /// Secondary selected nodes (everything in the multi-selection except the
+    /// primary `node` the gizmo is anchored to) that the drag should move in
+    /// lockstep. Each carries its own drag-start local transform + parent
+    /// world so the shared world-space `delta` lands correctly regardless of
+    /// where the node sits in the hierarchy. Empty for a single-node
+    /// selection. Ignored on a track-bound drag (the writeback there targets a
+    /// single track header).
+    pub others: Vec<GizmoTarget>,
+}
+
+/// Per-node drag-start snapshot for a secondary selected node that moves in
+/// lockstep with the primary during a multi-select gizmo drag. Holds just
+/// enough to re-derive the node's final local transform from the shared
+/// [`GizmoDrag::delta`] via [`apply_gizmo_drag_to`].
+#[derive(Clone, Debug)]
+pub struct GizmoTarget {
+    pub node: NodeId,
+    /// Node's local transform at drag start (rest pose).
+    pub start_transform: Transform,
+    /// Parent's world transform at drag start — used to pull world-space
+    /// deltas back into the node's local frame. `Mat4::IDENTITY` for roots.
+    pub parent_start_world: Mat4,
 }
 
 /// Snap step for translate: drag deltas that land the node's world-axis
@@ -309,6 +331,32 @@ pub(crate) fn begin_gizmo_drag(
     let (ro, rd) = crate::gizmo::screen_ray(viewproj, eye, rect, cursor);
     let scale = crate::gizmo::handle_scale(origin, eye, rect.height());
     let axis = crate::gizmo::hit_axis(st.gizmo_mode, origin, scale, ro, rd)?;
+    // Capture the rest of the multi-selection so the same world-space delta
+    // moves every selected node, not just the one the gizmo is anchored to.
+    // Skip nodes that don't accept gizmo handles (imported / non-editable) so
+    // we never synthesise an edit that would be silently dropped or land in
+    // the wrong file.
+    let others: Vec<GizmoTarget> = st
+        .selected
+        .iter()
+        .copied()
+        .filter(|&id| id != selected)
+        .filter_map(|id| {
+            if !gizmo_handles_supported(scene, &st.clip_active, id, st.gizmo_mode) {
+                return None;
+            }
+            let n = scene.nodes.get(id.0 as usize)?;
+            let parent_world = n
+                .parent
+                .and_then(|p| worlds.get(p.0 as usize).copied())
+                .unwrap_or(Mat4::IDENTITY);
+            Some(GizmoTarget {
+                node: id,
+                start_transform: n.transform,
+                parent_start_world: parent_world,
+            })
+        })
+        .collect();
     Some(GizmoDrag {
         node: selected,
         axis,
@@ -323,6 +371,7 @@ pub(crate) fn begin_gizmo_drag(
             _ => 0.0,
         },
         track_binding,
+        others,
     })
 }
 
@@ -408,6 +457,40 @@ pub(crate) fn commit_gizmo_drag(st: &mut ViewerState) -> Vec<PendingEdit> {
     if trivial {
         return Vec::new();
     }
+    let final_local = apply_gizmo_drag(drag);
+
+    // Track-bound drag: bypass the joint's rest-pose writeback entirely and
+    // splice the new axis-angle into the originating `track` header. Animation
+    // channels REPLACE the node's TRS at runtime, so the new track value
+    // **is** the desired local transform — no rest-pose composition needed.
+    // Track bindings target a single track header, so multi-select `others`
+    // are ignored on this path.
+    if let Some(binding) = drag.track_binding.as_ref() {
+        return commit_track_drag(drag, binding, final_local);
+    }
+    // Primary node first, then every other selected node moved in lockstep.
+    // Each `other` re-derives its own final transform from its captured
+    // start state so the same world-space delta lands correctly across the
+    // hierarchy.
+    let mut edits = transform_writeback_edits(st, drag.node, drag.mode, final_local);
+    for target in &drag.others {
+        let final_local = apply_gizmo_drag_to(drag, target.start_transform, target.parent_start_world);
+        edits.extend(transform_writeback_edits(st, target.node, drag.mode, final_local));
+    }
+    edits
+}
+
+/// Turn a node's freshly-dragged local transform into the [`PendingEdit`]s
+/// that write it back to the DSL source. Shared by the primary and every
+/// secondary node in a multi-select drag. Handles attach-binding subtraction
+/// and the relative-placement per-axis-shortcut quirk per node, since each
+/// selected node may sit in a different binding situation.
+fn transform_writeback_edits(
+    st: &ViewerState,
+    node: NodeId,
+    mode: crate::gizmo::GizmoMode,
+    final_local: Transform,
+) -> Vec<PendingEdit> {
     use crate::gizmo::GizmoMode;
     // Shortcut/corner-form attrs that the DSL lets override the canonical
     // transform field. The gizmo must strip these on commit or the author's
@@ -421,15 +504,6 @@ pub(crate) fn commit_gizmo_drag(st: &mut ViewerState) -> Vec<PendingEdit> {
     // selected node's own attrs).
     const POS_SHADOWS: &[&str] = &["x", "y", "z", "from", "to"];
     const ROT_SHADOWS: &[&str] = &["rx", "ry", "rz", "dir"];
-    let final_local = apply_gizmo_drag(drag);
-
-    // Track-bound drag: bypass the joint's rest-pose writeback entirely and
-    // splice the new axis-angle into the originating `track` header. Animation
-    // channels REPLACE the node's TRS at runtime, so the new track value
-    // **is** the desired local transform — no rest-pose composition needed.
-    if let Some(binding) = drag.track_binding.as_ref() {
-        return commit_track_drag(drag, binding, final_local);
-    }
     // For attach-bound nodes the post-compile transform is `attach + user`,
     // so the `pos=` we write back must be `final_local - attach_anchor`.
     // Likewise for `rot=`: the composed rotation is `user_rot * attach_rot`,
@@ -437,7 +511,7 @@ pub(crate) fn commit_gizmo_drag(st: &mut ViewerState) -> Vec<PendingEdit> {
     let attach_binding = st
         .scene
         .as_ref()
-        .and_then(|s| s.nodes.get(drag.node.0 as usize))
+        .and_then(|s| s.nodes.get(node.0 as usize))
         .and_then(|n| n.attach_binding.clone());
     let user_pos = match &attach_binding {
         Some(b) => final_local.translation - b.anchor_vec3(),
@@ -450,10 +524,10 @@ pub(crate) fn commit_gizmo_drag(st: &mut ViewerState) -> Vec<PendingEdit> {
     let relative_placed = st
         .scene
         .as_ref()
-        .and_then(|s| s.nodes.get(drag.node.0 as usize))
+        .and_then(|s| s.nodes.get(node.0 as usize))
         .map(|n| n.relative_placed)
         .unwrap_or(false);
-    match drag.mode {
+    match mode {
         GizmoMode::Translate if relative_placed => {
             // The layout pass (`above`/`below`/`left_of`/...) re-shifts one
             // axis of `transform.translation` from the target's AABB unless
@@ -470,19 +544,19 @@ pub(crate) fn commit_gizmo_drag(st: &mut ViewerState) -> Vec<PendingEdit> {
             // First edit also strips `pos`/`from`/`to` so the canonical and
             // corner-form attrs don't fight the new shortcuts on recompile.
             edits.push(PendingEdit::SetAttrCanonical {
-                node: drag.node,
+                node,
                 attr: "x".to_string(),
                 value: format_scalar(user_pos.x),
                 delete: ["pos", "from", "to"].iter().map(|s| s.to_string()).collect(),
             });
             edits.push(PendingEdit::SetAttrCanonical {
-                node: drag.node,
+                node,
                 attr: "y".to_string(),
                 value: format_scalar(user_pos.y),
                 delete: Vec::new(),
             });
             edits.push(PendingEdit::SetAttrCanonical {
-                node: drag.node,
+                node,
                 attr: "z".to_string(),
                 value: format_scalar(user_pos.z),
                 delete: Vec::new(),
@@ -500,7 +574,7 @@ pub(crate) fn commit_gizmo_drag(st: &mut ViewerState) -> Vec<PendingEdit> {
             // a rotated/scaled parent move along the world axis the user
             // grabbed instead of the parent's tilted axis.
             vec![PendingEdit::SetAttrCanonical {
-                node: drag.node,
+                node,
                 attr: "pos".to_string(),
                 value: format!(
                     "[{}, {}, {}]",
@@ -524,7 +598,7 @@ pub(crate) fn commit_gizmo_drag(st: &mut ViewerState) -> Vec<PendingEdit> {
                 format_scalar(rz.to_degrees())
             );
             vec![PendingEdit::SetAttrCanonical {
-                node: drag.node,
+                node,
                 attr: "rot".to_string(),
                 value,
                 delete: ROT_SHADOWS.iter().map(|s| s.to_string()).collect(),
@@ -540,7 +614,7 @@ pub(crate) fn commit_gizmo_drag(st: &mut ViewerState) -> Vec<PendingEdit> {
             );
             // Scale has no DSL shortcut attrs — no shadows to strip.
             vec![PendingEdit::SetAttrCanonical {
-                node: drag.node,
+                node,
                 attr: "scale".to_string(),
                 value,
                 delete: Vec::new(),
@@ -646,16 +720,28 @@ fn format_scalar(v: f32) -> String {
 }
 
 pub(crate) fn apply_gizmo_drag(drag: &GizmoDrag) -> Transform {
+    apply_gizmo_drag_to(drag, drag.start_transform, drag.parent_start_world)
+}
+
+/// Compose the shared gizmo `delta` onto an arbitrary node's drag-start
+/// state. Factored out of [`apply_gizmo_drag`] so a multi-select drag can
+/// apply the same world-space delta to every selected node, each carrying
+/// its own `start_transform` + `parent_start_world` ([`GizmoTarget`]).
+pub(crate) fn apply_gizmo_drag_to(
+    drag: &GizmoDrag,
+    start_transform: Transform,
+    parent_start_world: Mat4,
+) -> Transform {
     use crate::gizmo::GizmoMode;
-    let mut t = drag.start_transform;
+    let mut t = start_transform;
     let world_axis = drag.axis.unit();
     // Decompose the parent's world matrix once. The rotation is what we
     // conjugate the gizmo through; the inverse-of-the-full-matrix is what
     // we pull translation deltas back through (so a parent that scales
     // doesn't make a 1-unit drag move the child by 1 / parent_scale).
-    let parent_inv = drag.parent_start_world.inverse();
+    let parent_inv = parent_start_world.inverse();
     let (parent_scale, parent_rot, _) =
-        drag.parent_start_world.to_scale_rotation_translation();
+        parent_start_world.to_scale_rotation_translation();
     let parent_rot_inv = parent_rot.inverse();
     match drag.mode {
         GizmoMode::Translate => {
@@ -685,7 +771,7 @@ pub(crate) fn apply_gizmo_drag(drag: &GizmoDrag) -> Transform {
             let factor = drag.delta.max(0.01);
             let local_axis = parent_rot_inv * world_axis;
             let i = dominant_axis_index(local_axis);
-            let s0 = drag.start_transform.scale;
+            let s0 = start_transform.scale;
             t.scale = match i {
                 0 => Vec3::new(s0.x * factor, s0.y, s0.z),
                 1 => Vec3::new(s0.x, s0.y * factor, s0.z),

--- a/crates/mogen-studio/src/viewer/state/mod.rs
+++ b/crates/mogen-studio/src/viewer/state/mod.rs
@@ -28,7 +28,7 @@ pub use capture::{
     ImposterRequest, ImposterViewOverlay,
 };
 #[allow(unused_imports)]
-pub use gizmo::{GizmoDrag, PendingEdit, TrackBinding};
+pub use gizmo::{GizmoDrag, GizmoTarget, PendingEdit, TrackBinding};
 #[allow(unused_imports)]
 pub use selection::{is_import_wrapper, PickCycle};
 
@@ -37,7 +37,7 @@ pub use selection::{is_import_wrapper, PickCycle};
 // `state.rs` so this refactor is invisible to call sites.
 #[allow(unused_imports)]
 pub(crate) use gizmo::{
-    apply_gizmo_drag, aspect_for, begin_gizmo_drag, commit_gizmo_drag,
+    apply_gizmo_drag, apply_gizmo_drag_to, aspect_for, begin_gizmo_drag, commit_gizmo_drag,
     find_active_constant_track, gizmo_handles_supported, snap_rotate_delta, snap_scale_factor,
     snap_translate_delta, track_property_for_gizmo, update_gizmo_drag, ROTATE_SNAP_STEP_DEG,
     SCALE_SNAP_STEP, TRANSLATE_SNAP_STEP,
@@ -333,6 +333,13 @@ impl ViewerState {
         if let Some(drag) = &self.gizmo_drag {
             if let Some(t) = locals.get_mut(drag.node.0 as usize) {
                 *t = apply_gizmo_drag(drag);
+            }
+            // Multi-select: move every other selected node by the same delta
+            // so the preview matches what the commit will write back.
+            for target in &drag.others {
+                if let Some(t) = locals.get_mut(target.node.0 as usize) {
+                    *t = apply_gizmo_drag_to(drag, target.start_transform, target.parent_start_world);
+                }
             }
         }
         locals

--- a/crates/mogen-studio/src/viewer/tests/gizmo_commit_tests.rs
+++ b/crates/mogen-studio/src/viewer/tests/gizmo_commit_tests.rs
@@ -3,7 +3,7 @@
 
 use super::super::state::{
     apply_gizmo_drag, commit_gizmo_drag, snap_rotate_delta, snap_scale_factor,
-    snap_translate_delta, GizmoDrag, PendingEdit, ViewerState, SCALE_SNAP_STEP,
+    snap_translate_delta, GizmoDrag, GizmoTarget, PendingEdit, ViewerState, SCALE_SNAP_STEP,
 };
 use glam::{Mat4, Quat, Vec3};
 use mogen_core::{NodeId, Transform};
@@ -56,6 +56,7 @@ fn commit_gizmo_drag_is_noop_with_zero_delta() {
         start_ray_dir: Vec3::Z,
         delta: 0.0,
         track_binding: None,
+        others: Vec::new(),
     });
     assert!(commit_gizmo_drag(&mut st).is_empty());
 }
@@ -78,6 +79,7 @@ fn commit_gizmo_drag_translate_emits_full_pos_vec3() {
         start_ray_dir: Vec3::Z,
         delta: 0.75,
         track_binding: None,
+        others: Vec::new(),
     });
     let mut edits = commit_gizmo_drag(&mut st).into_iter();
     let Some(PendingEdit::SetAttrCanonical {
@@ -97,6 +99,54 @@ fn commit_gizmo_drag_translate_emits_full_pos_vec3() {
 }
 
 #[test]
+fn commit_gizmo_drag_translate_applies_to_every_selected_node() {
+    // Shift-click multi-select: the gizmo is anchored to the primary
+    // (`node`) but the drag must move every selected node by the same
+    // world-space delta. `others` carries each secondary node's own start
+    // state, so the +0.5-on-Y delta lands on both.
+    let mut st = ViewerState::default();
+    st.gizmo_drag = Some(GizmoDrag {
+        node: NodeId(1),
+        axis: crate::gizmo::Axis::Y,
+        mode: crate::gizmo::GizmoMode::Translate,
+        start_transform: Transform::from_trs(
+            Vec3::new(0.0, 1.0, 0.0),
+            Quat::IDENTITY,
+            Vec3::ONE,
+        ),
+        start_origin: Vec3::ZERO,
+        parent_start_world: Mat4::IDENTITY,
+        start_ray_origin: Vec3::ZERO,
+        start_ray_dir: Vec3::Z,
+        delta: 0.5,
+        track_binding: None,
+        others: vec![GizmoTarget {
+            node: NodeId(2),
+            start_transform: Transform::from_trs(
+                Vec3::new(3.0, 0.0, 0.0),
+                Quat::IDENTITY,
+                Vec3::ONE,
+            ),
+            parent_start_world: Mat4::IDENTITY,
+        }],
+    });
+    let edits = commit_gizmo_drag(&mut st);
+    assert_eq!(edits.len(), 2, "one edit per selected node, got {edits:?}");
+    let PendingEdit::SetAttrCanonical { node, attr, value, .. } = &edits[0] else {
+        panic!("expected SetAttrCanonical for primary");
+    };
+    assert_eq!(*node, NodeId(1), "primary node committed first");
+    assert_eq!(attr, "pos");
+    assert_eq!(value, "[0, 1.5, 0]");
+    let PendingEdit::SetAttrCanonical { node, attr, value, .. } = &edits[1] else {
+        panic!("expected SetAttrCanonical for secondary");
+    };
+    assert_eq!(*node, NodeId(2), "secondary node moved in lockstep");
+    assert_eq!(attr, "pos");
+    assert_eq!(value, "[3, 0.5, 0]", "same +0.5 Y delta applied");
+}
+
+#[test]
 fn commit_gizmo_drag_rotate_emits_euler_vec3() {
     let mut st = ViewerState::default();
     st.gizmo_drag = Some(GizmoDrag {
@@ -110,6 +160,7 @@ fn commit_gizmo_drag_rotate_emits_euler_vec3() {
         start_ray_dir: Vec3::Z,
         delta: 45.0_f32.to_radians(),
         track_binding: None,
+        others: Vec::new(),
     });
     let mut edits = commit_gizmo_drag(&mut st).into_iter();
     let Some(PendingEdit::SetAttrCanonical {
@@ -147,6 +198,7 @@ fn translate_drag_pulls_world_delta_through_rotated_parent() {
         start_ray_dir: Vec3::Z,
         delta: 1.0,
         track_binding: None,
+        others: Vec::new(),
     });
     let edits = commit_gizmo_drag(&mut st);
     let Some(PendingEdit::SetAttrCanonical { value, .. }) = edits.into_iter().next() else {
@@ -173,6 +225,7 @@ fn translate_drag_compensates_for_parent_scale() {
         start_ray_dir: Vec3::Z,
         delta: 1.0,
         track_binding: None,
+        others: Vec::new(),
     });
     let edits = commit_gizmo_drag(&mut st);
     let Some(PendingEdit::SetAttrCanonical { value, .. }) = edits.into_iter().next() else {
@@ -202,6 +255,7 @@ fn rotate_drag_conjugates_through_rotated_parent() {
         start_ray_dir: Vec3::Z,
         delta: 30.0_f32.to_radians(),
         track_binding: None,
+        others: Vec::new(),
     });
     let edits = commit_gizmo_drag(&mut st);
     let Some(PendingEdit::SetAttrCanonical { value, .. }) = edits.into_iter().next() else {
@@ -225,6 +279,7 @@ fn rotate_drag_conjugates_through_rotated_parent() {
         start_ray_dir: Vec3::Z,
         delta: 30.0_f32.to_radians(),
         track_binding: None,
+        others: Vec::new(),
     });
     let local = apply_gizmo_drag(st.gizmo_drag.as_ref().unwrap());
     let world_rot = parent_rot * local.rotation;
@@ -273,6 +328,7 @@ fn commit_gizmo_drag_translate_relative_placed_emits_axis_shortcuts() {
         start_ray_dir: Vec3::Z,
         delta: 0.75,
         track_binding: None,
+        others: Vec::new(),
     });
     let edits = commit_gizmo_drag(&mut st);
     assert_eq!(edits.len(), 3, "expected three shortcut edits, got {edits:?}");

--- a/crates/mogen-studio/src/viewer/tests/track_tests.rs
+++ b/crates/mogen-studio/src/viewer/tests/track_tests.rs
@@ -110,6 +110,7 @@ fn commit_gizmo_drag_with_track_binding_emits_axis_from_to() {
             span,
             property: TrackProperty::Rotation,
         }),
+        others: Vec::new(),
     });
     let edits = commit_gizmo_drag(&mut st);
     assert_eq!(edits.len(), 3, "expected axis/from/to triple, got {edits:?}");
@@ -169,6 +170,7 @@ clip "pose" (seconds=1.0) {
             span,
             property: TrackProperty::Rotation,
         }),
+        others: Vec::new(),
     });
     let edits = commit_gizmo_drag(&mut st);
     assert_eq!(edits.len(), 3);


### PR DESCRIPTION
## Summary

Shift-clicking in the MoGen Studio viewport already built a multi-node selection (`selected: Vec<NodeId>`), but the transform gizmo only ever moved the **primary** (last-selected) node. This makes a translate / rotate / scale drag apply to **every** selected node, matching the expected behaviour from any DCC tool.

## What changed

- **`gizmo.rs`** — added a `GizmoTarget` struct and an `others: Vec<GizmoTarget>` field on `GizmoDrag`. `begin_gizmo_drag` now snapshots each *other* selected node's start transform + parent world (skipping non-editable / imported nodes that can't accept handles). `apply_gizmo_drag` was split into a reusable `apply_gizmo_drag_to(start, parent_world)`, and the per-node source writeback was extracted into `transform_writeback_edits`, which `commit_gizmo_drag` now calls once per selected node.
- **`mod.rs`** — `live_locals` overlays the drag on all selected nodes, so the live preview moves everything in lockstep with what gets committed.
- **Tests** — added `commit_gizmo_drag_translate_applies_to_every_selected_node`; updated existing `GizmoDrag` literals for the new field.

## Behaviour notes

- The gizmo stays anchored to the primary node; translate shifts all selected together, while rotate/scale apply the same delta to each node about its own origin.
- Each node gets its own span-aware `.mog` writeback, so the drain path handles them like any other multi-edit batch.
- Track-bound drags still target a single track header (`others` is ignored on that path).
- Edge case left as-is: selecting a node **and** its descendant will double-move the child (parent transform + its own edit). Fine for the common sibling-selection case; not worth special-casing now.

## Test plan

- [x] `cargo test -p mogen-studio` — 332 passed
- [ ] Manual: shift-click several sibling meshes in MoGen Studio, drag a gizmo handle, confirm all move together and the `.mog` source updates for each (couldn't be verified in this environment — desktop GL app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)