### PR TITLE
Add remote-control web UI to MoGen Studio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,6 +2822,7 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
+ "tiny_http",
  "webbrowser",
  "zip",
 ]

--- a/crates/mogen-studio/Cargo.toml
+++ b/crates/mogen-studio/Cargo.toml
@@ -70,9 +70,11 @@ arboard = { version = "3", default-features = false }
 # tree stable.
 regex = "1"
 sentry = { version = "0.34", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls"] }
-# Browser shim — opens the GitHub OAuth URL via the system handler.
-# tiny_http is pulled in transitively via mogen-moghub-client's `oauth`
-# feature; we only need webbrowser directly here for the publish-success
-# "Open in browser" affordance.
+# Embedded HTTP server for the remote-control web UI (Preferences › Remote).
+# Already in the dependency tree via mogen-moghub-client's `oauth` feature and
+# mogen-llm, so this adds no new transitive weight.
+tiny_http = "0.12"
+# Browser shim — opens the GitHub OAuth URL via the system handler. Also used
+# by Preferences › Remote's "Open in browser" button.
 webbrowser = "1"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }

--- a/crates/mogen-studio/assets/remote/index.html
+++ b/crates/mogen-studio/assets/remote/index.html
@@ -1,0 +1,534 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MoGen Remote</title>
+<style>
+  :root {
+    --bg: #0d0f13;
+    --bg-soft: #14171d;
+    --card: #171b22;
+    --card-edge: #262c37;
+    --ink: #e8e4dc;
+    --ink-dim: #9aa0ab;
+    --ink-faint: #5f6672;
+    --accent: #f0a858;
+    --accent-deep: #b06024;
+    --ok: #6fce8f;
+    --warn: #e8b440;
+    --err: #e86050;
+    --mono: ui-monospace, "SF Mono", "Cascadia Code", "JetBrains Mono", Menlo, Consolas, monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; height: 100%; }
+  body {
+    background:
+      radial-gradient(1200px 600px at 85% -10%, rgba(176, 96, 36, 0.14), transparent 60%),
+      radial-gradient(900px 500px at -10% 110%, rgba(88, 120, 240, 0.06), transparent 60%),
+      var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 1280px; margin: 0 auto; padding: 20px 20px 48px; }
+
+  /* ------------------------------------------------------- header */
+  header {
+    display: flex; align-items: center; gap: 14px;
+    padding: 6px 2px 16px;
+  }
+  .brand {
+    font-size: 1.35rem; font-weight: 700; letter-spacing: 0.2px;
+    display: flex; align-items: baseline; gap: 8px; white-space: nowrap;
+  }
+  .brand .mark { color: var(--accent); }
+  .brand .sub {
+    font-size: 0.78rem; font-weight: 600; color: var(--ink-faint);
+    text-transform: uppercase; letter-spacing: 2.2px;
+  }
+  .spacer { flex: 1; }
+  .conn { display: flex; align-items: center; gap: 8px; font-size: 0.86rem; color: var(--ink-dim); }
+  .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--err); transition: background .3s; }
+  .dot.on { background: var(--ok); box-shadow: 0 0 8px rgba(111, 206, 143, 0.6); }
+
+  /* ------------------------------------------------------- tabs */
+  .tabs { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 14px; }
+  .tab {
+    background: var(--bg-soft); border: 1px solid var(--card-edge);
+    color: var(--ink-dim); border-radius: 8px; padding: 6px 14px;
+    font-size: 0.88rem; cursor: pointer; transition: all .15s;
+    font-family: var(--mono);
+  }
+  .tab:hover { color: var(--ink); border-color: var(--accent-deep); }
+  .tab.active {
+    color: var(--ink); background: linear-gradient(180deg, #22190f, #1b1510);
+    border-color: var(--accent-deep);
+    box-shadow: inset 0 1px 0 rgba(240, 168, 88, 0.15);
+  }
+  .tab .dirty { color: var(--accent); margin-left: 5px; }
+
+  /* ------------------------------------------------------- layout */
+  .grid { display: grid; grid-template-columns: minmax(0, 7fr) minmax(0, 5fr); gap: 16px; }
+  @media (max-width: 900px) { .grid { grid-template-columns: minmax(0, 1fr); } }
+
+  .card {
+    background: var(--card); border: 1px solid var(--card-edge);
+    border-radius: 12px; overflow: hidden;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  }
+  .card + .card { margin-top: 16px; }
+  .card-head {
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 14px; border-bottom: 1px solid var(--card-edge);
+    background: rgba(255, 255, 255, 0.015);
+  }
+  .card-head h2 {
+    margin: 0; font-size: 0.8rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 1.6px; color: var(--ink-dim);
+  }
+  .card-body { padding: 14px; }
+
+  /* ------------------------------------------------------- editor */
+  #editor {
+    width: 100%; min-height: 46vh; resize: vertical;
+    background: #101318; color: #e6e1d6;
+    border: 1px solid var(--card-edge); border-radius: 8px;
+    padding: 12px 14px; font-family: var(--mono); font-size: 13.5px;
+    line-height: 1.55; tab-size: 2; outline: none;
+    white-space: pre; overflow-wrap: normal; overflow-x: auto;
+  }
+  #editor:focus { border-color: var(--accent-deep); box-shadow: 0 0 0 3px rgba(176, 96, 36, 0.18); }
+  .editor-bar { display: flex; align-items: center; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
+  .hint { font-size: 0.8rem; color: var(--ink-faint); }
+  .hint.pending { color: var(--warn); }
+
+  /* ------------------------------------------------------- buttons */
+  button.btn {
+    font-family: var(--sans); font-size: 0.88rem; font-weight: 600;
+    border-radius: 8px; padding: 7px 16px; cursor: pointer;
+    border: 1px solid var(--card-edge); background: var(--bg-soft); color: var(--ink);
+    transition: all .15s;
+  }
+  button.btn:hover:not(:disabled) { border-color: var(--accent-deep); }
+  button.btn:disabled { opacity: 0.4; cursor: default; }
+  button.btn.primary {
+    background: linear-gradient(180deg, #cf7f34, #a5551f);
+    border-color: #cf7f34; color: #fff8ef;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
+  }
+  button.btn.primary:hover:not(:disabled) { filter: brightness(1.1); }
+
+  /* ------------------------------------------------------- preview */
+  .preview-box {
+    position: relative; aspect-ratio: 1 / 1; max-height: 380px;
+    display: flex; align-items: center; justify-content: center;
+    background:
+      radial-gradient(closest-side, rgba(240, 168, 88, 0.05), transparent),
+      #363a40;
+    border-radius: 8px; overflow: hidden;
+  }
+  .preview-box img { max-width: 100%; max-height: 100%; display: none; }
+  .preview-empty { color: var(--ink-faint); font-size: 0.85rem; text-align: center; padding: 0 20px; }
+
+  /* ------------------------------------------------------- stats / chips */
+  .stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+  .stat {
+    background: var(--bg-soft); border: 1px solid var(--card-edge);
+    border-radius: 8px; padding: 8px 12px;
+  }
+  .stat .k { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 1.2px; color: var(--ink-faint); }
+  .stat .v { font-size: 1.15rem; font-weight: 700; font-family: var(--mono); }
+
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 0.75rem; font-weight: 700; letter-spacing: 0.8px;
+    padding: 3px 10px; border-radius: 999px; text-transform: uppercase;
+  }
+  .chip.ok   { background: rgba(111, 206, 143, 0.12); color: var(--ok); }
+  .chip.err  { background: rgba(232, 96, 80, 0.14);  color: var(--err); }
+  .chip.busy { background: rgba(232, 180, 64, 0.13); color: var(--warn); }
+  .chip.busy::before {
+    content: ""; width: 8px; height: 8px; border-radius: 50%;
+    background: currentColor; animation: pulse 1.1s ease-in-out infinite;
+  }
+  @keyframes pulse { 50% { opacity: 0.25; } }
+
+  .statusline {
+    margin-top: 12px; font-family: var(--mono); font-size: 0.82rem;
+    color: var(--ink-dim); word-break: break-word;
+  }
+  .actions { display: flex; gap: 8px; margin-top: 12px; flex-wrap: wrap; }
+
+  /* ------------------------------------------------------- diagnostics */
+  .diag-list { display: flex; flex-direction: column; gap: 6px; max-height: 300px; overflow-y: auto; }
+  .diag {
+    display: flex; gap: 10px; align-items: baseline;
+    background: var(--bg-soft); border: 1px solid var(--card-edge);
+    border-left: 3px solid var(--ink-faint);
+    border-radius: 6px; padding: 7px 10px; cursor: pointer;
+    font-size: 0.84rem;
+  }
+  .diag:hover { border-color: var(--accent-deep); }
+  .diag.error   { border-left-color: var(--err); }
+  .diag.warning { border-left-color: var(--warn); }
+  .diag .code { font-family: var(--mono); color: var(--ink-faint); flex-shrink: 0; }
+  .diag .line { font-family: var(--mono); color: var(--accent); flex-shrink: 0; }
+  .diag-clean { color: var(--ink-faint); font-size: 0.86rem; padding: 4px 2px; }
+  .diag-clean .tick { color: var(--ok); }
+
+  /* ------------------------------------------------------- toasts */
+  #toasts {
+    position: fixed; bottom: 18px; left: 50%; transform: translateX(-50%);
+    display: flex; flex-direction: column; gap: 8px; z-index: 50; align-items: center;
+  }
+  .toast {
+    background: #21262f; border: 1px solid var(--card-edge); color: var(--ink);
+    border-radius: 8px; padding: 9px 18px; font-size: 0.86rem;
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.5);
+    animation: rise .2s ease-out;
+  }
+  .toast.err { border-color: var(--err); color: #f4b0a8; }
+  @keyframes rise { from { opacity: 0; transform: translateY(8px); } }
+
+  footer {
+    margin-top: 28px; text-align: center;
+    color: var(--ink-faint); font-size: 0.78rem;
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div class="brand">Mo<span class="mark">Gen</span>&nbsp;<span class="sub">Remote</span></div>
+    <div class="spacer"></div>
+    <div class="conn"><span class="dot" id="conn-dot"></span><span id="conn-text">connecting…</span></div>
+  </header>
+
+  <div class="tabs" id="tabs"></div>
+
+  <div class="grid">
+    <div>
+      <div class="card">
+        <div class="card-head">
+          <h2>Source</h2>
+          <div class="spacer" style="flex:1"></div>
+          <span class="hint" id="edit-hint">synced</span>
+        </div>
+        <div class="card-body">
+          <textarea id="editor" spellcheck="false" autocomplete="off" autocapitalize="off"></textarea>
+          <div class="editor-bar">
+            <button class="btn primary" id="btn-apply" disabled>Apply</button>
+            <button class="btn" id="btn-discard" disabled>Discard edits</button>
+            <div class="spacer" style="flex:1"></div>
+            <button class="btn" id="btn-save">Save</button>
+            <button class="btn" id="btn-recompile">Recompile</button>
+            <button class="btn primary" id="btn-build">Build GLB</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <h2>Diagnostics</h2>
+          <div class="spacer" style="flex:1"></div>
+          <span class="chip ok" id="stage-chip">—</span>
+        </div>
+        <div class="card-body">
+          <div class="diag-list" id="diags"></div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div class="card">
+        <div class="card-head"><h2>Preview</h2></div>
+        <div class="card-body">
+          <div class="preview-box">
+            <img id="preview" alt="viewport preview">
+            <div class="preview-empty" id="preview-empty">
+              Waiting for the first render…<br>
+              <span style="font-size:0.78rem">The preview orbits the compiled scene and refreshes live.</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <h2>Scene</h2>
+          <div class="spacer" style="flex:1"></div>
+          <span class="chip busy" id="busy-chip" style="display:none">working</span>
+        </div>
+        <div class="card-body">
+          <div class="stats">
+            <div class="stat"><div class="k">Nodes</div><div class="v" id="stat-nodes">—</div></div>
+            <div class="stat"><div class="k">Triangles</div><div class="v" id="stat-tris">—</div></div>
+            <div class="stat"><div class="k">Issues</div><div class="v" id="stat-diags">—</div></div>
+          </div>
+          <div class="statusline" id="status">—</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <footer>MoGen Studio remote control · changes apply to the live desktop session</footer>
+</div>
+
+<div id="toasts"></div>
+
+<script>
+"use strict";
+
+const $ = (id) => document.getElementById(id);
+const editor = $("editor");
+
+let stateRev = 0;          // last state revision we rendered
+let previewRev = -1;       // last preview revision we loaded
+let state = null;          // last snapshot
+let localDirty = false;    // textarea diverges from the server snapshot
+let editingTab = -1;       // tab index the local edits belong to
+let pollTimer = null;
+
+/* ------------------------------------------------------------ helpers */
+
+function toast(msg, isErr) {
+  const t = document.createElement("div");
+  t.className = "toast" + (isErr ? " err" : "");
+  t.textContent = msg;
+  $("toasts").appendChild(t);
+  setTimeout(() => t.remove(), 3200);
+}
+
+async function sendCommand(cmd) {
+  try {
+    const r = await fetch("/api/command", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(cmd),
+    });
+    const j = await r.json().catch(() => ({}));
+    if (!r.ok || j.error) {
+      toast(j.error || ("command failed (" + r.status + ")"), true);
+      return false;
+    }
+    schedulePoll(250); // pick up the effect quickly
+    return true;
+  } catch (e) {
+    toast("connection lost", true);
+    return false;
+  }
+}
+
+function setConnected(on) {
+  $("conn-dot").classList.toggle("on", on);
+  $("conn-text").textContent = on ? "connected" : "disconnected";
+}
+
+function fmt(n) {
+  return n >= 1000000 ? (n / 1000000).toFixed(2) + "M"
+       : n >= 1000    ? (n / 1000).toFixed(1) + "k"
+       : String(n);
+}
+
+/* ------------------------------------------------------------ render */
+
+function render(s) {
+  state = s;
+
+  // Tab strip
+  const tabs = $("tabs");
+  tabs.innerHTML = "";
+  s.tabs.forEach((t, i) => {
+    const b = document.createElement("button");
+    b.className = "tab" + (i === s.active ? " active" : "");
+    b.innerHTML = escapeHtml(t.name) + (t.dirty ? '<span class="dirty">●</span>' : "");
+    b.title = t.path || "unsaved buffer";
+    b.onclick = () => {
+      if (i === s.active) return;
+      if (localDirty && !confirm("Switch tabs? Your unapplied local edits will be discarded.")) return;
+      sendCommand({ cmd: "activate", tab: i });
+    };
+    tabs.appendChild(b);
+  });
+
+  // If the desktop switched tabs while we held local edits, they belong to
+  // a tab that's no longer in front — drop them rather than writing them
+  // into the wrong file.
+  if (localDirty && editingTab !== s.active) resetLocalEdits();
+
+  // Editor: never clobber in-progress local edits.
+  if (!localDirty && editor.value !== s.source) editor.value = s.source;
+
+  // Stage / diagnostics
+  const chip = $("stage-chip");
+  const errs = s.diagnostics.filter((d) => d.severity === "error").length;
+  if (s.stage === "ok" && errs === 0) {
+    chip.className = "chip ok"; chip.textContent = "compiles";
+  } else if (s.stage === "none") {
+    chip.className = "chip ok"; chip.textContent = "—";
+  } else {
+    chip.className = "chip err"; chip.textContent = errs ? errs + " error" + (errs > 1 ? "s" : "") : s.stage;
+  }
+
+  const list = $("diags");
+  list.innerHTML = "";
+  if (s.diagnostics.length === 0) {
+    list.innerHTML = '<div class="diag-clean"><span class="tick">✓</span> No diagnostics — scene is clean.</div>';
+  } else {
+    s.diagnostics.forEach((d) => {
+      const row = document.createElement("div");
+      row.className = "diag " + d.severity;
+      row.innerHTML =
+        '<span class="code">' + escapeHtml(d.code) + "</span>" +
+        (d.line ? '<span class="line">L' + d.line + "</span>" : "") +
+        "<span>" + escapeHtml(d.message) + "</span>";
+      if (d.line) row.onclick = () => jumpToLine(d.line);
+      list.appendChild(row);
+    });
+  }
+
+  // Stats + status
+  $("stat-nodes").textContent = s.nodes ? fmt(s.nodes) : "—";
+  $("stat-tris").textContent = s.triangles ? fmt(s.triangles) : "—";
+  $("stat-diags").textContent = String(s.diagnostics.length);
+  $("status").textContent = s.status || "—";
+
+  // Busy chip: building or LLM in flight
+  const busy = $("busy-chip");
+  if (s.building) {
+    busy.style.display = "";
+    busy.textContent = s.build_stage ? "build: " + s.build_stage : "building…";
+  } else if (s.llm) {
+    busy.style.display = "";
+    busy.textContent = "llm: " + s.llm;
+  } else {
+    busy.style.display = "none";
+  }
+  $("btn-build").disabled = !!s.building;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+function jumpToLine(line) {
+  const lines = editor.value.split("\n");
+  let pos = 0;
+  for (let i = 0; i < Math.min(line - 1, lines.length); i++) pos += lines[i].length + 1;
+  editor.focus();
+  editor.setSelectionRange(pos, pos + (lines[line - 1] || "").length);
+}
+
+/* ------------------------------------------------------------ editing */
+
+function resetLocalEdits() {
+  localDirty = false;
+  editingTab = -1;
+  $("btn-apply").disabled = true;
+  $("btn-discard").disabled = true;
+  const hint = $("edit-hint");
+  hint.textContent = "synced";
+  hint.className = "hint";
+}
+
+editor.addEventListener("input", () => {
+  if (!state) return;
+  localDirty = editor.value !== state.source;
+  editingTab = localDirty ? state.active : -1;
+  $("btn-apply").disabled = !localDirty;
+  $("btn-discard").disabled = !localDirty;
+  const hint = $("edit-hint");
+  hint.textContent = localDirty ? "local edits — Apply to push" : "synced";
+  hint.className = localDirty ? "hint pending" : "hint";
+});
+
+async function applyEdits() {
+  if (!state || !localDirty) return true;
+  const ok = await sendCommand({ cmd: "set_source", tab: state.active, source: editor.value });
+  if (ok) { resetLocalEdits(); toast("source applied"); }
+  return ok;
+}
+
+$("btn-apply").onclick = applyEdits;
+$("btn-discard").onclick = () => {
+  if (state) editor.value = state.source;
+  resetLocalEdits();
+};
+$("btn-save").onclick = async () => {
+  if (!state) return;
+  if (localDirty && !(await applyEdits())) return;
+  if (await sendCommand({ cmd: "save", tab: state.active })) toast("saved");
+};
+$("btn-recompile").onclick = async () => {
+  if (!state) return;
+  if (localDirty && !(await applyEdits())) return;
+  if (await sendCommand({ cmd: "recompile", tab: state.active })) toast("recompiling");
+};
+$("btn-build").onclick = async () => {
+  if (!state) return;
+  if (localDirty && !(await applyEdits())) return;
+  if (await sendCommand({ cmd: "build", tab: state.active })) toast("build started");
+};
+
+// Ctrl/Cmd+S applies + saves, Ctrl/Cmd+Enter applies — the muscle memory
+// people bring from the desktop.
+editor.addEventListener("keydown", (e) => {
+  const mod = e.ctrlKey || e.metaKey;
+  if (mod && e.key === "s") { e.preventDefault(); $("btn-save").click(); }
+  else if (mod && e.key === "Enter") { e.preventDefault(); applyEdits(); }
+  else if (e.key === "Tab") {
+    e.preventDefault();
+    const s = editor.selectionStart, t = editor.selectionEnd;
+    editor.setRangeText("  ", s, t, "end");
+    editor.dispatchEvent(new Event("input"));
+  }
+});
+
+/* ------------------------------------------------------------ preview */
+
+function refreshPreview() {
+  const img = $("preview");
+  const probe = new Image();
+  probe.onload = () => {
+    img.src = probe.src;
+    img.style.display = "block";
+    $("preview-empty").style.display = "none";
+  };
+  probe.onerror = () => {}; // keep the last good frame / placeholder
+  probe.src = "/api/preview.png?r=" + previewRev + "&t=" + Date.now();
+}
+
+// Keep the capture loop alive on the desktop even when the preview rev is
+// static (the endpoint hit is what signals "someone is watching").
+setInterval(() => { if (!document.hidden) refreshPreview(); }, 2500);
+
+/* ------------------------------------------------------------ polling */
+
+function schedulePoll(ms) {
+  clearTimeout(pollTimer);
+  pollTimer = setTimeout(poll, ms);
+}
+
+async function poll() {
+  try {
+    const r = await fetch("/api/state?rev=" + stateRev);
+    const j = await r.json();
+    setConnected(true);
+    if (!j.unchanged && j.state) { stateRev = j.rev; render(j.state); }
+    if (j.preview !== previewRev) { previewRev = j.preview; refreshPreview(); }
+  } catch (e) {
+    setConnected(false);
+  }
+  schedulePoll(document.hidden ? 4000 : 1200);
+}
+
+poll();
+</script>
+</body>
+</html>

--- a/crates/mogen-studio/src/app.rs
+++ b/crates/mogen-studio/src/app.rs
@@ -34,6 +34,7 @@ mod onboarding;
 mod preview;
 mod pricing;
 mod publish_textures;
+mod remote_link;
 mod spend_panel;
 mod spotlight;
 mod style;
@@ -469,6 +470,30 @@ pub struct MogenStudioApp {
     /// Refreshed each time the panel opens or the user clicks Refresh.
     pub(in crate::app) spending: crate::app::spend_panel::SpendingState,
 
+    /// Draft text for the Preferences › Remote port field. Committed (and
+    /// validated) on Enter / focus loss so mid-typing values don't bounce
+    /// the server through invalid ports.
+    prefs_remote_port_draft: String,
+
+    /// Remote-control web UI server, running while Preferences › Remote is
+    /// enabled. `None` when disabled or when the last bind attempt failed
+    /// (see `remote_error`). Reconciled against settings once per frame by
+    /// `drive_remote`.
+    pub(in crate::app) remote: Option<crate::remote::RemoteServer>,
+    /// Human-readable reason the remote server isn't running (port in use,
+    /// bind refused). Shown in Preferences › Remote; cleared on the next
+    /// successful start or when the feature is switched off.
+    pub(in crate::app) remote_error: Option<String>,
+    /// Last snapshot published to the remote server. Compared each frame so
+    /// idle frames cost one `PartialEq` walk instead of a re-serialization.
+    pub(in crate::app) remote_last_snapshot: Option<crate::remote::Snapshot>,
+    /// Wall-clock time the last remote preview capture was submitted.
+    /// Paces the turntable to `remote_link::PREVIEW_INTERVAL`.
+    pub(in crate::app) remote_preview_last_submit: Option<Instant>,
+    /// Current turntable yaw for the remote preview, advanced a step per
+    /// captured frame.
+    pub(in crate::app) remote_preview_yaw: f32,
+
     /// Scene Wizard window visibility. The wizard owns its own state in
     /// `wizard`; this flag just gates the window.
     pub(in crate::app) show_wizard: bool,
@@ -650,6 +675,12 @@ impl MogenStudioApp {
             spend_session_id: gen_session_id(),
             show_spending: false,
             spending: crate::app::spend_panel::SpendingState::default(),
+            prefs_remote_port_draft: String::new(),
+            remote: None,
+            remote_error: None,
+            remote_last_snapshot: None,
+            remote_preview_last_submit: None,
+            remote_preview_yaw: std::f32::consts::FRAC_PI_4,
             show_wizard: false,
             wizard: None,
         }
@@ -927,6 +958,11 @@ impl eframe::App for MogenStudioApp {
         self.drive_moghub_protocol(ctx);
         self.drive_compile_debounce(ctx);
         self.check_external_changes(ctx);
+        // Remote web UI: reconcile the server with settings, drain browser
+        // commands, publish state, and drive the preview turntable. Runs
+        // after the other polls so the snapshot reflects this frame's
+        // completions.
+        self.drive_remote(ctx);
 
         // Consume global shortcuts before the menu / editor see the key event,
         // so e.g. Ctrl+S doesn't reach the TextEdit. Spotlight is dispatched

--- a/crates/mogen-studio/src/app.rs
+++ b/crates/mogen-studio/src/app.rs
@@ -519,6 +519,7 @@ impl MogenStudioApp {
             .seed_override
             .map(|s| s.to_string())
             .unwrap_or_default();
+        let prefs_remote_port_draft = settings.remote_port().to_string();
         install_fonts(&cc.egui_ctx);
         apply_theme(&cc.egui_ctx, settings.theme());
         viewer.set_preview_shader(settings.preview_shader());
@@ -675,7 +676,7 @@ impl MogenStudioApp {
             spend_session_id: gen_session_id(),
             show_spending: false,
             spending: crate::app::spend_panel::SpendingState::default(),
-            prefs_remote_port_draft: String::new(),
+            prefs_remote_port_draft,
             remote: None,
             remote_error: None,
             remote_last_snapshot: None,

--- a/crates/mogen-studio/src/app/generate.rs
+++ b/crates/mogen-studio/src/app/generate.rs
@@ -226,7 +226,10 @@ impl MogenStudioApp {
         if let Some(outcome) = self.viewer.take_capture_outcome_if(|kind| {
             !matches!(
                 kind,
-                CaptureKind::PickerThumb | CaptureKind::Publish | CaptureKind::WizardThumb
+                CaptureKind::PickerThumb
+                    | CaptureKind::Publish
+                    | CaptureKind::WizardThumb
+                    | CaptureKind::RemotePreview
             )
         }) {
             self.handle_capture_outcome(ctx, outcome);
@@ -273,10 +276,14 @@ impl MogenStudioApp {
                     self.files[i].status = "thumbnail: render produced no output".into();
                 }
             }
-            CaptureKind::PickerThumb | CaptureKind::Publish | CaptureKind::WizardThumb => {
+            CaptureKind::PickerThumb
+            | CaptureKind::Publish
+            | CaptureKind::WizardThumb
+            | CaptureKind::RemotePreview => {
                 // PickerThumb is owned by `ThumbnailManager`; Publish by the
-                // community publish dialog; WizardThumb by the Scene Wizard.
-                // `poll_generate` filters all three out before reaching this
+                // community publish dialog; WizardThumb by the Scene Wizard;
+                // RemotePreview by the remote web UI's `poll_remote_preview`.
+                // `poll_generate` filters all four out before reaching this
                 // handler. Reaching here would only happen if the filter were
                 // bypassed — drop on the floor rather than mis-attributing it
                 // to the active file's status.

--- a/crates/mogen-studio/src/app/remote_link.rs
+++ b/crates/mogen-studio/src/app/remote_link.rs
@@ -1,0 +1,372 @@
+//! App-side glue for the remote-control web UI (`crate::remote`).
+//!
+//! Everything runs on the UI thread inside `update()`: reconcile the server
+//! lifecycle with the persisted settings, drain the command queue the HTTP
+//! thread filled, publish a fresh state snapshot when anything observable
+//! changed, and drive the turntable preview captures while a browser is
+//! watching. The HTTP thread itself never touches `MogenStudioApp`.
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use eframe::egui;
+use mogen_core::Severity;
+
+use crate::pipeline::Stage;
+use crate::remote::{DiagInfo, RemoteCommand, RemoteServer, Snapshot, TabInfo};
+use crate::viewer::{CaptureFrame, CaptureKind, CaptureRequest};
+
+use super::types::UndoKey;
+use super::MogenStudioApp;
+
+/// Minimum gap between remote preview captures. Two frames a second is
+/// plenty for a dashboard turntable and keeps the GL cost invisible next to
+/// normal viewport painting.
+const PREVIEW_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Edge length of the square preview render. Matches the thumbnail size —
+/// small enough to encode fast, big enough to look crisp in the dashboard.
+const PREVIEW_SIZE: u32 = 512;
+
+/// Yaw advance per captured frame (radians). One full turn every ~30 s at
+/// the capture cadence — slow enough to read the model, alive enough to
+/// show it's a live view.
+const PREVIEW_YAW_STEP: f32 = 0.105;
+
+impl MogenStudioApp {
+    /// One per-frame tick of everything remote. Called from `update()`.
+    pub(super) fn drive_remote(&mut self, ctx: &egui::Context) {
+        self.reconcile_remote(ctx);
+        if self.remote.is_none() {
+            return;
+        }
+        self.apply_remote_commands(ctx);
+        self.publish_remote_state();
+        self.drive_remote_preview(ctx);
+        self.poll_remote_preview();
+    }
+
+    /// Start / stop / restart the server so it matches the settings. Bind
+    /// errors land in `remote_error` for Preferences to display.
+    fn reconcile_remote(&mut self, ctx: &egui::Context) {
+        let want = self.settings.remote_enabled();
+        let port = self.settings.remote_port();
+        let lan = self.settings.remote_allow_lan();
+
+        let needs_restart = self
+            .remote
+            .as_ref()
+            .map(|s| s.port() != port || s.allow_lan() != lan)
+            .unwrap_or(false);
+
+        if !want || needs_restart {
+            if self.remote.take().is_some() {
+                // Force a fresh snapshot after a restart so a rebound server
+                // doesn't serve `null` until something changes.
+                self.remote_last_snapshot = None;
+            }
+            if !want {
+                self.remote_error = None;
+                return;
+            }
+        }
+        if self.remote.is_some() {
+            return;
+        }
+        match RemoteServer::start(port, lan, ctx.clone()) {
+            Ok(server) => {
+                self.remote = Some(server);
+                self.remote_error = None;
+            }
+            Err(e) => {
+                // Latch the error and flip the setting back off so the app
+                // doesn't retry the failing bind every frame. The user sees
+                // the message in Preferences › Remote and can pick another
+                // port.
+                self.remote_error = Some(e);
+                self.settings.set_remote_enabled(false);
+            }
+        }
+    }
+
+    /// Apply every queued browser command. Tab indices are re-validated here
+    /// because tabs can open/close between enqueue and drain.
+    fn apply_remote_commands(&mut self, ctx: &egui::Context) {
+        let Some(server) = self.remote.as_ref() else {
+            return;
+        };
+        let commands = server.take_commands();
+        for cmd in commands {
+            match cmd {
+                RemoteCommand::ActivateTab(i) => {
+                    if i < self.files.len() && i != self.active {
+                        self.activate(i);
+                    }
+                }
+                RemoteCommand::SetSource { tab, source } => {
+                    if tab >= self.files.len() {
+                        continue;
+                    }
+                    // Same guard as the gizmo path: an in-flight LLM call
+                    // overwrites `source` on completion, so a remote edit
+                    // now would silently vanish.
+                    if self.files[tab].llm_in_flight.is_some() {
+                        self.files[tab].status =
+                            "remote edit ignored — an LLM call is rewriting this file".into();
+                        continue;
+                    }
+                    let before = self.files[tab].source.clone();
+                    if before == source {
+                        continue;
+                    }
+                    {
+                        let f = &mut self.files[tab];
+                        f.source = source;
+                        f.dirty = f.source != f.last_saved_source;
+                        f.needs_compile = true;
+                        f.last_edit_at = Some(Instant::now());
+                        f.status = "remote: source updated".into();
+                    }
+                    // Remote replaces are discrete actions — never coalesce
+                    // them with in-app edits.
+                    self.break_undo_chain(tab);
+                    self.push_undo(
+                        tab,
+                        before,
+                        UndoKey {
+                            surface: "remote",
+                            attr: None,
+                            node_path: Vec::new(),
+                        },
+                    );
+                    if tab == self.active {
+                        self.compile_active();
+                    } else {
+                        self.compile_file(tab);
+                    }
+                }
+                RemoteCommand::Save { tab } => {
+                    if tab >= self.files.len() {
+                        continue;
+                    }
+                    match self.files[tab].path.clone() {
+                        Some(path) => self.save_index_to(tab, &path),
+                        None => {
+                            // Popping a native Save As dialog from a remote
+                            // command would ambush whoever is at the desk.
+                            self.files[tab].status =
+                                "remote save skipped — untitled buffer needs Save As in Studio"
+                                    .into();
+                        }
+                    }
+                }
+                RemoteCommand::Build { tab } => {
+                    if tab >= self.files.len() {
+                        continue;
+                    }
+                    if self.build_rx.is_some() || self.imposter_export_pending.is_some() {
+                        self.files[tab].status =
+                            "remote build skipped — a build is already running".into();
+                        continue;
+                    }
+                    if tab != self.active {
+                        self.activate(tab);
+                    }
+                    // Reuse the tab's remembered export options — the modal
+                    // draft is what `spawn_build` commits back to the file.
+                    self.export_opts_draft = self.files[self.active].export_opts.clone();
+                    self.spawn_build(ctx.clone());
+                }
+                RemoteCommand::Recompile { tab } => {
+                    if tab < self.files.len() {
+                        self.compile_file(tab);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Rebuild the dashboard snapshot and publish it if anything changed.
+    /// The rebuild is cheap (string clones of hand-sized `.mog` sources);
+    /// the `PartialEq` gate keeps idle frames from re-serializing.
+    fn publish_remote_state(&mut self) {
+        let Some(server) = self.remote.as_ref() else {
+            return;
+        };
+        let f = &self.files[self.active];
+        let result = f.last_result.as_ref();
+
+        let stage = match result.map(|r| r.stage) {
+            None => "none",
+            Some(Stage::Ok) => "ok",
+            Some(Stage::Parse) => "parse",
+            Some(Stage::ValidateAst) => "validate-ast",
+            Some(Stage::Lower) => "lower",
+            Some(Stage::ValidateGraph) => "validate-graph",
+        };
+
+        let diagnostics = result
+            .map(|r| {
+                r.diagnostics
+                    .iter()
+                    .map(|d| DiagInfo {
+                        severity: match d.severity {
+                            Severity::Error => "error",
+                            Severity::Warning => "warning",
+                            Severity::Info => "info",
+                        }
+                        .to_string(),
+                        code: d.code.clone(),
+                        message: d.message.clone(),
+                        line: d.span.map(|s| line_of_offset(&f.source, s.start)),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let (nodes, triangles) = result
+            .and_then(|r| r.scene.as_ref())
+            .map(|s| {
+                let tris: usize = s
+                    .nodes
+                    .iter()
+                    .filter_map(|n| n.mesh.as_ref())
+                    .map(|m| m.indices.len() / 3)
+                    .sum();
+                (s.nodes.len(), tris)
+            })
+            .unwrap_or((0, 0));
+
+        let snapshot = Snapshot {
+            app_version: env!("CARGO_PKG_VERSION").to_string(),
+            tabs: self
+                .files
+                .iter()
+                .map(|f| TabInfo {
+                    name: f.display_name(),
+                    path: f.path.as_ref().map(|p| p.display().to_string()),
+                    dirty: f.dirty,
+                })
+                .collect(),
+            active: self.active,
+            source: f.source.clone(),
+            status: f.status.clone(),
+            stage: stage.to_string(),
+            diagnostics,
+            nodes,
+            triangles,
+            building: self.build_rx.is_some() || self.imposter_export_pending.is_some(),
+            build_stage: self.build_stage.lock().unwrap().clone(),
+            llm: f.llm_in_flight.map(|k| k.label().to_string()),
+        };
+
+        if self.remote_last_snapshot.as_ref() != Some(&snapshot) {
+            server.publish_state(&snapshot);
+            self.remote_last_snapshot = Some(snapshot);
+        }
+    }
+
+    /// Submit the next turntable frame while a browser is watching the
+    /// preview. Skips whenever the single capture slot is busy with real
+    /// user work (thumbnails, video, publish, picker thumbs) — the remote
+    /// preview is strictly lowest-priority.
+    fn drive_remote_preview(&mut self, ctx: &egui::Context) {
+        let Some(server) = self.remote.as_ref() else {
+            return;
+        };
+        if !server.preview_watchers_active() {
+            return;
+        }
+        // Keep the loop ticking even with no local input: captures complete
+        // inside paint callbacks, so somebody has to keep requesting frames.
+        ctx.request_repaint_after(PREVIEW_INTERVAL);
+
+        if !self.viewer.has_scene()
+            || self.generate_in_flight()
+            || self.picker.is_some()
+            || self.thumbnail_mgr.is_busy()
+            || self.pending_modify_capture.is_some()
+            || self.imposter_export_pending.is_some()
+        {
+            return;
+        }
+        let due = self
+            .remote_preview_last_submit
+            .map(|t| t.elapsed() >= PREVIEW_INTERVAL)
+            .unwrap_or(true);
+        if !due {
+            return;
+        }
+        self.remote_preview_last_submit = Some(Instant::now());
+        self.remote_preview_yaw =
+            (self.remote_preview_yaw + PREVIEW_YAW_STEP) % std::f32::consts::TAU;
+        self.viewer.submit_capture(CaptureRequest {
+            kind: CaptureKind::RemotePreview,
+            size: PREVIEW_SIZE,
+            bg: self.settings.viewer_bg_rgb(),
+            frames: vec![CaptureFrame {
+                yaw: self.remote_preview_yaw,
+                pitch: 0.5,
+                time: 0.0,
+                path: remote_preview_path(),
+            }],
+            // submit_capture overwrites these bookkeeping fields.
+            total: 0,
+            written: Vec::new(),
+            error: None,
+        });
+    }
+
+    /// Drain a finished remote-preview capture and hand the PNG bytes to the
+    /// server. Errors are dropped silently — the dashboard keeps its last
+    /// good frame and the next tick retries.
+    fn poll_remote_preview(&mut self) {
+        let Some(server) = self.remote.as_ref() else {
+            return;
+        };
+        let Some(outcome) = self
+            .viewer
+            .take_capture_outcome_if(|kind| matches!(kind, CaptureKind::RemotePreview))
+        else {
+            return;
+        };
+        if outcome.error.is_some() {
+            return;
+        }
+        let Some(path) = outcome.frame_paths.last() else {
+            return;
+        };
+        if let Ok(bytes) = std::fs::read(path) {
+            server.publish_preview(bytes);
+        }
+    }
+}
+
+/// 1-based line number of a byte offset. Offsets past EOF clamp to the last
+/// line — diagnostics can outlive the exact source they were minted from by
+/// a frame.
+fn line_of_offset(source: &str, offset: usize) -> usize {
+    let end = offset.min(source.len());
+    source[..end].bytes().filter(|&b| b == b'\n').count() + 1
+}
+
+/// Scratch path the GL worker writes preview frames to. Fixed per-process
+/// so successive captures overwrite instead of accumulating.
+fn remote_preview_path() -> PathBuf {
+    std::env::temp_dir().join(format!("mogen-remote-preview-{}.png", std::process::id()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::line_of_offset;
+
+    #[test]
+    fn line_of_offset_basics() {
+        let src = "a\nbb\nccc\n";
+        assert_eq!(line_of_offset(src, 0), 1);
+        assert_eq!(line_of_offset(src, 2), 2);
+        assert_eq!(line_of_offset(src, 5), 3);
+        // Past-EOF clamps instead of panicking.
+        assert_eq!(line_of_offset(src, 999), 4);
+    }
+}

--- a/crates/mogen-studio/src/app/ui_dialogs/prefs.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/prefs.rs
@@ -16,6 +16,7 @@ pub enum PrefsTab {
     #[default]
     Llm,
     Appearance,
+    Remote,
     Privacy,
 }
 
@@ -24,12 +25,18 @@ impl PrefsTab {
         match self {
             PrefsTab::Llm => "LLM",
             PrefsTab::Appearance => "Appearance",
+            PrefsTab::Remote => "Remote",
             PrefsTab::Privacy => "Privacy",
         }
     }
 }
 
-const PREFS_TABS: [PrefsTab; 3] = [PrefsTab::Llm, PrefsTab::Appearance, PrefsTab::Privacy];
+const PREFS_TABS: [PrefsTab; 4] = [
+    PrefsTab::Llm,
+    PrefsTab::Appearance,
+    PrefsTab::Remote,
+    PrefsTab::Privacy,
+];
 
 /// Models surfaced in the Preferences dropdown for each slot. Free-form
 /// text still wins if a user types one in, but these cover the tiers almost
@@ -198,6 +205,7 @@ impl MogenStudioApp {
                         match self.prefs_active_tab {
                             PrefsTab::Llm => self.prefs_tab_llm(ui),
                             PrefsTab::Appearance => self.prefs_tab_appearance(ui, ctx),
+                            PrefsTab::Remote => self.prefs_tab_remote(ui),
                             PrefsTab::Privacy => self.prefs_tab_privacy(ui),
                         }
                     });
@@ -431,6 +439,124 @@ impl MogenStudioApp {
         if let Some(val) = new_fps {
             self.settings.set_max_fps(val);
             self.viewer.set_max_fps(val);
+        }
+    }
+
+    /// Preferences › Remote — the embedded web UI that lets a browser (on
+    /// this machine or, opt-in, on the LAN) drive the live session. The
+    /// enable toggle takes effect immediately; `drive_remote` reconciles the
+    /// server with these settings once per frame.
+    fn prefs_tab_remote(&mut self, ui: &mut egui::Ui) {
+        ui.heading("Remote control");
+        ui.label(
+            "Serve a web dashboard that mirrors this session — open tabs, \
+             source, diagnostics, and a live preview — and accepts edits, \
+             saves, and builds from the browser. Handy for tweaking a scene \
+             from a phone or a second machine.",
+        );
+        ui.add_space(8.0);
+
+        let mut enabled = self.settings.remote_enabled();
+        if ui
+            .checkbox(&mut enabled, "Enable remote control web UI")
+            .changed()
+        {
+            self.settings.set_remote_enabled(enabled);
+            // A fresh manual toggle supersedes any stale bind failure.
+            self.remote_error = None;
+        }
+
+        ui.add_space(6.0);
+        ui.horizontal(|ui| {
+            ui.label("Port");
+            // Seed the draft from settings on first paint (and after an
+            // external change wiped it). Committed below on Enter / focus
+            // loss so half-typed ports never reach the server.
+            if self.prefs_remote_port_draft.is_empty() {
+                self.prefs_remote_port_draft = self.settings.remote_port().to_string();
+            }
+            let resp = ui.add(
+                egui::TextEdit::singleline(&mut self.prefs_remote_port_draft)
+                    .desired_width(72.0),
+            );
+            let commit = resp.lost_focus()
+                || (resp.has_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)));
+            if commit {
+                match self.prefs_remote_port_draft.trim().parse::<u16>() {
+                    Ok(p) if p >= 1024 => {
+                        self.settings.set_remote_port(p);
+                        self.remote_error = None;
+                    }
+                    _ => {
+                        // Snap the draft back to the last good value.
+                        self.prefs_remote_port_draft =
+                            self.settings.remote_port().to_string();
+                    }
+                }
+            }
+            ui.label(egui::RichText::new("(1024–65535)").weak());
+        });
+
+        ui.add_space(6.0);
+        let mut lan = self.settings.remote_allow_lan();
+        let lan_resp = ui.checkbox(
+            &mut lan,
+            "Allow connections from other devices on this network",
+        );
+        if lan_resp.changed() {
+            self.settings.set_remote_allow_lan(lan);
+        }
+        lan_resp.on_hover_text(
+            "Binds 0.0.0.0 instead of loopback. Anyone who can reach the \
+             port can edit and save your open files — only enable this on \
+             networks you trust.",
+        );
+        if lan {
+            ui.label(
+                egui::RichText::new(
+                    "⚠ The dashboard has no password — everyone on this \
+                     network can edit and save your open files.",
+                )
+                .color(crate::app::style::accent_warn(ui.visuals())),
+            );
+        }
+
+        ui.add_space(10.0);
+        ui.separator();
+        ui.add_space(6.0);
+
+        if let Some(err) = self.remote_error.clone() {
+            ui.colored_label(
+                ui.visuals().error_fg_color,
+                format!("Could not start the server: {err}"),
+            );
+        } else if let Some(server) = self.remote.as_ref() {
+            let url = server.local_url();
+            ui.horizontal(|ui| {
+                ui.label("Running at");
+                if ui
+                    .link(egui::RichText::new(&url).monospace())
+                    .on_hover_text("Open the dashboard in your browser")
+                    .clicked()
+                {
+                    let _ = webbrowser::open(&url);
+                }
+                if ui
+                    .button("Copy")
+                    .on_hover_text("Copy the URL to the clipboard")
+                    .clicked()
+                {
+                    ui.ctx().copy_text(url.clone());
+                }
+            });
+            if server.allow_lan() {
+                ui.label(
+                    "Other devices connect via this machine's LAN address on \
+                     the same port (e.g. http://192.168.x.x:port/).",
+                );
+            }
+        } else {
+            ui.label(egui::RichText::new("Server is off.").weak());
         }
     }
 

--- a/crates/mogen-studio/src/app/ui_dialogs/prefs.rs
+++ b/crates/mogen-studio/src/app/ui_dialogs/prefs.rs
@@ -469,12 +469,9 @@ impl MogenStudioApp {
         ui.add_space(6.0);
         ui.horizontal(|ui| {
             ui.label("Port");
-            // Seed the draft from settings on first paint (and after an
-            // external change wiped it). Committed below on Enter / focus
-            // loss so half-typed ports never reach the server.
-            if self.prefs_remote_port_draft.is_empty() {
-                self.prefs_remote_port_draft = self.settings.remote_port().to_string();
-            }
+            // Draft is seeded once from settings at startup (`MogenStudioApp::new`)
+            // and only ever written back here on commit, so a user clearing the
+            // field to type a new value never gets silently reset mid-edit.
             let resp = ui.add(
                 egui::TextEdit::singleline(&mut self.prefs_remote_port_draft)
                     .desired_width(72.0),

--- a/crates/mogen-studio/src/main.rs
+++ b/crates/mogen-studio/src/main.rs
@@ -10,6 +10,7 @@ mod pick;
 mod pipeline;
 mod preview_shader;
 mod protocol;
+mod remote;
 mod settings;
 mod splash;
 mod theme;

--- a/crates/mogen-studio/src/remote.rs
+++ b/crates/mogen-studio/src/remote.rs
@@ -1,0 +1,482 @@
+//! Remote-control web UI server.
+//!
+//! When enabled in Preferences › Remote, Studio runs a tiny embedded HTTP
+//! server (tiny_http, one background thread) that serves a self-contained
+//! browser dashboard mirroring the live session — open tabs, active source,
+//! diagnostics, scene stats, and a periodically refreshed viewport preview —
+//! and accepts a small command set (activate tab / edit source / save /
+//! build / recompile) that the app drains on its UI thread once per frame.
+//!
+//! Threading model: the HTTP thread never touches app state directly. All
+//! communication goes through [`Shared`] behind one mutex — the UI thread
+//! *publishes* a pre-serialized JSON snapshot whenever the observable state
+//! changes, and *drains* the command queue the HTTP thread appends to. The
+//! HTTP thread nudges `egui::Context::request_repaint` after enqueueing a
+//! command so the app reacts promptly even when idle.
+//!
+//! Security: the server binds loopback by default; binding `0.0.0.0` (so
+//! phones/tablets on the LAN can drive Studio) is a separate opt-in in
+//! Preferences, because anyone who can reach the port can edit and save the
+//! open files. No TLS, no auth — this is a local-tooling convenience in the
+//! same spirit as every dev-server, not an internet-facing surface.
+
+use std::collections::VecDeque;
+use std::io::Read;
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use eframe::egui;
+use serde::{Deserialize, Serialize};
+
+/// The dashboard, embedded so the binary stays self-contained (same pattern
+/// as the splash image and fonts).
+const REMOTE_UI_HTML: &str = include_str!("../assets/remote/index.html");
+
+/// Hard cap on POST bodies. A `.mog` source is KBs; 4 MiB leaves generous
+/// headroom while keeping a hostile client from ballooning memory.
+const MAX_BODY_BYTES: usize = 4 * 1024 * 1024;
+
+/// How long after the last `/api/preview.png` hit the app keeps rendering
+/// fresh preview captures. Browsers poll every ~1.5s while the page is
+/// visible, so this comfortably covers a live viewer and stops capture work
+/// shortly after the last tab closes.
+const PREVIEW_WANTED_WINDOW: Duration = Duration::from_secs(10);
+
+/// One remote command, appended by the HTTP thread and applied by the app
+/// on its UI thread. Tab indices are validated at apply time — tabs can
+/// open/close between enqueue and drain.
+pub enum RemoteCommand {
+    ActivateTab(usize),
+    /// Replace a tab's source buffer (recompiles via the normal debounce
+    /// path and records an undo entry, exactly like an in-app edit).
+    SetSource { tab: usize, source: String },
+    Save { tab: usize },
+    /// Export the tab's scene to a GLB next to the file, using the tab's
+    /// remembered export options.
+    Build { tab: usize },
+    Recompile { tab: usize },
+}
+
+/// Wire format for `POST /api/command`.
+#[derive(Deserialize)]
+struct CommandBody {
+    cmd: String,
+    #[serde(default)]
+    tab: Option<usize>,
+    #[serde(default)]
+    source: Option<String>,
+}
+
+/// One open tab as shown in the dashboard's tab strip.
+#[derive(Serialize, Clone, PartialEq)]
+pub struct TabInfo {
+    pub name: String,
+    pub path: Option<String>,
+    pub dirty: bool,
+}
+
+/// One diagnostic row. `line` is 1-based, derived from the span so the web
+/// editor can badge the offending line.
+#[derive(Serialize, Clone, PartialEq)]
+pub struct DiagInfo {
+    pub severity: String,
+    pub code: String,
+    pub message: String,
+    pub line: Option<usize>,
+}
+
+/// Everything the dashboard renders, published as one JSON blob. The app
+/// rebuilds this each frame and re-serializes only when it actually changed
+/// (`PartialEq` against the previous snapshot), so idle frames cost one
+/// cheap comparison.
+#[derive(Serialize, Clone, PartialEq)]
+pub struct Snapshot {
+    pub app_version: String,
+    pub tabs: Vec<TabInfo>,
+    pub active: usize,
+    /// Active tab's full source. The dashboard editor is view + replace —
+    /// fine for `.mog` files, which are hand-sized by design.
+    pub source: String,
+    pub status: String,
+    /// Compile stage of the active tab: `ok`, `parse`, `validate-ast`,
+    /// `lower`, `validate-graph`, or `none` before the first compile.
+    pub stage: String,
+    pub diagnostics: Vec<DiagInfo>,
+    pub nodes: usize,
+    pub triangles: usize,
+    pub building: bool,
+    pub build_stage: String,
+    /// Label of the in-flight LLM call on the active tab, if any.
+    pub llm: Option<String>,
+}
+
+/// State shared between the UI thread and the HTTP thread.
+struct Shared {
+    snapshot_json: String,
+    rev: u64,
+    preview_png: Vec<u8>,
+    preview_rev: u64,
+    /// Last time a client asked for the preview image. Drives the app-side
+    /// decision to keep submitting viewport captures.
+    preview_wanted_at: Option<Instant>,
+    commands: VecDeque<RemoteCommand>,
+}
+
+/// Handle owned by the app. Dropping it shuts the server down (the worker
+/// notices `shutdown` within one accept-timeout slice and exits).
+pub struct RemoteServer {
+    shared: Arc<Mutex<Shared>>,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+    port: u16,
+    allow_lan: bool,
+}
+
+impl RemoteServer {
+    /// Bind and start serving. Returns a human-readable error when the port
+    /// is taken (the common failure) so Preferences can show it verbatim.
+    pub fn start(port: u16, allow_lan: bool, egui_ctx: egui::Context) -> Result<Self, String> {
+        let host = if allow_lan { "0.0.0.0" } else { "127.0.0.1" };
+        let listener = TcpListener::bind((host, port)).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::AddrInUse {
+                format!("port {port} is already in use — pick another port")
+            } else {
+                format!("bind {host}:{port}: {e}")
+            }
+        })?;
+        let server = tiny_http::Server::from_listener(listener, None)
+            .map_err(|e| format!("start server on {host}:{port}: {e}"))?;
+
+        let shared = Arc::new(Mutex::new(Shared {
+            snapshot_json: "null".to_string(),
+            rev: 0,
+            preview_png: Vec::new(),
+            preview_rev: 0,
+            preview_wanted_at: None,
+            commands: VecDeque::new(),
+        }));
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let worker_shared = Arc::clone(&shared);
+        let worker_shutdown = Arc::clone(&shutdown);
+        let handle = std::thread::Builder::new()
+            .name("mogen-remote-http".into())
+            .spawn(move || {
+                serve_loop(server, worker_shared, worker_shutdown, egui_ctx);
+            })
+            .map_err(|e| format!("spawn remote server thread: {e}"))?;
+
+        Ok(Self {
+            shared,
+            shutdown,
+            handle: Some(handle),
+            port,
+            allow_lan,
+        })
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn allow_lan(&self) -> bool {
+        self.allow_lan
+    }
+
+    /// Browser-reachable URL for the local machine.
+    pub fn local_url(&self) -> String {
+        format!("http://127.0.0.1:{}/", self.port)
+    }
+
+    /// Replace the published snapshot. Callers should only invoke this when
+    /// the snapshot actually changed — the revision bump is what tells
+    /// polling clients to re-render.
+    pub fn publish_state(&self, snapshot: &Snapshot) {
+        let json = serde_json::to_string(snapshot)
+            .unwrap_or_else(|e| format!("{{\"error\":\"serialize: {e}\"}}"));
+        let mut sh = self.shared.lock().unwrap();
+        sh.snapshot_json = json;
+        sh.rev = sh.rev.wrapping_add(1);
+    }
+
+    /// Replace the preview PNG served at `/api/preview.png`.
+    pub fn publish_preview(&self, png: Vec<u8>) {
+        let mut sh = self.shared.lock().unwrap();
+        sh.preview_png = png;
+        sh.preview_rev = sh.preview_rev.wrapping_add(1);
+    }
+
+    /// Whether any browser asked for the preview image recently. The app
+    /// only spends GL time on remote captures while this is true.
+    pub fn preview_watchers_active(&self) -> bool {
+        let sh = self.shared.lock().unwrap();
+        sh.preview_wanted_at
+            .map(|t| t.elapsed() < PREVIEW_WANTED_WINDOW)
+            .unwrap_or(false)
+    }
+
+    /// Drain every queued command, oldest first.
+    pub fn take_commands(&self) -> Vec<RemoteCommand> {
+        let mut sh = self.shared.lock().unwrap();
+        sh.commands.drain(..).collect()
+    }
+}
+
+impl Drop for RemoteServer {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            // Worker wakes from `recv_timeout` within one slice and sees the
+            // flag; join is bounded in practice.
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Accept loop. Runs until the shutdown flag flips.
+fn serve_loop(
+    server: tiny_http::Server,
+    shared: Arc<Mutex<Shared>>,
+    shutdown: Arc<AtomicBool>,
+    egui_ctx: egui::Context,
+) {
+    while !shutdown.load(Ordering::SeqCst) {
+        match server.recv_timeout(Duration::from_millis(250)) {
+            Ok(Some(req)) => handle_request(req, &shared, &egui_ctx),
+            Ok(None) => continue,
+            Err(_) => break,
+        }
+    }
+}
+
+fn handle_request(
+    mut req: tiny_http::Request,
+    shared: &Arc<Mutex<Shared>>,
+    egui_ctx: &egui::Context,
+) {
+    let url = req.url().to_string();
+    let (path, query) = match url.split_once('?') {
+        Some((p, q)) => (p, q),
+        None => (url.as_str(), ""),
+    };
+    let method = req.method().clone();
+
+    match (method, path) {
+        (tiny_http::Method::Get, "/") | (tiny_http::Method::Get, "/index.html") => {
+            respond(req, 200, "text/html; charset=utf-8", REMOTE_UI_HTML.as_bytes());
+        }
+        (tiny_http::Method::Get, "/api/state") => {
+            let since = query_u64(query, "rev");
+            let (rev, preview_rev, body) = {
+                let sh = shared.lock().unwrap();
+                (sh.rev, sh.preview_rev, sh.snapshot_json.clone())
+            };
+            // Skip re-sending an unchanged snapshot: the client passes the
+            // rev it already has and we answer with a slim marker. The
+            // preview rev always rides along so the <img> refresh loop can
+            // key off it without a second endpoint.
+            let json = if since == Some(rev) {
+                format!("{{\"rev\":{rev},\"preview\":{preview_rev},\"unchanged\":true}}")
+            } else {
+                format!("{{\"rev\":{rev},\"preview\":{preview_rev},\"state\":{body}}}")
+            };
+            respond(req, 200, "application/json", json.as_bytes());
+        }
+        (tiny_http::Method::Get, "/api/preview.png") => {
+            let png = {
+                let mut sh = shared.lock().unwrap();
+                sh.preview_wanted_at = Some(Instant::now());
+                sh.preview_png.clone()
+            };
+            // Nudge the app so the capture loop starts promptly on the very
+            // first request instead of waiting for the next natural repaint.
+            egui_ctx.request_repaint();
+            if png.is_empty() {
+                respond(req, 404, "text/plain", b"no preview rendered yet");
+            } else {
+                respond(req, 200, "image/png", &png);
+            }
+        }
+        (tiny_http::Method::Post, "/api/command") => {
+            let mut body = Vec::new();
+            let read = req
+                .as_reader()
+                .take(MAX_BODY_BYTES as u64 + 1)
+                .read_to_end(&mut body);
+            if read.is_err() || body.len() > MAX_BODY_BYTES {
+                respond(req, 413, "application/json", b"{\"error\":\"body too large\"}");
+                return;
+            }
+            match parse_command(&body) {
+                Ok(cmd) => {
+                    {
+                        let mut sh = shared.lock().unwrap();
+                        sh.commands.push_back(cmd);
+                    }
+                    egui_ctx.request_repaint();
+                    respond(req, 200, "application/json", b"{\"ok\":true}");
+                }
+                Err(msg) => {
+                    let json = serde_json::json!({ "error": msg }).to_string();
+                    respond(req, 400, "application/json", json.as_bytes());
+                }
+            }
+        }
+        _ => respond(req, 404, "text/plain", b"not found"),
+    }
+}
+
+fn parse_command(body: &[u8]) -> Result<RemoteCommand, String> {
+    let parsed: CommandBody =
+        serde_json::from_slice(body).map_err(|e| format!("bad command JSON: {e}"))?;
+    let tab = || parsed.tab.ok_or_else(|| "missing `tab`".to_string());
+    match parsed.cmd.as_str() {
+        "activate" => Ok(RemoteCommand::ActivateTab(tab()?)),
+        "set_source" => Ok(RemoteCommand::SetSource {
+            tab: tab()?,
+            source: parsed.source.ok_or_else(|| "missing `source`".to_string())?,
+        }),
+        "save" => Ok(RemoteCommand::Save { tab: tab()? }),
+        "build" => Ok(RemoteCommand::Build { tab: tab()? }),
+        "recompile" => Ok(RemoteCommand::Recompile { tab: tab()? }),
+        other => Err(format!("unknown command `{other}`")),
+    }
+}
+
+fn respond(req: tiny_http::Request, status: u16, content_type: &str, body: &[u8]) {
+    let ct = tiny_http::Header::from_bytes(&b"Content-Type"[..], content_type.as_bytes())
+        .expect("static header");
+    // Everything here is live state — a cached snapshot or preview is
+    // strictly worse than a re-fetch on a loopback link.
+    let cc = tiny_http::Header::from_bytes(&b"Cache-Control"[..], &b"no-store"[..])
+        .expect("static header");
+    let resp = tiny_http::Response::from_data(body)
+        .with_status_code(status)
+        .with_header(ct)
+        .with_header(cc);
+    let _ = req.respond(resp);
+}
+
+/// Pull a `u64` query value (`rev=42`) out of a raw query string.
+fn query_u64(query: &str, key: &str) -> Option<u64> {
+    for pair in query.split('&') {
+        if let Some((k, v)) = pair.split_once('=') {
+            if k == key {
+                return v.parse().ok();
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_set_source_command() {
+        let body = br#"{"cmd":"set_source","tab":1,"source":"scene {}"}"#;
+        match parse_command(body).unwrap() {
+            RemoteCommand::SetSource { tab, source } => {
+                assert_eq!(tab, 1);
+                assert_eq!(source, "scene {}");
+            }
+            _ => panic!("wrong command"),
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_command() {
+        assert!(parse_command(br#"{"cmd":"reboot"}"#).is_err());
+    }
+
+    #[test]
+    fn rejects_missing_tab() {
+        assert!(parse_command(br#"{"cmd":"save"}"#).is_err());
+    }
+
+    #[test]
+    fn query_parses_rev() {
+        assert_eq!(query_u64("rev=42&x=1", "rev"), Some(42));
+        assert_eq!(query_u64("x=1", "rev"), None);
+        assert_eq!(query_u64("rev=abc", "rev"), None);
+    }
+
+    #[test]
+    fn server_roundtrip_state_and_commands() {
+        // Bind an ephemeral port, publish a snapshot, fetch it over HTTP,
+        // post a command, and confirm the app-side drain sees it.
+        let ctx = egui::Context::default();
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let server = RemoteServer::start(port, false, ctx).expect("start");
+
+        let snap = Snapshot {
+            app_version: "test".into(),
+            tabs: vec![TabInfo { name: "a.mog".into(), path: None, dirty: false }],
+            active: 0,
+            source: "scene {}".into(),
+            status: "ok".into(),
+            stage: "ok".into(),
+            diagnostics: vec![],
+            nodes: 1,
+            triangles: 12,
+            building: false,
+            build_stage: String::new(),
+            llm: None,
+        };
+        server.publish_state(&snap);
+
+        let get = |path: &str| -> (u16, String) {
+            use std::io::Write;
+            let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
+            write!(stream, "GET {path} HTTP/1.0\r\nHost: localhost\r\n\r\n").unwrap();
+            let mut buf = String::new();
+            stream.read_to_string(&mut buf).unwrap();
+            let status: u16 = buf
+                .split_whitespace()
+                .nth(1)
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+            let body = buf.split("\r\n\r\n").nth(1).unwrap_or("").to_string();
+            (status, body)
+        };
+
+        let (status, body) = get("/api/state");
+        assert_eq!(status, 200);
+        assert!(body.contains("\"source\":\"scene {}\""), "body: {body}");
+
+        // Unchanged marker when the client already has this rev.
+        let (_, body2) = get("/api/state?rev=1");
+        assert!(body2.contains("\"unchanged\":true"), "body: {body2}");
+
+        // Post a command and drain it app-side.
+        {
+            use std::io::Write;
+            let payload = r#"{"cmd":"activate","tab":0}"#;
+            let mut stream = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
+            write!(
+                stream,
+                "POST /api/command HTTP/1.0\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{}",
+                payload.len(),
+                payload
+            )
+            .unwrap();
+            let mut buf = String::new();
+            stream.read_to_string(&mut buf).unwrap();
+            assert!(buf.contains("\"ok\":true"), "resp: {buf}");
+        }
+        let cmds = server.take_commands();
+        assert_eq!(cmds.len(), 1);
+        assert!(matches!(cmds[0], RemoteCommand::ActivateTab(0)));
+
+        // The dashboard itself serves at /.
+        let (status, body) = get("/");
+        assert_eq!(status, 200);
+        assert!(body.contains("MoGen"), "dashboard should carry branding");
+    }
+}

--- a/crates/mogen-studio/src/settings.rs
+++ b/crates/mogen-studio/src/settings.rs
@@ -381,6 +381,28 @@ pub struct Settings {
     #[serde(default)]
     pub word_wrap: Option<bool>,
 
+    /// Remote-control web UI. When `true`, Studio runs an embedded HTTP
+    /// server that serves a browser dashboard mirroring the active session
+    /// (tabs, source, diagnostics, live preview) and accepts edit / save /
+    /// build commands. Off by default — the server binds only when the user
+    /// explicitly enables it in Preferences › Remote.
+    #[serde(default)]
+    pub remote_enabled: Option<bool>,
+
+    /// TCP port for the remote-control server. `None` / `0` falls back to
+    /// [`DEFAULT_REMOTE_PORT`]. Clamped to the unprivileged range at read
+    /// time so a hand-edited settings file can't ask Studio to bind :80.
+    #[serde(default)]
+    pub remote_port: Option<u16>,
+
+    /// When `true`, the remote server binds `0.0.0.0` so other devices on
+    /// the local network (a phone, a tablet) can reach the dashboard. The
+    /// default (`false` / unset) binds loopback only — anyone who can reach
+    /// the port can edit and save the open files, so exposure beyond the
+    /// local machine is a deliberate opt-in.
+    #[serde(default)]
+    pub remote_allow_lan: Option<bool>,
+
     /// When `Some(true)` (or absent — defaults to `true`), Z.ai chat
     /// calls (Generate / Modify / Animate / Ask) route through the
     /// dedicated GLM Coding Plan endpoint
@@ -399,6 +421,11 @@ pub struct Settings {
 /// colours read consistently regardless of the panel scheme. Tuned to match
 /// Blender / Maya / Modo defaults.
 pub const DEFAULT_VIEWER_BG_RGB: [u8; 3] = [54, 58, 64];
+
+/// Default TCP port for the remote-control web UI. Chosen out of the way
+/// of the common dev-server ports (3000/5173/8000/8080) so enabling the
+/// remote rarely collides with whatever else the user is running.
+pub const DEFAULT_REMOTE_PORT: u16 = 7878;
 
 /// Factory default for the viewport repaint cap. Picked to match the most
 /// common display refresh rate while keeping battery / thermals reasonable
@@ -778,6 +805,40 @@ impl Settings {
 
     pub fn set_max_fps(&mut self, fps: Option<u32>) {
         self.max_fps = Some(fps.unwrap_or(0));
+    }
+
+    /// Whether the remote-control web UI server should be running. Defaults
+    /// to `false` — the server only binds on explicit opt-in.
+    pub fn remote_enabled(&self) -> bool {
+        self.remote_enabled.unwrap_or(false)
+    }
+
+    pub fn set_remote_enabled(&mut self, on: bool) {
+        self.remote_enabled = Some(on);
+    }
+
+    /// Remote server port, falling back to [`DEFAULT_REMOTE_PORT`] and
+    /// clamped to the unprivileged range so a corrupted settings file can't
+    /// request a root-only bind.
+    pub fn remote_port(&self) -> u16 {
+        match self.remote_port {
+            None | Some(0) => DEFAULT_REMOTE_PORT,
+            Some(p) => p.max(1024),
+        }
+    }
+
+    pub fn set_remote_port(&mut self, port: u16) {
+        self.remote_port = Some(port);
+    }
+
+    /// Whether the remote server binds all interfaces (`0.0.0.0`) instead of
+    /// loopback. Defaults to `false` — LAN exposure is a deliberate opt-in.
+    pub fn remote_allow_lan(&self) -> bool {
+        self.remote_allow_lan.unwrap_or(false)
+    }
+
+    pub fn set_remote_allow_lan(&mut self, on: bool) {
+        self.remote_allow_lan = Some(on);
     }
 
     /// Promote `path` to the front of [`Self::recent_files`], dedup'ing any

--- a/crates/mogen-studio/src/settings.rs
+++ b/crates/mogen-studio/src/settings.rs
@@ -867,3 +867,41 @@ impl Settings {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_port_defaults_when_unset_or_zero() {
+        let mut s = Settings::default();
+        assert_eq!(s.remote_port(), DEFAULT_REMOTE_PORT);
+        s.set_remote_port(0);
+        assert_eq!(s.remote_port(), DEFAULT_REMOTE_PORT);
+    }
+
+    #[test]
+    fn remote_port_clamps_privileged_range() {
+        let mut s = Settings::default();
+        s.set_remote_port(80);
+        assert_eq!(s.remote_port(), 1024, "a hand-edited settings file must not be able to request a root-only bind");
+        s.set_remote_port(1023);
+        assert_eq!(s.remote_port(), 1024);
+    }
+
+    #[test]
+    fn remote_port_passes_through_unprivileged_values() {
+        let mut s = Settings::default();
+        s.set_remote_port(7878);
+        assert_eq!(s.remote_port(), 7878);
+        s.set_remote_port(65535);
+        assert_eq!(s.remote_port(), 65535);
+    }
+
+    #[test]
+    fn remote_toggles_default_off() {
+        let s = Settings::default();
+        assert!(!s.remote_enabled());
+        assert!(!s.remote_allow_lan());
+    }
+}

--- a/crates/mogen-studio/src/viewer/state/capture.rs
+++ b/crates/mogen-studio/src/viewer/state/capture.rs
@@ -37,6 +37,11 @@ pub enum CaptureKind {
     /// tells `poll_generate` to route the outcome back into the wizard
     /// instead of the active tab's status line.
     WizardThumb,
+    /// Single-frame render owned by the remote-control web UI's live
+    /// preview. Same GL path as a `Thumbnail`; the variant keeps
+    /// `poll_generate` from draining outcomes that belong to
+    /// `poll_remote_preview`.
+    RemotePreview,
 }
 
 /// One frame the renderer should produce as part of a capture. Yaw/pitch

--- a/docs/studio.md
+++ b/docs/studio.md
@@ -258,10 +258,36 @@ path. It's safe to edit by hand — Studio reloads on next launch.
 | `open_tabs` | Absolute paths of every titled tab open at last persist time. |
 | `recent_files` | Most-recently-opened paths, newest first. Capped at 12. |
 | `onboarded` | Set once the first-launch onboarding has been dismissed. |
+| `remote_enabled` | Serve the remote-control web dashboard. `null`/`false` → off. |
+| `remote_port` | TCP port for the dashboard. `null`/`0` → `7878`. |
+| `remote_allow_lan` | Bind `0.0.0.0` so other devices on the network can connect. `null`/`false` → loopback only. |
 
 Untitled buffers are deliberately not persisted — there's nothing to
 key off — so a fresh Studio launch with only-untitled tabs comes up
 empty. Save first if you want them back.
+
+---
+
+## Remote control
+
+Options › **Remote** can start an embedded web server that mirrors the
+live session in any browser: the open tabs, the active source, compile
+diagnostics, scene stats, and a slowly orbiting live preview of the
+compiled model. The dashboard can push source edits back, save, force a
+recompile, and kick off a **Build GLB** — every action lands in the
+desktop session exactly as if it were performed there (remote edits even
+join the in-app undo stack).
+
+- Off by default. Enable it with the checkbox; the server starts
+  immediately and the dialog shows the URL (default
+  `http://127.0.0.1:7878/`).
+- By default only this machine can connect. Ticking *Allow connections
+  from other devices* rebinds to `0.0.0.0` so a phone or tablet on the
+  same network can drive Studio — there is **no password**, so only do
+  this on networks you trust.
+- The preview renders on the same GL pipeline as thumbnails, only while
+  a browser is actually watching, and always yields to real capture
+  work (thumbnail / video / publish renders).
 
 ---
 


### PR DESCRIPTION
Options › Remote can now start an embedded HTTP server (tiny_http, one
background thread) that serves a self-contained browser dashboard
mirroring the live session: open tabs, active source, diagnostics with
line jumps, scene stats, and a slowly orbiting live viewport preview.
The dashboard pushes source edits, saves, recompiles, and GLB builds
back into the desktop session — remote edits recompile through the
normal pipeline and join the in-app undo stack.

- crates/mogen-studio/src/remote.rs: server, JSON state snapshots with
  revision-gated polling, command queue, embedded dashboard, tests.
- assets/remote/index.html: dark amber-on-charcoal dashboard, mobile
  friendly, no external assets.
- app/remote_link.rs: per-frame reconcile with settings, command
  drain, change-gated state publish, turntable preview captures via a
  new CaptureKind::RemotePreview (always yields to real capture work).
- Preferences › Remote tab: enable toggle, port, LAN opt-in with a
  no-password warning, live URL with open/copy actions, bind errors.
- Settings: remote_enabled / remote_port / remote_allow_lan (off by
  default, loopback-only by default, port clamped to unprivileged).
- docs/studio.md: settings keys + a Remote control section.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01712zVMAk39EKdJYnXnXqBF