### PR TITLE
Add `hull` primitive and per-face `box` materials

### DIFF
--- a/crates/mogen-dsl/src/ast.rs
+++ b/crates/mogen-dsl/src/ast.rs
@@ -210,6 +210,16 @@ impl Node {
         }
     }
 
+    /// Returns a list of strings (`["a", "b", …]`). A single bare/quoted
+    /// string is *not* promoted to a one-element list — callers that want that
+    /// should special-case it.
+    pub fn attr_list_string(&self, key: &str) -> Option<Vec<String>> {
+        match self.attr(key)? {
+            Value::ListString(v) => Some(v.clone()),
+            _ => None,
+        }
+    }
+
     pub fn attr_number(&self, key: &str) -> Option<f32> {
         match self.attr(key)? {
             Value::Number(n) => Some(*n),

--- a/crates/mogen-dsl/src/lower.rs
+++ b/crates/mogen-dsl/src/lower.rs
@@ -8,6 +8,7 @@ pub(crate) mod connector;
 mod csg;
 mod deform;
 mod dungeon;
+mod faced_box;
 mod gradient_bake;
 mod helpers;
 mod layout;

--- a/crates/mogen-dsl/src/lower/faced_box.rs
+++ b/crates/mogen-dsl/src/lower/faced_box.rs
@@ -1,0 +1,103 @@
+//! Per-face materials on `box`.
+//!
+//! A `box "crate" (size=…, faces=[…])` carries six material names in the fixed
+//! `+X, -X, +Y, -Y, +Z, -Z` order (the same order the BD1 → mog map converter
+//! emits, one per cube face). Rather than teach the core mesh to hold submeshes,
+//! the box lowers to an editable wrapper (the box node itself, keeping its
+//! transform / metadata / connectors) plus one *frozen* child per distinct
+//! material — each a quad group of just that material's faces. Faces sharing a
+//! material collapse into one child, so a crate with one material on the lid and
+//! another on the sides becomes two children, not six.
+//!
+//! The children are stamped non-editable: they have no AST node of their own, so
+//! the Studio inspector redirects clicks to the wrapper (the same contract the
+//! procedural generators use). An empty `""` entry means "use the box's own
+//! `mat=` / inherited material" for that face.
+
+use anyhow::{anyhow, bail, Result};
+use glam::Vec3;
+
+use mogen_core::{MaterialId, NodeId, SceneGraph, Transform, UvMode};
+use mogen_geom::{box_faces_mesh, box_mesh};
+
+use crate::ast::Node;
+
+use super::helpers::{anchor_for, apply_anchor_to_mesh, resolve_size3};
+
+/// Short, filename-safe tokens for the six faces, used to name the per-material
+/// child nodes. Index order matches [`mogen_geom::box_faces_mesh`].
+const FACE_TOKENS: [&str; 6] = ["px", "nx", "py", "ny", "pz", "nz"];
+
+/// Lower a `box` carrying `faces=[…]` into per-material quad children under the
+/// (meshless) wrapper `box_id`. Returns the anchor shift applied to the child
+/// geometry so the caller can offset the wrapper's default connectors by the
+/// same amount.
+pub(super) fn lower_faced_box(
+    node: &Node,
+    box_id: NodeId,
+    graph: &mut SceneGraph,
+) -> Result<Vec3> {
+    let faces = node
+        .attr_list_string("faces")
+        .ok_or_else(|| anyhow!("`box` faces= must be a list of 6 material names"))?;
+    if faces.len() != 6 {
+        bail!(
+            "`box` faces= needs exactly 6 entries (+X, -X, +Y, -Y, +Z, -Z order), got {}",
+            faces.len()
+        );
+    }
+
+    let size = resolve_size3(node, Vec3::ONE);
+    let fallback = graph.nodes[box_id.0 as usize].material;
+
+    // Resolve each face's material name to an id (empty string → the box's own
+    // material), preserving first-seen order so the emitted children are stable.
+    let mut groups: Vec<(Option<MaterialId>, Vec<usize>)> = Vec::new();
+    for (fi, name) in faces.iter().enumerate() {
+        let mat = if name.is_empty() {
+            fallback
+        } else {
+            Some(
+                graph
+                    .find_material_scoped(name, node.origin.as_deref())
+                    .ok_or_else(|| anyhow!("unknown material: {name}"))?,
+            )
+        };
+        match groups.iter_mut().find(|(m, _)| *m == mat) {
+            Some((_, idxs)) => idxs.push(fi),
+            None => groups.push((mat, vec![fi])),
+        }
+    }
+
+    // Anchor shift comes from the full box AABB so every face group lands at the
+    // same anchored origin (a single-face AABB would be degenerate on one axis).
+    let anchor = anchor_for(node);
+    let mut probe = box_mesh([size.x, size.y, size.z], UvMode::Fit);
+    let anchor_shift = apply_anchor_to_mesh(&mut probe, anchor.as_deref());
+
+    let box_name = graph.nodes[box_id.0 as usize].name.clone();
+    for (mat, idxs) in groups {
+        let uv_mode = mat
+            .and_then(|m| graph.materials.get(m.0 as usize))
+            .map(|m| m.uv_mode)
+            .unwrap_or_default();
+        let mut mesh = box_faces_mesh([size.x, size.y, size.z], uv_mode, &idxs);
+        if anchor_shift != Vec3::ZERO {
+            for p in &mut mesh.positions {
+                p[0] += anchor_shift.x;
+                p[1] += anchor_shift.y;
+                p[2] += anchor_shift.z;
+            }
+        }
+        let tokens: String = idxs.iter().map(|&i| FACE_TOKENS[i]).collect::<Vec<_>>().join("");
+        let child_name = format!("{box_name}_{tokens}");
+        let child = graph.add_child(box_id, child_name, "box_face", Transform::IDENTITY);
+        graph.set_mesh(child, mesh);
+        if let Some(m) = mat {
+            graph.set_material(child, m);
+        }
+        graph.set_not_editable(child);
+    }
+
+    Ok(anchor_shift)
+}

--- a/crates/mogen-dsl/src/lower/node.rs
+++ b/crates/mogen-dsl/src/lower/node.rs
@@ -150,7 +150,11 @@ pub(super) fn lower_into(
         .and_then(|mid| graph.materials.get(mid.0 as usize))
         .map(|m| m.uv_mode)
         .unwrap_or_default();
-    if let Some(mesh_res) = primitive_mesh(node, uv_mode) {
+    if node.kind == "box" && node.attr("faces").is_some() {
+        // Per-face materials: the box becomes a meshless wrapper carrying one
+        // frozen quad-group child per material. See `faced_box`.
+        anchor_shift = super::faced_box::lower_faced_box(node, id, graph)?;
+    } else if let Some(mesh_res) = primitive_mesh(node, uv_mode) {
         let mut mesh = mesh_res?;
         // Deformation runs before anchor shift so the anchor reflects the
         // post-deform AABB — the user's `anchor=bottom` still lines up flush

--- a/crates/mogen-dsl/src/lower/primitive.rs
+++ b/crates/mogen-dsl/src/lower/primitive.rs
@@ -5,7 +5,7 @@ use mogen_core::{Mesh, UvMode};
 use mogen_geom::{
     bezier_patch_mesh, box_mesh, capsule_mesh, chamfered_box_mesh, clean_csg_output, coil_mesh,
     cone_mesh, curved_plane_mesh, cylinder_mesh, difference_many, disc_mesh, ellipsoid_mesh,
-    extrude_mesh, frustum_mesh, half_cylinder_mesh, heightfield_mesh, hemisphere_mesh,
+    extrude_mesh, frustum_mesh, half_cylinder_mesh, heightfield_mesh, hemisphere_mesh, hull_mesh,
     icosphere_mesh, inset_box_mesh, lathe_mesh, leaf_card_mesh, loft_mesh, mesh_from_glb_bytes,
     metaball_mesh, plane_mesh, prism_mesh, pyramid_mesh, quad_mesh, read_glb_bytes,
     rounded_box_mesh, sphere_mesh, spline_ribbon_mesh, spline_tube_mesh, superellipsoid_mesh,
@@ -294,6 +294,19 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
             let rings = seg("rings", 12, 2);
             let segments = seg("segments", 16, 3);
             metaball_mesh(&points, &radii, blend, rings, segments, uv_mode)
+        }
+        "hull" => {
+            // Convex hull of a point cloud — the lossless sink for arbitrary
+            // convex solids (sheared/sloped blocks) no parametric primitive
+            // captures. Needs ≥4 points; fewer can't bound a volume.
+            let points = node.attr_list_vec3("points").unwrap_or_default();
+            if points.len() < 4 {
+                return Some(Err(anyhow!(
+                    "`hull` requires at least 4 points in `points=[[x,y,z], …]`, got {}",
+                    points.len(),
+                )));
+            }
+            hull_mesh(&points)
         }
         "wall" => {
             // Box cut through along Z by any number of rectangular holes

--- a/crates/mogen-dsl/src/lower/tests/faced_box.rs
+++ b/crates/mogen-dsl/src/lower/tests/faced_box.rs
@@ -1,0 +1,115 @@
+use super::*;
+use crate::lower::*;
+use crate::parser::parse;
+
+fn children_of<'a>(g: &'a SceneGraph, name: &str) -> Vec<&'a mogen_core::SceneNode> {
+    let parent = find_mesh_node(g, name);
+    parent.children.iter().map(|c| &g.nodes[c.0 as usize]).collect()
+}
+
+#[test]
+fn faced_box_groups_faces_by_material() {
+    // +Y is "lid", the other five faces are "side": two distinct materials, so
+    // two frozen children (a 5-face group and a 1-face group), not six.
+    let g = lower_src(
+        r#"scene {
+            material "lid"  (color=[0.8, 0.6, 0.2])
+            material "side" (color=[0.3, 0.3, 0.3])
+            box "crate" (
+                size=[2, 1, 1],
+                faces=["side", "side", "lid", "side", "side", "side"]
+            )
+        }"#,
+    );
+    let crate_node = find_mesh_node(&g, "crate");
+    assert!(crate_node.mesh.is_none(), "faced box wrapper must carry no mesh of its own");
+    assert!(crate_node.editable, "wrapper stays editable");
+
+    let kids = children_of(&g, "crate");
+    assert_eq!(kids.len(), 2, "two materials → two children");
+    for k in &kids {
+        assert!(!k.editable, "face-group children are frozen");
+        assert!(k.material.is_some(), "each face group binds a material");
+        let m = k.mesh.as_ref().expect("face group has a mesh");
+        assert_eq!(m.indices.len() % 6, 0, "each face is a quad (6 indices)");
+    }
+    // Total faces across the children must equal six (5 sides + 1 lid).
+    let total_quads: usize = kids
+        .iter()
+        .map(|k| k.mesh.as_ref().unwrap().indices.len() / 6)
+        .sum();
+    assert_eq!(total_quads, 6, "all six faces emitted exactly once");
+
+    let lid = g.find_material("lid").unwrap();
+    let lid_child = kids.iter().find(|k| k.material == Some(lid)).unwrap();
+    assert_eq!(lid_child.mesh.as_ref().unwrap().indices.len() / 6, 1, "lid is a single face");
+}
+
+#[test]
+fn faced_box_with_one_material_emits_one_child() {
+    let g = lower_src(
+        r#"scene {
+            material "m" (color=[0.5, 0.5, 0.5])
+            box "b" (faces=["m", "m", "m", "m", "m", "m"])
+        }"#,
+    );
+    let kids = children_of(&g, "b");
+    assert_eq!(kids.len(), 1, "uniform material collapses to one child");
+    assert_eq!(kids[0].mesh.as_ref().unwrap().indices.len() / 6, 6, "all six faces in one group");
+}
+
+#[test]
+fn faced_box_empty_entry_falls_back_to_node_material() {
+    // The box carries mat="body"; the empty faces use it, "trim" overrides +Y.
+    let g = lower_src(
+        r#"scene {
+            material "body" (color=[0.2, 0.2, 0.2])
+            material "trim" (color=[0.9, 0.9, 0.1])
+            box "b" (mat="body", faces=["", "", "trim", "", "", ""])
+        }"#,
+    );
+    let body = g.find_material("body").unwrap();
+    let trim = g.find_material("trim").unwrap();
+    let kids = children_of(&g, "b");
+    assert_eq!(kids.len(), 2);
+    assert!(kids.iter().any(|k| k.material == Some(body)), "empty entries reuse the box material");
+    assert!(kids.iter().any(|k| k.material == Some(trim)), "named entry overrides one face");
+}
+
+#[test]
+fn faced_box_rejects_wrong_face_count() {
+    let src = r#"scene {
+        material "m" (color=[0.5, 0.5, 0.5])
+        box "b" (faces=["m", "m", "m"])
+    }"#;
+    let ast = parse(src).unwrap();
+    assert!(lower(&ast).is_err(), "faces must have exactly 6 entries");
+}
+
+#[test]
+fn faced_box_rejects_unknown_material() {
+    let src = r#"scene {
+        box "b" (faces=["nope", "nope", "nope", "nope", "nope", "nope"])
+    }"#;
+    let ast = parse(src).unwrap();
+    assert!(lower(&ast).is_err(), "unknown face material must error");
+}
+
+#[test]
+fn faced_box_anchor_shifts_all_faces() {
+    // anchor=bottom moves the whole box up so its base sits on y=0; every face
+    // group must shift together, so the lowest vertex across all children is 0.
+    let g = lower_src(
+        r#"scene {
+            material "m" (color=[0.5, 0.5, 0.5])
+            box "b" (size=[1, 2, 1], anchor="bottom", faces=["m","m","m","m","m","m"])
+        }"#,
+    );
+    let kids = children_of(&g, "b");
+    let min_y = kids
+        .iter()
+        .flat_map(|k| k.mesh.as_ref().unwrap().positions.iter())
+        .map(|p| p[1])
+        .fold(f32::INFINITY, f32::min);
+    assert!(min_y.abs() < 1e-3, "anchored base should rest at y=0 (got {min_y})");
+}

