### PR TITLE
Caves & dungeons: per-floor exterior entrance control + Studio inspector UI

### DIFF
--- a/crates/mogen-dsl/src/lower/cave/config.rs
+++ b/crates/mogen-dsl/src/lower/cave/config.rs
@@ -11,8 +11,19 @@
 
 use anyhow::{bail, Result};
 
-use crate::ast::Node;
+use crate::ast::{Node, Value};
 use crate::lower::cfg;
+
+/// How many side mouths to punch, and where. A scalar `entrances=N` reads as
+/// `Surface(N)` — N mouths on the topmost populated band (the surface entrance).
+/// An array `entrances=[b0, b1, …]` reads as `PerBand`, one count per vertical
+/// band indexed from the bottom (index 0 = lowest band), so a chosen storey can
+/// open onto an adjacent dungeon or pit. Bands past the array end get none.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum CaveEntrances {
+    Surface(u32),
+    PerBand(Vec<u32>),
+}
 
 /// The decoration kinds a cave can be populated with. Each maps to a distinct
 /// mesh builder in `decorate.rs`.
@@ -146,8 +157,9 @@ pub(super) struct CaveCfg {
     pub margin: f32,
     /// Voxel-grid resolution (samples along the longest axis).
     pub resolution: u32,
-    /// Openings punched out to a side face so the cave is enterable.
-    pub entrances: u32,
+    /// Side-mouth openings: a scalar count on the surface band, or a per-band
+    /// array (index 0 = lowest) for connecting a chosen storey to a dungeon/pit.
+    pub entrances: CaveEntrances,
     pub water_mat: Option<String>,
     /// Which rock surfaces get a trimesh collider (`all` | `shell` | `none`).
     /// A game importer reads `extras.collider` off these nodes for physics.
@@ -219,7 +231,7 @@ pub(super) fn read_cfg(node: &Node) -> Result<CaveCfg> {
     let blend = cfg::scalar(node, "blend", 1.5, 0.0);
     let margin = cfg::scalar(node, "margin", 2.0, 0.5);
     let resolution = cfg::int_clamped(node, "resolution", 96, 32, 224);
-    let entrances = cfg::count(node, "entrances", 1.0, 0.0);
+    let entrances = read_entrances(node);
 
     let water_mat = node.attr_string("water_mat").map(|s| s.to_string());
 
@@ -276,6 +288,20 @@ pub(super) fn read_cfg(node: &Node) -> Result<CaveCfg> {
         debug_hide_shell,
         debug_show_poi,
     })
+}
+
+/// Read the `entrances` attr. A scalar lowers to `Surface(N)` (N mouths on the
+/// topmost band); an array lowers to `PerBand`, one count per band from the
+/// bottom up (3-element arrays enter as `Vec3`). Absent ⇒ one surface mouth.
+/// Negatives clamp to 0.
+fn read_entrances(node: &Node) -> CaveEntrances {
+    let to_counts = |xs: &[f32]| xs.iter().map(|v| v.max(0.0) as u32).collect();
+    match node.attr("entrances") {
+        Some(Value::Number(n)) => CaveEntrances::Surface(n.max(0.0) as u32),
+        Some(Value::Vec3(a)) => CaveEntrances::PerBand(to_counts(a)),
+        Some(Value::List(v)) => CaveEntrances::PerBand(to_counts(v)),
+        _ => CaveEntrances::Surface(1),
+    }
 }
 
 /// Merge the top-level count knobs with any `feature` children into one

--- a/crates/mogen-dsl/src/lower/cave/generate.rs
+++ b/crates/mogen-dsl/src/lower/cave/generate.rs
@@ -11,8 +11,9 @@
 //! 3. Any passage steeper than `max_slope` is rebuilt as a switchback ramp —
 //!    each leg's rise-over-run is capped, so no walkable surface exceeds the
 //!    angle limit even when linking distant floors.
-//! 4. Punch `entrances` horizontal mouths out through the nearest side face,
-//!    hosted on the highest chambers so the cave is entered from the top layer.
+//! 4. Punch `entrances` horizontal mouths out through the nearest side face. A
+//!    scalar count opens them on the topmost band (the surface); an array
+//!    `[b0, b1, …]` opens them per band from the bottom up.
 //!
 //! Every carver is a `Subtract` `BlobChild`; `emit.rs` pairs them with an
 //! additive bounding box and meshes `box − ⋃ carvers` with surface nets.
@@ -24,7 +25,7 @@ use glam::{Mat4, Quat, Vec3};
 
 use mogen_geom::{BlobChild, SdfOp, SdfPrim};
 
-use super::config::CaveCfg;
+use super::config::{CaveCfg, CaveEntrances};
 use super::rng::{rand_f01, rand_in, rand_range, sub_seed};
 
 /// One carved cavity. Oblate (`half.y < half.x`) so the floor reads as gently
@@ -566,8 +567,10 @@ fn add_passage(carvers: &mut Vec<BlobChild>, a: Vec3, b: Vec3, radius: f32, max_
     }
 }
 