--- a/crates/mogen-dsl/src/lower/tests/hull.rs
+++ b/crates/mogen-dsl/src/lower/tests/hull.rs
@@ -1,0 +1,53 @@
+use super::*;
+use crate::lower::*;
+use crate::parser::parse;
+
+#[test]
+fn hull_lowers_a_closed_box_from_cube_corners() {
+    let g = lower_src(
+        r#"scene {
+            hull "blk" (
+                points=[
+                    [-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1],
+                    [-1, -1,  1], [1, -1,  1], [1, 1,  1], [-1, 1,  1]
+                ]
+            )
+        }"#,
+    );
+    let (min, max) = mesh_aabb(&g, "blk");
+    assert!((min.x + 1.0).abs() < 1e-3 && (max.x - 1.0).abs() < 1e-3, "X span ±1");
+    assert!((min.y + 1.0).abs() < 1e-3 && (max.y - 1.0).abs() < 1e-3, "Y span ±1");
+    assert!((min.z + 1.0).abs() < 1e-3 && (max.z - 1.0).abs() < 1e-3, "Z span ±1");
+    let m = find_mesh_node(&g, "blk").mesh.as_ref().unwrap();
+    assert!(!m.indices.is_empty(), "hull produced no triangles");
+}
+
+#[test]
+fn hull_ignores_interior_points() {
+    // The origin sits inside the cube and must not change the hull's bounds.
+    let g = lower_src(
+        r#"scene {
+            hull "blk" (
+                points=[
+                    [-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1],
+                    [-1, -1,  1], [1, -1,  1], [1, 1,  1], [-1, 1,  1],
+                    [0, 0, 0]
+                ]
+            )
+        }"#,
+    );
+    let (min, max) = mesh_aabb(&g, "blk");
+    assert!((max.x - min.x - 2.0).abs() < 1e-3, "interior point must not grow the hull");
+}
+
+#[test]
+fn hull_rejects_fewer_than_four_points() {
+    // Three points can only span a plane — no closed volume to hull.
+    let src = r#"scene {
+        hull "bad" (
+            points=[[0, 0, 0], [1, 0, 0], [0, 1, 0]]
+        )
+    }"#;
+    let ast = parse(src).unwrap();
+    assert!(lower(&ast).is_err(), "hull must reject fewer than 4 points");
+}