-/// Punch `entrances` horizontal mouths out through the nearest side face,
-/// hosted on the highest chambers so the openings land on the top layer.
+/// Punch horizontal mouths out through the nearest side face. A scalar
+/// `entrances=N` opens N mouths on the topmost populated band (the surface); an
+/// `entrances=[b0, b1, …]` array opens that many on each band from the bottom up
+/// (index 0 = lowest), so a chosen storey can meet an adjacent dungeon or pit.
 /// Returns one `(chamber_index, yaw)` per mouth for the POI pass: `yaw` points a
 /// prefab's local `-Z` (forward) out through the wall (toward the open world).
 fn add_entrances(
@@ -576,52 +579,100 @@ fn add_entrances(
     cfg: &CaveCfg,
     block_half: Vec3,
 ) -> Vec<(usize, f32)> {
-    if cfg.entrances == 0 || chambers.is_empty() {
+    if chambers.is_empty() {
         return Vec::new();
     }
-    // Highest chambers first (mouths open onto the top layer).
-    let mut order: Vec<usize> = (0..chambers.len()).collect();
-    order.sort_by(|&i, &j| {
-        chambers[j]
-            .center
-            .y
-            .partial_cmp(&chambers[i].center.y)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-
     let mut anchors = Vec::new();
-    for &idx in order.iter().take(cfg.entrances as usize) {
-        let c = &chambers[idx];
-        // Opening centre sits a passage-radius above the chamber floor so the
-        // mouth's lower lip lands near walking height.
-        let y = (c.floor_y() + cfg.passage_radius).min(c.ceiling_y());
-        let start = Vec3::new(c.center.x, y, c.center.z);
+    let mut used = vec![false; chambers.len()];
 
-        // Nearest of the four vertical faces.
-        let dpx = block_half.x - c.center.x;
-        let dnx = c.center.x + block_half.x;
-        let dpz = block_half.z - c.center.z;
-        let dnz = c.center.z + block_half.z;
-        let min = dpx.min(dnx).min(dpz).min(dnz);
-        // Outward horizontal direction toward the chosen face.
-        let (end, out): (Vec3, (f32, f32)) = if min == dpx {
-            (Vec3::new(block_half.x + cfg.margin + 1.0, y, c.center.z), (1.0, 0.0))
-        } else if min == dnx {
-            (Vec3::new(-(block_half.x + cfg.margin + 1.0), y, c.center.z), (-1.0, 0.0))
-        } else if min == dpz {
-            (Vec3::new(c.center.x, y, block_half.z + cfg.margin + 1.0), (0.0, 1.0))
-        } else {
-            (Vec3::new(c.center.x, y, -(block_half.z + cfg.margin + 1.0)), (0.0, -1.0))
-        };
-        add_capsule(carvers, start, end, cfg.passage_radius);
+    // Chamber indices grouped by vertical band, lowest band first.
+    let mut by_level: BTreeMap<u32, Vec<usize>> = BTreeMap::new();
+    for (i, c) in chambers.iter().enumerate() {
+        by_level.entry(c.level).or_default().push(i);
+    }
 
-        // Yaw so the prefab's local -Z faces out through the wall. With
-        // `Quat::from_rotation_y(a)`, local -Z maps to world -(sin a, cos a), so
-        // to send -Z → out we set a = atan2(-out.x, -out.z).
-        let yaw = (-out.0).atan2(-out.1);
-        anchors.push((idx, yaw));
+    let mut punch_band = |level_idxs: &[usize], count: usize, used: &mut [bool], anchors: &mut Vec<(usize, f32)>, carvers: &mut Vec<BlobChild>| {
+        if count == 0 {
+            return;
+        }
+        // Prefer the chambers nearest a wall so the tunnels stay short.
+        let mut by_wall = level_idxs.to_vec();
+        by_wall.sort_by(|&i, &j| {
+            wall_distance(&chambers[i], block_half)
+                .partial_cmp(&wall_distance(&chambers[j], block_half))
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(i.cmp(&j))
+        });
+        let chosen: Vec<usize> = by_wall.into_iter().filter(|&idx| !used[idx]).take(count).collect();
+        for idx in chosen {
+            used[idx] = true;
+            anchors.push(punch_mouth(carvers, &chambers[idx], cfg, block_half, idx));
+        }
+    };
+
+    match &cfg.entrances {
+        CaveEntrances::Surface(n) => {
+            // Topmost populated band gets all the surface mouths.
+            if let Some((_, idxs)) = by_level.iter().next_back() {
+                punch_band(idxs, *n as usize, &mut used, &mut anchors, carvers);
+            }
+        }
+        CaveEntrances::PerBand(counts) => {
+            for (&level, idxs) in by_level.iter() {
+                let count = counts.get(level as usize).copied().unwrap_or(0) as usize;
+                punch_band(idxs, count, &mut used, &mut anchors, carvers);
+            }
+        }
     }
     anchors
+}
+
+/// Distance from a chamber centre to the nearest of the four vertical faces.
+fn wall_distance(c: &Chamber, block_half: Vec3) -> f32 {
+    let dpx = block_half.x - c.center.x;
+    let dnx = c.center.x + block_half.x;
+    let dpz = block_half.z - c.center.z;
+    let dnz = c.center.z + block_half.z;
+    dpx.min(dnx).min(dpz).min(dnz)
+}
+
+/// Carve one mouth from chamber `idx` out through its nearest vertical face and
+/// return the `(idx, yaw)` anchor for the POI pass.
+fn punch_mouth(
+    carvers: &mut Vec<BlobChild>,
+    c: &Chamber,
+    cfg: &CaveCfg,
+    block_half: Vec3,
+    idx: usize,
+) -> (usize, f32) {
+    // Opening centre sits a passage-radius above the chamber floor so the
+    // mouth's lower lip lands near walking height.
+    let y = (c.floor_y() + cfg.passage_radius).min(c.ceiling_y());
+    let start = Vec3::new(c.center.x, y, c.center.z);
+
+    // Nearest of the four vertical faces.
+    let dpx = block_half.x - c.center.x;
+    let dnx = c.center.x + block_half.x;
+    let dpz = block_half.z - c.center.z;
+    let dnz = c.center.z + block_half.z;
+    let min = dpx.min(dnx).min(dpz).min(dnz);
+    // Outward horizontal direction toward the chosen face.
+    let (end, out): (Vec3, (f32, f32)) = if min == dpx {
+        (Vec3::new(block_half.x + cfg.margin + 1.0, y, c.center.z), (1.0, 0.0))
+    } else if min == dnx {
+        (Vec3::new(-(block_half.x + cfg.margin + 1.0), y, c.center.z), (-1.0, 0.0))
+    } else if min == dpz {
+        (Vec3::new(c.center.x, y, block_half.z + cfg.margin + 1.0), (0.0, 1.0))
+    } else {
+        (Vec3::new(c.center.x, y, -(block_half.z + cfg.margin + 1.0)), (0.0, -1.0))
+    };
+    add_capsule(carvers, start, end, cfg.passage_radius);
+
+    // Yaw so the prefab's local -Z faces out through the wall. With
+    // `Quat::from_rotation_y(a)`, local -Z maps to world -(sin a, cos a), so
+    // to send -Z → out we set a = atan2(-out.x, -out.z).
+    let yaw = (-out.0).atan2(-out.1);
+    (idx, yaw)
 }
 
 /// An ellipsoid carver at `center` with the given half-extents, yawed by `rot`.
@@ -681,7 +732,7 @@ mod tests {
             blend: 1.5,
             margin: 2.0,
             resolution: 64,
-            entrances: 1,
+            entrances: CaveEntrances::Surface(1),
             water_mat: None,
             colliders: super::super::config::ColliderMode::All,
             water_collider: false,

--- a/crates/mogen-dsl/src/lower/cave/generate.rs
+++ b/crates/mogen-dsl/src/lower/cave/generate.rs
@@ -591,7 +591,7 @@ fn add_entrances(
         by_level.entry(c.level).or_default().push(i);
     }
 
-    let mut punch_band = |level_idxs: &[usize], count: usize, used: &mut [bool], anchors: &mut Vec<(usize, f32)>, carvers: &mut Vec<BlobChild>| {
+    let punch_band = |level_idxs: &[usize], count: usize, used: &mut [bool], anchors: &mut Vec<(usize, f32)>, carvers: &mut Vec<BlobChild>| {
         if count == 0 {
             return;
         }

--- a/crates/mogen-dsl/src/lower/dungeon/config.rs
+++ b/crates/mogen-dsl/src/lower/dungeon/config.rs
@@ -13,7 +13,7 @@
 //! `spacing`), the corridor shape (`corridor_width` + `loops`), and the
 //! vertical structure (`levels` + `stairs`).
 
-use crate::ast::Node;
+use crate::ast::{Node, Value};
 use crate::lower::cfg;
 
 /// Which generated surfaces get a trimesh collider for the game engine.
@@ -63,6 +63,12 @@ pub(super) struct DungeonCfg {
     pub loops: u32,
     /// Staircases carved between each pair of adjacent levels.
     pub stairs: u32,
+    /// Exterior doorways per floor, indexed by level (`0` = ground). A scalar
+    /// `entrances=N` reads as `[N]` (N doors on the ground only); an array
+    /// `entrances=[1, 0, 2]` sets each floor independently — the hook for opening
+    /// a chosen storey onto an adjacent cave mouth or ledge. Floors past the end
+    /// of the array get none.
+    pub entrances_per_floor: Vec<u32>,
     /// Wall thickness in metres.
     pub wall_thickness: f32,
     /// Floor / ceiling deck thickness in metres.
@@ -113,6 +119,7 @@ pub(super) fn read_cfg(node: &Node) -> DungeonCfg {
     let corridor_width = cfg::int_clamped(node, "corridor_width", 1, 1, 8);
     let loops = cfg::count(node, "loops", 1.0, 0.0);
     let stairs = cfg::count(node, "stairs", 1.0, 0.0);
+    let entrances_per_floor = read_entrances_per_floor(node);
 
     let wall_thickness = cfg::scalar(node, "wall_thickness", 0.4, 0.05);
     let floor_thickness = cfg::scalar(node, "floor_thickness", 0.4, 0.05);
@@ -148,6 +155,7 @@ pub(super) fn read_cfg(node: &Node) -> DungeonCfg {
         corridor_width,
         loops,
         stairs,
+        entrances_per_floor,
         wall_thickness,
         floor_thickness,
         ceilings,
@@ -157,5 +165,20 @@ pub(super) fn read_cfg(node: &Node) -> DungeonCfg {
         debug_hide_roof,
         debug_render_floor,
         debug_show_poi,
+    }
+}
+
+/// Read the per-floor exterior-doorway counts. Accepts a scalar `entrances=N`
+/// (N doors on the ground floor, floor 0) or an array `entrances=[g, f1, f2, …]`
+/// (one count per level, index 0 = ground). The grammar lowers a 3-element
+/// bracket literal to `Vec3` rather than `List`, so both are accepted. Absent ⇒
+/// one ground doorway, matching the historic default. Negatives clamp to 0.
+fn read_entrances_per_floor(node: &Node) -> Vec<u32> {
+    let to_counts = |xs: &[f32]| xs.iter().map(|v| v.max(0.0) as u32).collect();
+    match node.attr("entrances") {
+        Some(Value::Number(n)) => vec![n.max(0.0) as u32],
+        Some(Value::Vec3(a)) => to_counts(a),
+        Some(Value::List(v)) => to_counts(v),
+        _ => vec![1],
     }
 }

--- a/crates/mogen-dsl/src/lower/dungeon/emit.rs
+++ b/crates/mogen-dsl/src/lower/dungeon/emit.rs
@@ -136,14 +136,14 @@ pub(super) fn emit(
                     if layout.is_walkable(level, i + di, j + dj) {
                         continue;
                     }
-                    // Leave a gap in the perimeter wall where the exterior
-                    // doorway is carved, so there is a clear way in.
-                    if level == 0 {
-                        if let Some(e) = layout.entrance {
-                            if e.i == i && e.j == j && e.di == di && e.dj == dj {
-                                continue;
-                            }
-                        }
+                    // Leave a gap in the perimeter wall where an exterior
+                    // doorway is carved on this level, so there is a clear way in.
+                    if layout
+                        .entrances
+                        .iter()
+                        .any(|e| e.level == level && e.i == i && e.j == j && e.di == di && e.dj == dj)
+                    {
+                        continue;
                     }
                     // Wall sits on the shared edge, extended by a wall-thickness
                     // along its length so perpendicular walls overlap at corners.

--- a/crates/mogen-dsl/src/lower/dungeon/generate.rs
+++ b/crates/mogen-dsl/src/lower/dungeon/generate.rs
@@ -49,12 +49,14 @@ pub(super) struct Stair {
     pub cells: Vec<(i32, i32)>,
 }
 
-/// An exterior doorway carved through the perimeter wall of a ground-level
-/// room. A one-cell floor stub runs from the room out to the grid border;
-/// `(i, j)` is that border threshold cell and `(di, dj)` the outward direction
-/// whose perimeter wall the emit pass drops to open the door.
+/// An exterior doorway carved through the perimeter wall of a room. A one-cell
+/// floor stub runs from the room out to the grid border; `(i, j)` is that border
+/// threshold cell and `(di, dj)` the outward direction whose perimeter wall the
+/// emit pass drops to open the door. `level` is the floor it sits on (`0` =
+/// ground).
 #[derive(Clone, Copy, Debug)]
 pub(super) struct Entrance {
+    pub level: usize,
     pub i: i32,
     pub j: i32,
     pub di: i32,
@@ -84,8 +86,9 @@ pub(super) struct DungeonLayout {
     pub stairs: Vec<Stair>,
     /// Corridor connections per room index (into `rooms`); degree 1 == dead end.
     pub room_degree: Vec<u32>,
-    /// The ground-level exterior doorway, when one could be placed.
-    pub entrance: Option<Entrance>,
+    /// Exterior doorways, as many per floor as `cfg.entrances_per_floor` asks
+    /// for (and as many as fit). Empty when none could be placed.
+    pub entrances: Vec<Entrance>,
 }
 
 impl DungeonLayout {
@@ -154,77 +157,122 @@ pub(super) fn generate(cfg: &DungeonCfg) -> DungeonLayout {
         rooms,
         stairs: Vec::new(),
         room_degree,
-        entrance: None,
+        entrances: Vec::new(),
     };
 
     // --- staircases between adjacent levels -------------------------------
     place_stairs(cfg, &mut layout);
 
-    // --- exterior entrance on the ground level ----------------------------
-    layout.entrance = place_entrance(&mut layout);
+    // --- exterior entrances -----------------------------------------------
+    layout.entrances = place_entrances(cfg, &mut layout);
 
     layout
 }
 
-/// Carve an exterior doorway on the ground level: pick a ground-level room
-/// (preferring a dead end so the entrance is a defensible vestibule), run a
-/// one-cell floor stub from its nearest side straight out to the grid border,
-/// and return the threshold cell + outward direction. The emit pass drops the
-/// perimeter wall on that edge and the POI pass marks the threshold.
-fn place_entrance(layout: &mut DungeonLayout) -> Option<Entrance> {
+/// Carve exterior doorways per floor from `cfg.entrances_per_floor` (index 0 =
+/// ground). Each is a one-cell floor stub from a room's nearest side out to the
+/// grid border; the emit pass drops the perimeter wall on that edge and the POI
+/// pass marks the threshold.
+fn place_entrances(cfg: &DungeonCfg, layout: &mut DungeonLayout) -> Vec<Entrance> {
+    let mut out = Vec::new();
+    for level in 0..layout.levels {
+        let want = cfg.entrances_per_floor.get(level).copied().unwrap_or(0) as usize;
+        place_level_entrances(layout, level, want, &mut out);
+    }
+    out
+}
+
+/// Place up to `want` doorways on `level`, preferring dead-end rooms (so an
+/// entrance is a defensible vestibule) and shorter border stubs, spreading
+/// across distinct rooms before reusing one. Carves each stub and appends the
+/// resulting `Entrance`s to `out`.
+fn place_level_entrances(
+    layout: &mut DungeonLayout,
+    level: usize,
+    want: usize,
+    out: &mut Vec<Entrance>,
+) {
+    if want == 0 {
+        return;
+    }
     let gw = layout.gw;
     let gd = layout.gd;
-    let ground: Vec<usize> = layout
+    let rooms: Vec<usize> = layout
         .rooms
         .iter()
         .enumerate()
-        .filter(|(_, r)| r.level == 0)
+        .filter(|(_, r)| r.level == level)
         .map(|(i, _)| i)
         .collect();
-    if ground.is_empty() {
-        return None;
+    if rooms.is_empty() {
+        return;
     }
 
-    // Prefer ground-level dead ends; fall back to any ground room.
-    let dead_ends: Vec<usize> = ground
-        .iter()
-        .copied()
-        .filter(|&i| layout.room_degree[i] == 1)
-        .collect();
-    let candidates = if dead_ends.is_empty() {
-        &ground
-    } else {
-        &dead_ends
-    };
-
-    // Choose the (room, side) with the smallest gap to the border so the entry
-    // stub is as short as possible.
-    let mut best: Option<(usize, i32, i32, i32)> = None; // (room, di, dj, gap)
-    for &ri in candidates {
+    // Every (room, side) candidate with its gap to the border. Dead-end rooms
+    // sort first so they are picked before through-rooms; then by shortest gap;
+    // then by room/direction for a stable, deterministic order.
+    let mut cands: Vec<(bool, i32, usize, i32, i32)> = Vec::new(); // (not_dead_end, gap, room, di, dj)
+    for &ri in &rooms {
         let r = layout.rooms[ri];
+        let dead_end = layout.room_degree[ri] == 1;
         let sides = [
-            (-1, 0, r.x0),                  // west
-            (1, 0, gw - 1 - (r.x0 + r.w)),  // east
-            (0, -1, r.z0),                  // north
-            (0, 1, gd - 1 - (r.z0 + r.d)),  // south
+            (-1, 0, r.x0),                 // west
+            (1, 0, gw - 1 - (r.x0 + r.w)), // east
+            (0, -1, r.z0),                 // north
+            (0, 1, gd - 1 - (r.z0 + r.d)), // south
         ];
         for (di, dj, gap) in sides {
             if gap < 0 {
                 continue;
             }
-            if best.map(|(_, _, _, bg)| gap < bg).unwrap_or(true) {
-                best = Some((ri, di, dj, gap));
+            cands.push((!dead_end, gap, ri, di, dj));
+        }
+    }
+    cands.sort();
+
+    // Greedy pick: first pass takes one doorway per distinct room; a second pass
+    // allows a room to host another (distinct side) if we still need more.
+    let mut chosen: Vec<(usize, i32, i32)> = Vec::new();
+    let mut used_rooms = std::collections::BTreeSet::new();
+    for &(_, _, ri, di, dj) in &cands {
+        if chosen.len() >= want {
+            break;
+        }
+        if used_rooms.insert(ri) {
+            chosen.push((ri, di, dj));
+        }
+    }
+    if chosen.len() < want {
+        for &(_, _, ri, di, dj) in &cands {
+            if chosen.len() >= want {
+                break;
+            }
+            if !chosen.iter().any(|&(cr, cdi, cdj)| cr == ri && cdi == di && cdj == dj) {
+                chosen.push((ri, di, dj));
             }
         }
     }
-    let (ri, di, dj, _) = best?;
-    let r = layout.rooms[ri];
-    let grid = &mut layout.grids[0];
 
-    // Carve a one-cell-wide floor stub from the room edge out to the border,
-    // along the room's centre line on the chosen axis, and record the border
-    // threshold cell.
-    let (ti, tj) = if di != 0 {
+    for (ri, di, dj) in chosen {
+        let (ti, tj) = carve_stub(layout, level, ri, di, dj);
+        out.push(Entrance { level, i: ti, j: tj, di, dj, room: ri });
+    }
+}
+
+/// Carve a one-cell floor stub from room `ri` on `level` straight out to the
+/// grid border along the chosen axis, returning the border threshold cell.
+fn carve_stub(
+    layout: &mut DungeonLayout,
+    level: usize,
+    ri: usize,
+    di: i32,
+    dj: i32,
+) -> (i32, i32) {
+    let gw = layout.gw;
+    let gd = layout.gd;
+    let r = layout.rooms[ri];
+    let grid = &mut layout.grids[level];
+    if di != 0 {
         let j = r.z0 + r.d / 2;
         let (lo, hi) = if di < 0 {
             (0, r.x0 - 1)
@@ -246,15 +294,7 @@ fn place_entrance(layout: &mut DungeonLayout) -> Option<Entrance> {
             grid.floor[(j * gw + i) as usize] = true;
         }
         (i, if dj < 0 { 0 } else { gd - 1 })
-    };
-
-    Some(Entrance {
-        i: ti,
-        j: tj,
-        di,
-        dj,
-        room: ri,
-    })
+    }
 }
 
 /// Best-effort random placement of `cfg.rooms` non-overlapping rectangles inside

--- a/crates/mogen-dsl/src/lower/dungeon/poi.rs
+++ b/crates/mogen-dsl/src/lower/dungeon/poi.rs
@@ -71,7 +71,9 @@ pub(super) fn emit_pois(
         .map(|(i, _)| i)
         .collect();
     let spawn_room = layout
-        .entrance
+        .entrances
+        .iter()
+        .find(|e| e.level == 0)
         .map(|e| e.room)
         .or_else(|| ground.iter().copied().find(|&i| layout.room_degree[i] == 1))
         .or_else(|| ground.first().copied());
@@ -120,9 +122,9 @@ pub(super) fn emit_pois(
 
     drop(push);
 
-    // Entrance: at the exterior threshold, oriented so its forward (-Z) faces
-    // outward through the doorway.
-    if let Some(e) = layout.entrance {
+    // Entrances: each exterior threshold, oriented so its forward (-Z) faces
+    // outward through the doorway, at its own level's floor height.
+    for e in &layout.entrances {
         let yaw = (-(e.di as f32)).atan2(-(e.dj as f32));
         markers.push(PoiMarker {
             name_key: "entrance".to_string(),
@@ -133,7 +135,7 @@ pub(super) fn emit_pois(
                 "entrance".to_string(),
             ],
             transform: Transform::from_trs(
-                Vec3::new(cx(e.i), floor_y(0), cz(e.j)),
+                Vec3::new(cx(e.i), floor_y(e.level), cz(e.j)),
                 Quat::from_rotation_y(yaw),
                 Vec3::ONE,
             ),

--- a/crates/mogen-dsl/src/lower/dungeon/tests.rs
+++ b/crates/mogen-dsl/src/lower/dungeon/tests.rs
@@ -32,6 +32,7 @@ fn cfg(levels: u32) -> DungeonCfg {
         corridor_width: 1,
         loops: 1,
         stairs: 1,
+        entrances_per_floor: vec![1],
         wall_thickness: 0.4,
         floor_thickness: 0.4,
         ceilings: true,
@@ -166,9 +167,9 @@ fn meshes_are_non_degenerate() {
 #[test]
 fn entrance_is_carved_and_marked() {
     let layout = generate::generate(&cfg(1));
-    let e = layout
-        .entrance
-        .expect("expected an exterior entrance on the ground level");
+    assert_eq!(layout.entrances.len(), 1, "expected one ground entrance by default");
+    let e = layout.entrances[0];
+    assert_eq!(e.level, 0, "default entrance should be on the ground level");
     // The threshold sits on the grid border and is walkable floor.
     let on_border = e.i == 0 || e.i == layout.gw - 1 || e.j == 0 || e.j == layout.gd - 1;
     assert!(on_border, "entrance not on the grid border: {e:?}");
@@ -181,6 +182,19 @@ fn entrance_is_carved_and_marked() {
         .filter(|n| n.role.as_deref() == Some("entrance"))
         .count();
     assert_eq!(entrances, 1, "expected exactly one entrance marker");
+}
+
+#[test]
+fn entrances_per_floor_selects_specific_levels() {
+    // [1, 0, 1] → a door on the ground and top floors, none on the middle.
+    let mut c = cfg(3);
+    c.entrances_per_floor = vec![1, 0, 1];
+    let layout = generate::generate(&c);
+    let levels: Vec<usize> = layout.entrances.iter().map(|e| e.level).collect();
+    assert!(levels.contains(&0), "expected a ground-floor entrance: {levels:?}");
+    assert!(levels.contains(&2), "expected a top-floor entrance: {levels:?}");
+    assert!(!levels.contains(&1), "middle floor should have no entrance: {levels:?}");
+    assert_eq!(levels.len(), 2, "expected exactly two entrances: {levels:?}");
 }
 
 #[test]

--- a/crates/mogen-dsl/src/proc_schema.rs
+++ b/crates/mogen-dsl/src/proc_schema.rs
@@ -41,6 +41,21 @@ pub enum ParamKind {
     /// supplies the per-component value shown when the attr is absent; its
     /// length is the vector's arity.
     Vec { defaults: &'static [f32], speed: f32 },
+    /// A variable-length integer array whose arity tracks another attr's value
+    /// (e.g. `entrances=[a, b, …]` with one slot per `levels`). Rendered as one
+    /// clamped DragValue per level and written back as a list literal. A legacy
+    /// scalar value seeds a single slot — at the top index when `scalar_at_top`
+    /// (cave surface), else index 0 (dungeon ground).
+    LevelCounts {
+        /// Attr whose (integer) value sets how many slots to show.
+        levels_attr: &'static str,
+        /// Slot count shown when `levels_attr` is absent.
+        levels_default: i32,
+        /// Per-slot clamp ceiling.
+        max_per_level: i32,
+        /// Where a bare scalar value seeds: top slot (true) or slot 0 (false).
+        scalar_at_top: bool,
+    },
 }
 
 /// Which sidebar section a parameter belongs to. `Main` params render first
@@ -309,12 +324,17 @@ static CAVE: ProcSchema = ProcSchema {
         },
         ParamSpec {
             attr: "entrances",
-            label: "Entrances",
-            kind: ParamKind::Int { default: 1, min: 0, max: 16 },
+            label: "Entrances / band",
+            kind: ParamKind::LevelCounts {
+                levels_attr: "levels",
+                levels_default: 2,
+                max_per_level: 16,
+                scalar_at_top: true,
+            },
             group: Main,
             help: Some(
-                "Side mouths on the surface (top) band. For per-band control set an \
-                 array in the code view, e.g. entrances=[1, 0, 1] (index 0 = lowest band).",
+                "Side mouths per vertical band (index 0 = lowest band). A bare \
+                 scalar opens them on the surface (top) band instead.",
             ),
         },
         int("mushrooms", "Mushrooms", 0, 0, 256),
@@ -503,12 +523,17 @@ static DUNGEON: ProcSchema = ProcSchema {
         int("stairs", "Stairs", 1, 0, 16),
         ParamSpec {
             attr: "entrances",
-            label: "Entrances",
-            kind: ParamKind::Int { default: 1, min: 0, max: 16 },
+            label: "Entrances / floor",
+            kind: ParamKind::LevelCounts {
+                levels_attr: "levels",
+                levels_default: 1,
+                max_per_level: 16,
+                scalar_at_top: false,
+            },
             group: Main,
             help: Some(
-                "Exterior doorways on the ground floor. For per-floor control set \
-                 an array in the code view, e.g. entrances=[1, 0, 2] (index 0 = ground).",
+                "Exterior doorways per floor (index 0 = ground). A bare scalar \
+                 opens them all on the ground floor.",
             ),
         },
         int("rooms", "Rooms", 6, 1, 64),

--- a/crates/mogen-dsl/src/proc_schema.rs
+++ b/crates/mogen-dsl/src/proc_schema.rs
@@ -307,7 +307,16 @@ static CAVE: ProcSchema = ProcSchema {
             group: Main,
             help: Some("Voxel-grid resolution (samples along the longest axis)."),
         },
-        int("entrances", "Entrances", 1, 0, 16),
+        ParamSpec {
+            attr: "entrances",
+            label: "Entrances",
+            kind: ParamKind::Int { default: 1, min: 0, max: 16 },
+            group: Main,
+            help: Some(
+                "Side mouths on the surface (top) band. For per-band control set an \
+                 array in the code view, e.g. entrances=[1, 0, 1] (index 0 = lowest band).",
+            ),
+        },
         int("mushrooms", "Mushrooms", 0, 0, 256),
         ParamSpec {
             attr: "colliders",
@@ -492,6 +501,16 @@ static DUNGEON: ProcSchema = ProcSchema {
         },
         int("levels", "Levels", 1, 1, 16),
         int("stairs", "Stairs", 1, 0, 16),
+        ParamSpec {
+            attr: "entrances",
+            label: "Entrances",
+            kind: ParamKind::Int { default: 1, min: 0, max: 16 },
+            group: Main,
+            help: Some(
+                "Exterior doorways on the ground floor. For per-floor control set \
+                 an array in the code view, e.g. entrances=[1, 0, 2] (index 0 = ground).",
+            ),
+        },
         int("rooms", "Rooms", 6, 1, 64),
         int("room_min", "Room min", 2, 1, 64),
         int("room_max", "Room max", 5, 1, 64),

--- a/crates/mogen-studio/src/app/ui_panels/selected/geom_params.rs
+++ b/crates/mogen-studio/src/app/ui_panels/selected/geom_params.rs
@@ -330,6 +330,95 @@ fn schema_vec_row(
     ui.end_row();
 }
 
+/// Seed a length-`levels` count array from a single scalar `n`, placed at the
+/// top slot when `at_top` (cave surface) or slot 0 otherwise (dungeon ground).
+fn seed_level_counts(levels: usize, n: i32, at_top: bool) -> Vec<i32> {
+    let levels = levels.max(1);
+    let mut v = vec![0; levels];
+    let idx = if at_top { levels - 1 } else { 0 };
+    v[idx] = n.max(0);
+    v
+}
+
+/// Per-level integer-array row: one DragValue per level (arity read live from
+/// `levels_attr`), written back as `attr=[a, b, …]`. A bare scalar seeds one
+/// slot (see [`seed_level_counts`]); an expression / `$param` locks the row.
+#[allow(clippy::too_many_arguments)]
+fn level_counts_row(
+    ui: &mut egui::Ui,
+    label: &str,
+    attr: &'static str,
+    src: &str,
+    span: mogen_core::Span,
+    levels_attr: &str,
+    levels_default: i32,
+    max_per_level: i32,
+    scalar_at_top: bool,
+    help: Option<&str>,
+    out: &mut Vec<(&'static str, String)>,
+) {
+    // Slot count tracks the live `levels` value (clamped to a sane editor cap).
+    let levels = match field(src, span, levels_attr) {
+        Field::Num(n) => (n.round() as i32).clamp(1, 16),
+        _ => levels_default.clamp(1, 16),
+    } as usize;
+
+    // Resolve the current per-level counts from source.
+    let mut counts: Vec<i32> = match get_attr(src, span, attr) {
+        None => seed_level_counts(levels, 1, scalar_at_top),
+        Some(s) => {
+            let t = s.trim();
+            if let Some(inner) = t.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+                let parsed: Option<Vec<f32>> = inner
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|p| !p.is_empty())
+                    .map(|p| p.parse::<f32>().ok())
+                    .collect();
+                match parsed {
+                    Some(v) => v.iter().map(|x| x.max(0.0) as i32).collect(),
+                    None => {
+                        locked_row(ui, label, t);
+                        return;
+                    }
+                }
+            } else {
+                match t.parse::<f32>() {
+                    Ok(n) => seed_level_counts(levels, n.max(0.0) as i32, scalar_at_top),
+                    Err(_) => {
+                        locked_row(ui, label, t);
+                        return;
+                    }
+                }
+            }
+        }
+    };
+    counts.resize(levels, 0);
+
+    label_with_help(ui, label, help);
+    ui.horizontal_wrapped(|ui| {
+        let mut changed = false;
+        for (i, c) in counts.iter_mut().enumerate() {
+            let resp = ui
+                .add(
+                    egui::DragValue::new(c)
+                        .speed(0.1)
+                        .range(0..=max_per_level)
+                        .prefix(format!("{i}:")),
+                )
+                .on_hover_text(format!("Level {i} (0 = lowest)"));
+            if resp.changed() {
+                changed = true;
+            }
+        }
+        if changed {
+            let body = counts.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(", ");
+            out.push((attr, format!("[{body}]")));
+        }
+    });
+    ui.end_row();
+}
+
 /// Render every parameter of a procedural generator schema as inspector rows,
 /// inserting a subheader row whenever the [`ParamGroup`] changes. This is the
 /// single generic path that replaces the former per-kind hand-written arms for
@@ -373,6 +462,24 @@ fn render_schema(
             ),
             ParamKind::Vec { defaults, speed } => schema_vec_row(
                 ui, spec.label, spec.attr, src, span, defaults, *speed, spec.help, out,
+            ),
+            ParamKind::LevelCounts {
+                levels_attr,
+                levels_default,
+                max_per_level,
+                scalar_at_top,
+            } => level_counts_row(
+                ui,
+                spec.label,
+                spec.attr,
+                src,
+                span,
+                levels_attr,
+                *levels_default,
+                *max_per_level,
+                *scalar_at_top,
+                spec.help,
+                out,
             ),
         }
     }

--- a/crates/mogen-studio/src/autocomplete.rs
+++ b/crates/mogen-studio/src/autocomplete.rs
@@ -589,7 +589,7 @@ fn attr_key_pool(parent_kind: Option<&str>) -> Vec<Candidate> {
             ("margin", "rock padding around the block"),
             ("resolution", "voxel grid resolution"),
             ("lod_scale", "0.1..1.0 mesh-quality / triangle budget"),
-            ("entrances", "openings carved to the surface"),
+            ("entrances", "surface mouth count, or per-band array [b0,b1,…]"),
             ("stalagmites", "floor spike count"),
             ("stalactites", "ceiling spike count"),
             ("columns", "floor-to-ceiling stone pillars"),

--- a/crates/mogen-validate/src/ast_checks/cave_rules.rs
+++ b/crates/mogen-validate/src/ast_checks/cave_rules.rs
@@ -65,7 +65,6 @@ pub(super) fn check_cave(n: &Node, diags: &mut Vec<Diagnostic>) {
     // Non-negative counts.
     for key in [
         "loops",
-        "entrances",
         "level_gap",
         "level_links",
         "rock_piles",
@@ -84,6 +83,20 @@ pub(super) fn check_cave(n: &Node, diags: &mut Vec<Diagnostic>) {
                 );
             }
         }
+    }
+
+    // `entrances` is a scalar count or a per-band array; every count must be ≥ 0.
+    let entrance_counts: &[f32] = match n.attr("entrances") {
+        Some(Value::Number(v)) => std::slice::from_ref(v),
+        Some(Value::Vec3(a)) => a.as_slice(),
+        Some(Value::List(v)) => v.as_slice(),
+        _ => &[],
+    };
+    if entrance_counts.iter().any(|v| *v < 0.0) {
+        diags.push(
+            Diagnostic::error("E1202", "`cave.entrances` counts must each be ≥ 0".to_string())
+                .with_span(n.span),
+        );
     }
 
     // `size=[w, h, d]` must be a vec3 of positive numbers.

--- a/crates/mogen-validate/src/ast_checks/dungeon_rules.rs
+++ b/crates/mogen-validate/src/ast_checks/dungeon_rules.rs
@@ -67,6 +67,20 @@ pub(super) fn check_dungeon(n: &Node, diags: &mut Vec<Diagnostic>) {
         }
     }
 
+    // `entrances` is a scalar count or a per-floor array; every count must be ≥ 0.
+    let entrance_counts: &[f32] = match n.attr("entrances") {
+        Some(Value::Number(v)) => std::slice::from_ref(v),
+        Some(Value::Vec3(a)) => a.as_slice(),
+        Some(Value::List(v)) => v.as_slice(),
+        _ => &[],
+    };
+    if entrance_counts.iter().any(|v| *v < 0.0) {
+        diags.push(
+            Diagnostic::error("E1603", "`dungeon.entrances` counts must each be ≥ 0".to_string())
+                .with_span(n.span),
+        );
+    }
+
     // `size=[w, h, d]` must be a vec3 of positive numbers.
     if let Some(Value::Vec3(s)) = n.attr("size") {
         if s.iter().any(|v| !v.is_finite() || *v <= 0.0) {

--- a/crates/mogen-validate/src/ast_checks/schema.rs
+++ b/crates/mogen-validate/src/ast_checks/schema.rs
@@ -241,7 +241,8 @@ pub fn attrs_for_kind(kind: &str) -> &'static [&'static str] {
         "dungeon" => &[
             "seed", "mat_style", "size", "cell", "levels", "rooms",
             "room_min", "room_max", "spacing", "corridor_width", "loops",
-            "stairs", "wall_thickness", "floor_thickness", "ceilings",
+            "stairs", "entrances",
+            "wall_thickness", "floor_thickness", "ceilings",
             "colliders", "prop_spots", "lod_scale",
             "debug_hide_roof", "debug_render_floor", "debug_show_poi",
         ],
@@ -480,6 +481,8 @@ pub(super) fn attr_type(kind: &str, attr: &str) -> Option<&'static str> {
         ("room_type", "mat") => "string",
         ("adjacency", "adjacent_to") | ("adjacency", "away_from") => "list of string",
         ("cave", "size") => "vec3",
+        // Scalar (surface count) or per-band array, e.g. `entrances=[1, 0, 1]`.
+        ("cave", "entrances") => "number or list of number",
         ("cave", "chambers")
         | ("cave", "levels")
         | ("cave", "chamber_min")
@@ -496,7 +499,6 @@ pub(super) fn attr_type(kind: &str, attr: &str) -> Option<&'static str> {
         | ("cave", "blend")
         | ("cave", "margin")
         | ("cave", "resolution")
-        | ("cave", "entrances")
         | ("cave", "rock_piles")
         | ("cave", "pools")
         | ("cave", "lakes")
@@ -533,6 +535,8 @@ pub(super) fn attr_type(kind: &str, attr: &str) -> Option<&'static str> {
         | ("terrain", "debug_show_poi") => "number",
         ("dungeon", "size") => "vec3",
         ("dungeon", "mat_style") | ("dungeon", "colliders") => "string",
+        // Scalar (ground count) or per-floor array, e.g. `entrances=[1, 0, 2]`.
+        ("dungeon", "entrances") => "number or list of number",
         ("dungeon", "cell")
         | ("dungeon", "levels")
         | ("dungeon", "rooms")
@@ -747,6 +751,12 @@ pub(super) fn value_matches(v: &Value, expected: &str) -> bool {
         // though the schema declares it a list).
         (Value::List(_) | Value::ListExpr(_), "list of number") => true,
         (Value::Vec3(_) | Value::Vec3Expr(_), "list of number") => true,
+        // Scalar count or per-floor array (3-element arrays enter as `Vec3`).
+        (Value::Number(_) | Value::Expr(_), "number or list of number") => true,
+        (
+            Value::List(_) | Value::ListExpr(_) | Value::Vec3(_) | Value::Vec3Expr(_),
+            "number or list of number",
+        ) => true,
         (Value::ListString(_), "list of string") => true,
         (Value::String(_) | Value::Ident(_), "list of string") => true,
         // Deferred expressions: accept as their natural type; evaluation errors

--- a/docs/caves.md
+++ b/docs/caves.md
@@ -61,8 +61,11 @@ The pipeline, all seeded from `seed=`:
    exceeds the angle cap** — even when linking distant floors.
 
 5. **Entrances.** `entrances` horizontal mouths are punched out through the
-   nearest side face, hosted on the highest chambers so they open onto the top
-   layer. This is what makes the otherwise-enclosed block enterable.
+   nearest side face. A scalar `entrances=N` hosts them on the topmost band so
+   they open onto the surface, which is what makes the otherwise-enclosed block
+   enterable. An array `entrances=[b0, b1, …]` instead opens that many on each
+   band from the bottom up (index 0 = lowest), choosing the chambers nearest a
+   wall, so a chosen storey can open onto an adjacent dungeon or pit.
 
 6. **Roughening.** The shell is displaced along its normals by bounded,
    low-frequency value noise (`roughness`) for a natural stone finish. The
@@ -173,7 +176,7 @@ cave "hollow" (
 | `margin` | `2.0` | Rock thickness around the void (m). |
 | `resolution` | `96` | Voxel-grid resolution, clamped `[32, 224]`. |
 | `lod_scale` | `1.0` | Mesh-quality scale, clamped `[0.1, 1.0]`. Scales rock voxel grid + decoration tessellation; lower = fewer triangles. Layout / counts / POIs unaffected. |
-| `entrances` | `1` | Mouths punched out to a side face. |
+| `entrances` | `1` | Mouths to a side face: scalar = count on the surface (top) band; array `[b0, b1, …]` = per band from the bottom up. |
 | `mat` | `cave_rock` | Rock material (auto-stamped grey stone if undeclared). |
 | `mat_style` | `""` | Free-text style hint forwarded to texture generation. |
 | `water_mat` | `cave_water` | Pool / lake material. |

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -563,7 +563,7 @@ of `seed=` plus the declared attrs). See `docs/caves.md` for the full spec.
 | `margin` | `2.0` | Rock thickness kept around the void on every face (m). |
 | `resolution` | `96` | Voxel-grid resolution (32–224). Higher = finer + slower. |
 | `lod_scale` | `1.0` | Mesh-quality scale `[0.1, 1.0]`; scales rock voxel grid + decoration tessellation. Lower = fewer triangles. Layout / counts / POIs unaffected. |
-| `entrances` | `1` | Horizontal mouths punched out to a side face. |
+| `entrances` | `1` | Horizontal mouths punched to a side face. A scalar `N` opens `N` on the surface (top) band; an array `[b0, b1, …]` opens them per band from the bottom up (index `0` = lowest), so e.g. `entrances=[1, 0, 1]` connects a chosen storey to an adjacent dungeon. Bands past the array end get none; mouths prefer chambers nearest a wall. |
 | `mat` | `cave_rock` | Rock material; defaults to an auto-stamped grey stone. |
 | `water_mat` | `cave_water` | Material for pools / lakes. |
 | `rock_piles`, `pools`, `lakes`, `stalagmites`, `stalactites`, `columns` | `0` | Decoration counts scattered on chamber floors / ceilings (`columns` span floor→ceiling). |
@@ -720,6 +720,7 @@ pure function of `seed=` plus the declared attrs).
 | `cell` | `4` | Grid cell edge length (m). Rooms and corridors quantise to this lattice so walls always meet flush. |
 | `levels` | `1` | Stacked floors. `1` is single-storey; higher values stack independent room layouts linked by staircases. |
 | `stairs` | `1` | Staircases between each pair of adjacent levels. |
+| `entrances` | `1` | Exterior doorways through the perimeter wall. A scalar `N` puts `N` on the ground floor; an array `[g, f1, f2, …]` sets each floor independently (index `0` = ground), so e.g. `entrances=[1, 0, 2]` opens a chosen storey onto an adjacent cave mouth or ledge. Floors past the array end get none; doors prefer dead-end rooms and the shortest border stub. |
 | `rooms` | `6` | Target room count per level (placement is best-effort within the grid). |
 | `room_min` | `2` | Room side length range in cells (inclusive). `room_min > room_max` is swapped. |
 | `room_max` | `5` | — |
@@ -741,9 +742,11 @@ Geometry is built from **decks**: deck `k` is simultaneously the floor of level
 walkable cell — including staircase landings — is covered, so the top level is
 fully roofed and stairwells are enclosed. Staircases punch an opening through
 the upper deck and fill it with a flight of small (~0.18 m riser) steps sized
-for in-game use. One ground-level room gets an **exterior doorway**: a one-cell
-floor stub runs out to the grid border and the perimeter wall there is left
-open, so the dungeon has a clear way in. Walls are extended by `wall_thickness`
+for in-game use. Each **exterior doorway** is a one-cell floor stub run out to
+the grid border with the perimeter wall there left open, so the dungeon has a
+clear way in; `entrances` controls how many per floor (a scalar for the ground
+floor, or a per-floor array) so a raised storey can open onto an adjacent cave
+mouth or ledge. Walls are extended by `wall_thickness`
 at their ends so corners always close — no holes. A single material pair
 (`dungeon_floor`, `dungeon_stone`) is auto-stamped if you don't supply `mat=`.
 

--- a/examples/procgen/cave.mog
+++ b/examples/procgen/cave.mog
@@ -1,13 +1,14 @@
-// A traversable multi-floor cave: chambers carved across two vertical levels
+// A traversable multi-floor cave: chambers carved across four vertical bands
 // and linked by slope-capped passages, populated with stalagmites, stalactites,
 // a rock pile and a small pool. Everything is a deterministic function of
-// `seed=`, so rebuilds are reproducible. See docs/caves.md for the full surface.
+// `seed=`, so rebuilds are reproducible. The `entrances` array opens side mouths
+// on the bands you choose (here the lowest and the surface). See docs/caves.md.
 
 meta (
   name = "cave",
-  description = "A traversable multi-floor cave with chambers, sloped passages, stalagmites, stalactites and a pool",
+  description = "A traversable multi-floor cave with chambers, sloped passages, per-band entrances, stalagmites, stalactites and a pool",
   tags = ["cave", "nature", "environment", "dungeon", "procedural"],
-  mogen_version = "0.1.8")
+  mogen_version = "0.1.9")
 
 lod_scale (value=0.6)
 
@@ -39,7 +40,9 @@ cave "hollow" (
   margin = 2.5,
   resolution = 128,
   lod_scale = 1.0, // mesh-quality scale (0.1–1.0); lower = fewer triangles
-  entrances = 1,
+  // side mouths per band (index 0 = lowest): one down low to meet a dungeon or
+  // pit, one up top for the surface. Middle bands stay sealed.
+  entrances = [1, 0, 0, 1],
   mat = "limestone",
   debug_hide_shell=1, // uncomment to hide the outer shell and see the whole cave interior
 

--- a/examples/procgen/dungeon.mog
+++ b/examples/procgen/dungeon.mog
@@ -2,15 +2,16 @@
 // by axis-aligned corridors, stacked into three floors that staircases connect.
 // Everything is a deterministic function of `seed=`, so rebuilds reproduce the
 // same layout. Walls, floors and ceilings are watertight box meshes; interior
-// doorways are gaps in the walls and one ground-level room opens to the outside
-// through the perimeter wall. POI markers flag the entrance, spawn, treasure
-// rooms and stair landings for the game engine.
+// doorways are gaps in the walls. The `entrances` array opens a doorway on the
+// floors you choose (here the ground and the top) so a raised storey can meet an
+// adjacent cave mouth or ledge. POI markers flag every entrance, spawn, treasure
+// room and stair landing for the game engine.
 
 meta (
   name = "dungeon",
-  description = "A three-level grid dungeon with rooms, corridors and staircases for dungeon-crawler games",
+  description = "A three-level grid dungeon with rooms, corridors, staircases and per-floor entrances for dungeon-crawler games",
   tags = ["dungeon", "building", "environment", "procedural", "crawler"],
-  mogen_version = "0.1.8")
+  mogen_version = "0.1.9")
 
 dungeon "keep" (
   seed = 7,
@@ -19,6 +20,10 @@ dungeon "keep" (
 
   levels = 3, // three stacked floors …
   stairs = 1, // … each pair linked by a staircase
+
+  // exterior doorways per floor (index 0 = ground): one on the ground, none on
+  // the middle floor, one up top to meet an adjacent cave mouth or ledge.
+  entrances = [1, 0, 1],
 
   rooms = 7, // target rooms per level (best-effort placement)
   room_min = 2, // room side length range, in cells


### PR DESCRIPTION
Recovers and rebases two previously-dangling commits (originally on the deleted `claude/mogen-game-engine-voghj2` branch) onto current master.

## What this adds

**Per-floor entrance control** (`1f10fc8`)
- `entrances` on caves and dungeons becomes per-floor instead of a single int.
- Caves (`cave/config.rs`, `cave/generate.rs`): per-band entrance counts.
- Dungeons (`dungeon/config.rs`, `generate.rs`, `emit.rs`, `poi.rs`): per-level entrances.
- New schema shape in `proc_schema.rs`; validation for the array form in `mogen-validate` (`cave_rules.rs`, `dungeon_rules.rs`, `schema.rs`).
- Docs (`docs/caves.md`, `docs/dsl.md`) and `examples/procgen/dungeon.mog` updated.

**Studio inspector UI** (`3a91507`)
- New `LevelCounts` param kind: `entrances` renders as one clamped count field per level in the right sidebar, arity tracked live from `levels`, written back as an array literal (no locked fallback row).
- A bare scalar seeds the natural entry slot — top band for caves, ground floor for dungeons.
- `app/ui_panels/selected/geom_params.rs` renders the grid generically from the schema; `examples/procgen/cave.mog` updated to a per-band array.

## Testing
- `cargo test -p mogen-dsl` — 417 passed
- `cargo test -p mogen-validate` — 83 passed
- `cargo build -p mogen-studio` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)