--- a/crates/mogen-dsl/src/lower/tests/mod.rs
+++ b/crates/mogen-dsl/src/lower/tests/mod.rs
@@ -5,6 +5,8 @@ mod branch;
 mod control_flow;
 mod deform;
 mod extrude_sweep_loft;
+mod faced_box;
+mod hull;
 mod layout;
 mod lights;
 mod lod;

--- a/crates/mogen-geom/src/csg.rs
+++ b/crates/mogen-geom/src/csg.rs
@@ -270,6 +270,22 @@ pub fn intersect_many(meshes: &[Mesh]) -> Mesh {
     it.fold(first.clone(), |acc, m| intersect(&acc, m))
 }
 
+/// Convex hull of a 3D point cloud, returned as a clean, watertight,
+/// triplanar-UV'd `Mesh`. Backs the `hull` primitive — the lossless sink for
+/// arbitrary convex solids (e.g. a sheared/sloped 8-corner block) that no
+/// parametric primitive captures. Fewer than 4 points, or a fully coplanar
+/// set, yields a degenerate (empty) hull; callers validate the point count
+/// before reaching here. UVs come from `clean_csg_output`'s triplanar pass,
+/// since a hull has no natural parameterisation.
+pub fn hull_mesh(points: &[[f32; 3]]) -> Mesh {
+    let pts: Vec<[f64; 3]> = points
+        .iter()
+        .map(|p| [p[0] as f64, p[1] as f64, p[2] as f64])
+        .collect();
+    let raw = from_manifold_output(&Manifold::hull_pts(&pts));
+    crate::cleanup::clean_csg_output(&raw)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -321,6 +337,46 @@ mod tests {
     #[test]
     fn is_csg_manifold_accepts_closed_primitive() {
         assert!(is_csg_manifold(&ubox([1.0, 1.0, 1.0])));
+    }
+
+    #[test]
+    fn hull_of_cube_corners_is_a_closed_manifold_box() {
+        // The 8 corners of a unit cube; their convex hull is that cube.
+        let corners: Vec<[f32; 3]> = [-0.5f32, 0.5]
+            .iter()
+            .flat_map(|&x| {
+                [-0.5f32, 0.5].iter().flat_map(move |&y| {
+                    [-0.5f32, 0.5].iter().map(move |&z| [x, y, z])
+                })
+            })
+            .collect();
+        let m = hull_mesh(&corners);
+        assert!(!m.positions.is_empty(), "hull must produce geometry");
+        assert!(
+            is_csg_manifold(&m),
+            "a convex hull must be a watertight, consistently-wound manifold"
+        );
+        // Hull is a clean solid usable as a CSG operand (the migration's
+        // arbitrary-block sink relies on this).
+        assert!(crate::is_closed_manifold(&m));
+        // Extra interior points must not change the convex hull.
+        let mut padded = corners.clone();
+        padded.push([0.0, 0.0, 0.0]);
+        padded.push([0.1, -0.2, 0.3]);
+        let m2 = hull_mesh(&padded);
+        let bb = |mesh: &Mesh| {
+            let mut lo = [f32::MAX; 3];
+            let mut hi = [f32::MIN; 3];
+            for p in &mesh.positions {
+                for k in 0..3 {
+                    lo[k] = lo[k].min(p[k]);
+                    hi[k] = hi[k].max(p[k]);
+                }
+            }
+            (lo, hi)
+        };
+        assert_eq!(bb(&m).0, bb(&m2).0);
+        assert_eq!(bb(&m).1, bb(&m2).1);
     }
 
     #[test]

--- a/crates/mogen-geom/src/lib.rs
+++ b/crates/mogen-geom/src/lib.rs
@@ -22,8 +22,8 @@ pub use conform::{
 };
 #[cfg(any(feature = "csg", feature = "unstable-wasm-uu"))]
 pub use csg::{
-    difference, difference_many, intersect, intersect_many, is_csg_manifold, try_union_many, union,
-    union_many,
+    difference, difference_many, hull_mesh, intersect, intersect_many, is_csg_manifold,
+    try_union_many, union, union_many,
 };
 #[cfg(any(feature = "csg", feature = "unstable-wasm-uu"))]
 pub use csg_smooth::union_smooth;
@@ -33,7 +33,7 @@ pub use sdf::{blob_aabb, evaluate_field, smax, smin, BlobChild, SdfOp, SdfPrim};
 pub use subdivide::loop_subdivide;
 pub use surface_query::{SurfaceIndex, SurfacePoint};
 pub use primitives::{
-    box_mesh, capsule_mesh, chamfered_box_mesh, coil_mesh, cone_mesh, curved_plane_mesh,
+    box_faces_mesh, box_mesh, capsule_mesh, chamfered_box_mesh, coil_mesh, cone_mesh, curved_plane_mesh,
     cylinder_mesh, disc_mesh, ellipsoid_mesh, extrude_mesh, frustum_mesh, half_cylinder_mesh,
     heightfield_mesh,
     hemisphere_mesh, icosphere_mesh, inset_box_mesh, lathe_mesh, leaf_card_mesh, loft_mesh,
@@ -87,9 +87,12 @@ mod csg_stub {
     pub fn union_smooth(_meshes: &[Mesh], _k: f32) -> Mesh {
         unsupported()
     }
+    pub fn hull_mesh(_points: &[[f32; 3]]) -> Mesh {
+        unsupported()
+    }
 }
 #[cfg(not(any(feature = "csg", feature = "unstable-wasm-uu")))]
 pub use csg_stub::{
-    difference, difference_many, intersect, intersect_many, is_csg_manifold, try_union_many, union,
-    union_many, union_smooth,
+    difference, difference_many, hull_mesh, intersect, intersect_many, is_csg_manifold,
+    try_union_many, union, union_many, union_smooth,
 };

--- a/crates/mogen-geom/src/primitives.rs
+++ b/crates/mogen-geom/src/primitives.rs
@@ -28,7 +28,7 @@ pub use coil::{coil_mesh, Handedness as CoilHandedness};
 pub use heightfield::heightfield_mesh;
 pub use bezier_patch::bezier_patch_mesh;
 pub use metaball::metaball_mesh;
-pub use cuboid::box_mesh;
+pub use cuboid::{box_faces_mesh, box_mesh};
 pub use cylinder::{cylinder_mesh, half_cylinder_mesh, tube_mesh};
 pub use disc::disc_mesh;
 pub use extrude::{extrude_mesh, Contour};

--- a/crates/mogen-geom/src/primitives/cuboid.rs
+++ b/crates/mogen-geom/src/primitives/cuboid.rs
@@ -1,17 +1,20 @@
 use mogen_core::{Mesh, UvMode};
 
-pub fn box_mesh(size: [f32; 3], mode: UvMode) -> Mesh {
+/// The six box faces in canonical order: `+X, -X, +Y, -Y, +Z, -Z`. This order
+/// is the public contract for per-face material assignment (`box (faces=[…])`
+/// in the DSL), so it must stay stable.
+///
+/// Each entry is `(outward normal, four CCW corners, (u_size, v_size) tile
+/// dimensions, per-corner tile-space coords)` for a unit-centred box of the
+/// given `size`.
+fn box_faces(size: [f32; 3]) -> [([f32; 3], [[f32; 3]; 4], [f32; 2], [[f32; 2]; 4]); 6] {
     let hx = size[0] * 0.5;
     let hy = size[1] * 0.5;
     let hz = size[2] * 0.5;
     let sx = size[0];
     let sy = size[1];
     let sz = size[2];
-
-    // Each face: outward normal, four CCW corners, the (u_axis_size, v_axis_size)
-    // that defines the face's tile-space dimensions, and per-corner local 2D
-    // coordinates in [0, u_size]×[0, v_size] for tile mode.
-    let faces: [([f32; 3], [[f32; 3]; 4], [f32; 2], [[f32; 2]; 4]); 6] = [
+    [
         // +X: U=Z, V=Y. Corner order matches positions.
         ([1.0, 0.0, 0.0],  [[ hx, -hy, -hz], [ hx,  hy, -hz], [ hx,  hy,  hz], [ hx, -hy,  hz]],
             [sz, sy], [[0.0, 0.0], [0.0, sy], [sz, sy], [sz, 0.0]]),
@@ -30,16 +33,30 @@ pub fn box_mesh(size: [f32; 3], mode: UvMode) -> Mesh {
         // -Z: U=X (flipped), V=Y.
         ([0.0, 0.0, -1.0], [[ hx, -hy, -hz], [-hx, -hy, -hz], [-hx,  hy, -hz], [ hx,  hy, -hz]],
             [sx, sy], [[0.0, 0.0], [sx, 0.0], [sx, sy], [0.0, sy]]),
-    ];
+    ]
+}
 
-    let mut positions = Vec::with_capacity(24);
-    let mut normals = Vec::with_capacity(24);
-    let mut uvs = Vec::with_capacity(24);
-    let mut indices = Vec::with_capacity(36);
+pub fn box_mesh(size: [f32; 3], mode: UvMode) -> Mesh {
+    box_faces_mesh(size, mode, &[0, 1, 2, 3, 4, 5])
+}
+
+/// Build a box made of only the requested faces (indices into [`box_faces`]'s
+/// canonical `+X,-X,+Y,-Y,+Z,-Z` order). Used to split a box into per-face
+/// quad groups so each group can carry its own material. Out-of-range indices
+/// are ignored.
+pub fn box_faces_mesh(size: [f32; 3], mode: UvMode, include: &[usize]) -> Mesh {
+    let faces = box_faces(size);
+    let mut positions = Vec::with_capacity(include.len() * 4);
+    let mut normals = Vec::with_capacity(include.len() * 4);
+    let mut uvs = Vec::with_capacity(include.len() * 4);
+    let mut indices = Vec::with_capacity(include.len() * 6);
     // Fit-mode UVs collapse every face into the unit square so each face shows
     // the texture once. Tile-mode UVs are world-space metres.
     const FIT_UVS: [[f32; 2]; 4] = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
-    for (normal, verts, _size, tile_uvs) in faces {
+    for &fi in include {
+        let Some((normal, verts, _size, tile_uvs)) = faces.get(fi).copied() else {
+            continue;
+        };
         let base = positions.len() as u32;
         for (i, v) in verts.into_iter().enumerate() {
             positions.push(v);

--- a/crates/mogen-validate/src/ast_checks/schema.rs
+++ b/crates/mogen-validate/src/ast_checks/schema.rs
@@ -13,7 +13,7 @@ pub const KNOWN_KINDS: &[&str] = &[
     "prism", "pyramid", "disc", "icosphere", "rounded_box", "chamfered_box", "inset_box",
     "wedge", "frustum", "tube", "hemisphere", "half_cylinder", "torus_arc", "ellipsoid", "heightfield", "bezier_patch", "metaball", "blob",
     "superellipsoid", "curved_plane", "lathe", "spline_tube", "spline_ribbon", "coil", "leaf_card", "mesh",
-    "extrude", "sweep", "loft",
+    "extrude", "sweep", "loft", "hull",
     "slab", "post", "panel", "wall",
     "branch",
     "building", "room_type", "adjacency",
@@ -145,7 +145,8 @@ pub fn attrs_for_kind(kind: &str) -> &'static [&'static str] {
             // same MoGHub model instead of allocating a new slug.
             "moghub_model_id", "moghub_slug", "moghub_version",
         ],
-        "box" | "plane" | "quad" | "prism" => &["size"],
+        "box" => &["size", "faces"],
+        "plane" | "quad" | "prism" => &["size"],
         "slab" | "post" | "panel" => &["size"],
         "wall" => &["size", "holes"],
         "stack" => &["axis", "align", "pack"],
@@ -198,6 +199,7 @@ pub fn attrs_for_kind(kind: &str) -> &'static [&'static str] {
             "profile", "path", "samples", "twist", "roll", "scale_along", "caps",
         ],
         "loft" => &["points", "heights", "samples", "caps"],
+        "hull" => &["points"],
         "mesh" => &["src"],
         "branch" => &[
             "length", "radius", "depth", "splits", "length_falloff", "radius_falloff",
@@ -389,6 +391,7 @@ pub(super) fn attr_type(kind: &str, attr: &str) -> Option<&'static str> {
         | ("post", "size")
         | ("panel", "size")
         | ("wall", "size") => "number or vec3",
+        ("box", "faces") => "list of string",
         ("wall", "holes") => "list",
         ("stack", "axis") | ("stack", "align") | ("stack", "pack") => "string",
         ("solid", "cleanup") => "string",
@@ -416,6 +419,7 @@ pub(super) fn attr_type(kind: &str, attr: &str) -> Option<&'static str> {
         ("loft", "points") => "list",
         ("loft", "heights") => "list of number",
         ("loft", "samples") | ("loft", "caps") => "number",
+        ("hull", "points") => "list",
         ("leaf_card", "size") => "number or vec3",
         ("leaf_card", "cards") => "number",
         ("decal", "size") => "list",

--- a/crates/mogen-validate/src/ast_checks/tests.rs
+++ b/crates/mogen-validate/src/ast_checks/tests.rs
@@ -375,6 +375,39 @@ mod common_attr_scope_tests {
     }
 
     #[test]
+    fn box_accepts_faces_attr() {
+        // Per-face materials: `faces=` is a box-only attribute holding a list
+        // of strings. It must validate cleanly on `box`.
+        let src = r#"
+            material "a" (color=[0.5, 0.5, 0.5])
+            scene {
+              box "b" (size=[1,1,1], faces=["a", "a", "a", "a", "a", "a"])
+            }
+        "#;
+        let diags = diags_for(src);
+        assert!(
+            !has_unknown_attr(&diags, "faces", "box"),
+            "faces= must be a recognised box attribute, got {diags:?}"
+        );
+        assert!(
+            diags.iter().all(|d| d.severity != Severity::Error),
+            "well-formed faced box should not error, got {diags:?}"
+        );
+    }
+
+    #[test]
+    fn faces_attr_rejected_on_non_box_primitives() {
+        // `faces=` is meaningful only on `box`; the schema split keeps siblings
+        // like `plane`/`quad` from silently accepting it.
+        let src = r#"scene { plane "p" (size=[1,1,1], faces=["a","a","a","a","a","a"]) }"#;
+        let diags = diags_for(src);
+        assert!(
+            has_unknown_attr(&diags, "faces", "plane"),
+            "faces= on plane should warn W0102, got {diags:?}"
+        );
+    }
+
+    #[test]
     fn light_requires_kind() {
         let src = r#"scene { light "x" () }"#;
         let diags = diags_for(src);

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -345,7 +345,7 @@ All primitives accept the common attributes above (`pos`, `rot`, `scale`,
 
 | kind | required attrs | other attrs |
 |---|---|---|
-| `box` | `size=[x,y,z]` | — |
+| `box` | `size=[x,y,z]` | `faces=[…]` — six material names in `+X,-X,+Y,-Y,+Z,-Z` order for [per-face materials](#per-face-box-materials-faces) |
 | `plane` | `size=[x,_,z]` (Y ignored) | — |
 | `quad` | `size=[w,h]` or `vec3` (w,h,_) | — |
 | `cylinder` | `radius`, `height` | `segments` (default 24) |
@@ -380,6 +380,7 @@ All primitives accept the common attributes above (`pos`, `rot`, `scale`,
 | `extrude` | `points=[[x,z], …]` (closed CCW) | `hole=[[x,z], …]` (one CW inner contour), `height` (1.0), `taper` (1.0), `twist` (0), `caps` (1). Multi-hole: chain `extrude` + `difference` |
 | `sweep` | `profile=[[x,y], …]` (closed CCW), `path=[[x,y,z], …]` | `samples` per segment (8), `twist` (uniform deg), `roll=[deg, …]`, `scale_along=[s, …]`, `caps` (1). Generalises `spline_tube`/`spline_ribbon` |
 | `loft` | `points=[[x,z], …]`, `heights=[y, …]` | sections flat-packed in `points` (vertex counts must match); `samples` (4), `caps` (1) |
+| `hull` | `points=[[x,y,z], …]` (≥4) | convex hull of the point cloud — the tightest closed manifold enclosing them. Interior points are ignored. Lossless sink for any convex polyhedron (sheared boxes, wedges, ramps) when no parametric primitive fits |
 | `leaf_card` | `size=[w,h]` | `cards` (2). Alpha-cutout foliage cluster — one quad + `cards-1` rotated copies sharing an XY plane. Pair with `alpha_mode="mask"` + `double_sided=1` |
 | `mesh` | `src="path.glb"` | embed an external glTF binary as a single mesh. Path relative to the calling `.mog`. Source materials/skinning/animations are dropped — set them in the DSL |
 | `branch` | — | procedural tree / vine / antler. See [Branch](#branch) below |
@@ -411,6 +412,39 @@ wall "barracks" (size=[3, 3, 0.1], holes=[
   [ 0.9,  0.3, 0.8, 0.8],    // window
 ])
 ```
+
+### Per-face box materials (`faces=`)
+
+A `box` can carry a different material on each face via `faces=[…]` — exactly
+six material names in the fixed order **`+X, -X, +Y, -Y, +Z, -Z`**:
+
+```
+material "wood"  (color=[0.6, 0.4, 0.2])
+material "metal" (color=[0.7, 0.7, 0.75], metallic=0.9)
+
+box "crate" (size=[2, 1, 1], faces=[
+  "wood", "wood",   // +X, -X
+  "metal",          // +Y (lid)
+  "wood", "wood", "wood"  // -Y, +Z, -Z
+])
+```
+
+The box lowers to an editable wrapper (keeping its transform, anchor, and
+connectors) plus one **frozen** child per distinct material — each a quad group
+of just that material's faces. Faces sharing a material collapse into one child,
+so the crate above becomes two children (`wood` ×5, `metal` ×1), not six. The
+children have no AST of their own, so the Studio inspector redirects clicks to
+the wrapper.
+
+An empty entry `""` falls back to the box's own `mat=` (or inherited material),
+so you can override just the faces you care about:
+
+```
+box "panel" (mat="body", faces=["", "", "label", "", "", ""])  // only +Y differs
+```
+
+This is the migration sink for engine map blocks whose six faces each reference
+a different tile texture.
 
 ### Branch
 

--- a/examples/features/faced_crate.mog
+++ b/examples/features/faced_crate.mog
@@ -1,0 +1,23 @@
+// Per-face box materials. `faces=` lists six material names in the fixed
+// +X, -X, +Y, -Y, +Z, -Z order — one per cube face. The box lowers to an
+// editable wrapper plus one frozen child per distinct material (faces sharing
+// a material collapse into a single quad group), so a crate with a metal lid
+// on timber sides is two child meshes, not six. This is the migration sink for
+// engine map blocks whose six faces each name a different tile texture.
+
+material "timber" (color=[0.55, 0.38, 0.20], roughness=0.7)
+material "lid"    (color=[0.72, 0.72, 0.78], metallic=0.85, roughness=0.35)
+material "label"  (color=[0.85, 0.15, 0.12], roughness=0.6)
+
+scene {
+  box "crate" (
+    size=[1.2, 0.9, 1.2],
+    anchor="bottom",
+    faces=[
+      "label",  "timber", // +X carries the stencil, -X bare timber
+      "lid",              // +Y metal lid
+      "timber",           // -Y underside
+      "timber", "timber"  // +Z, -Z sides
+    ]
+  )
+}

--- a/examples/features/hull_ramp.mog
+++ b/examples/features/hull_ramp.mog
@@ -1,0 +1,21 @@
+// Convex hull of a raw point cloud, built with the `hull` primitive. The 8
+// corners below describe a sheared, tapered block — a slab whose top face is
+// both tilted and narrower than its base, so no axis-aligned box or wedge
+// fits it. `hull` wraps the tightest closed manifold around the points, so
+// any convex polyhedron (ramps, bevelled kerbs, lopsided crates) becomes a
+// single compact node. Interior points are ignored, so a cloud sampled off a
+// scanned chunk of geometry collapses straight to its convex shell.
+
+material "concrete" (color=[0.55, 0.55, 0.52], roughness=0.9)
+
+scene {
+  hull "ramp" (
+    points=[
+      // base rectangle (y = 0)
+      [-1.0, 0.0, -0.6], [1.0, 0.0, -0.6], [1.0, 0.0, 0.6], [-1.0, 0.0, 0.6],
+      // top rectangle: lifted, shifted +x, and narrowed in z
+      [-0.4, 0.8, -0.3], [0.7, 1.1, -0.3], [0.7, 1.1, 0.3], [-0.4, 0.8, 0.3]
+    ],
+    mat="concrete"
+  )
+}


### PR DESCRIPTION
## Summary

Two DSL features that make simple block geometry compact and editable — and that unblock an automated pipeline migrating engine map blocks (each block = a 6-faced box with a texture per face) into editable `.mog`.

- **`hull (points=[[x,y,z], …])`** — convex hull of a point cloud, built via Manifold (`hull_pts`). The lossless sink for arbitrary convex polyhedra (sheared boxes, ramps, bevelled kerbs) when no parametric primitive fits. Requires ≥4 points; no-csg builds get the usual stub.
- **`box (faces=[…])`** — six material names in the fixed `+X, -X, +Y, -Y, +Z, -Z` order. The box lowers to an **editable, meshless wrapper** (keeps its transform, anchor, and connectors) plus one **frozen** child per distinct material — each a quad group of just that material's faces. Faces sharing a material collapse into a single child, and an empty `""` entry falls back to the box's own `mat=`. Studio's existing non-editable→editable-ancestor pick redirect handles the wrapper with no change.

## Implementation notes

- `hull_mesh` added to `mogen-geom` (gated `csg` + stub), wired through DSL lowering and the validate schema.
- `cuboid.rs` refactored to expose `box_faces_mesh(size, mode, &[face_indices])`; `box_mesh` now calls it with all six faces.
- New `mogen-dsl/src/lower/faced_box.rs` groups faces by resolved material and emits the frozen children; intercepted in `node.rs` before the single-mesh path.
- New AST accessor `attr_list_string`; schema split so `faces` is box-only (not inherited by `plane`/`quad`/`prism`).
- Docs: primitives-table rows + a "Per-face box materials" section and a `hull` row in `docs/dsl.md`.
- Examples: `examples/features/hull_ramp.mog`, `examples/features/faced_crate.mog`.

## Test plan

- [x] `cargo build` (whole workspace) clean
- [x] `cargo test -p mogen-geom -p mogen-dsl -p mogen-validate` — all green (incl. 1 geom hull unit test, 3 hull lowering tests, 6 faced-box lowering tests, 2 faces validation tests)
- [x] CLI `check` + `build` on both example files produce valid GLB (hull: 12 tris; faced crate: 3 materials → 3 frozen children)

🤖 Generated with [Claude Code](https://claude.com/claude-code)