### PR TITLE
Part connection ontology + deep solid merge for module-instantiated parts

### DIFF
--- a/crates/mogen-export/src/merge.rs
+++ b/crates/mogen-export/src/merge.rs
@@ -26,13 +26,18 @@
 
 use std::collections::{HashMap, HashSet};
 
-use mogen_core::{MaterialId, Mesh, NodeId, SceneGraph, SceneNode};
+use glam::Mat4;
+use mogen_core::{MaterialId, Mesh, NodeId, SceneGraph, SceneNode, Transform};
 
 #[derive(Clone, Copy)]
 enum CleanupMode {
     Standard,
     Coplanar,
 }
+
+/// Mergeable leaves grouped by material, each paired with its transform
+/// relative to the enclosing solid. Used by the deep solid merge.
+type LeafGroups = Vec<(Option<MaterialId>, Vec<(NodeId, Mat4)>)>;
 
 /// Build a new scene graph by applying the merge transform. The original
 /// graph is left untouched.
@@ -157,6 +162,25 @@ fn rebuild_level<P>(
 where
     P: Fn(Option<NodeId>, &SceneGraph) -> Option<CleanupMode>,
 {
+    // Deep solid merge: when the parent is a `solid` whose *entire* subtree is
+    // made of mergeable leaves (no skins / colliders / slots / protected nodes /
+    // non-manifold meshes), collapse ALL same-material descendant leaves — not
+    // just the direct children — into one mesh per material. Parts authored as
+    // modules wrap their geometry in a group (the module body plus `use`'s
+    // implicit transform group), so without this pass a `solid` built from
+    // `use`d parts never reaches the merge at all.
+    if let Some(p) = src_parent {
+        let pn = &scene.nodes[p.0 as usize];
+        if pn.tags.iter().any(|t| t == "solid") && solid_qualifies_deep(scene, p, protected) {
+            let cleanup = if pn.tags.iter().any(|t| t == "cleanup=coplanar") {
+                CleanupMode::Coplanar
+            } else {
+                CleanupMode::Standard
+            };
+            return deep_merge_solid_children(scene, p, protected, out, new_parent, cleanup);
+        }
+    }
+
     // Split each child into "copy as-is" and "merge candidate" buckets. The
     // only candidates are *leaves* with a plain (non-skinned) mesh, no skin
     // binding, not referenced by skins or clips. Preserving ordering matters
@@ -268,6 +292,139 @@ fn is_mergeable(n: &SceneNode, id: NodeId, protected: &HashSet<NodeId>) -> bool 
             mogen_geom::is_csg_manifold(&baked)
         }
         _ => false,
+    }
+}
+
+/// A `solid` qualifies for the deep merge when *every* mesh in its subtree is a
+/// mergeable leaf and nothing in it is referenced by a skin/clip. Any keeper
+/// (skinned/collider/slot leaf, a `cast_shadow=false` opt-out, a non-manifold
+/// mesh, or a protected node) disqualifies the whole solid, which then falls
+/// back to the shallow direct-child merge below. Transform-only groups are fine
+/// — they are exactly what we flatten through.
+fn solid_qualifies_deep(scene: &SceneGraph, solid_id: NodeId, protected: &HashSet<NodeId>) -> bool {
+    fn walk(scene: &SceneGraph, id: NodeId, protected: &HashSet<NodeId>) -> bool {
+        if protected.contains(&id) {
+            return false;
+        }
+        let n = &scene.nodes[id.0 as usize];
+        // A mesh-bearing node that can't be merged is a keeper — bail.
+        if n.mesh.is_some() && !is_mergeable(n, id, protected) {
+            return false;
+        }
+        if n.skin.is_some() || n.collider.is_some() || n.slot.is_some() {
+            return false;
+        }
+        n.children
+            .iter()
+            .all(|&c| walk(scene, c, protected))
+    }
+    scene.nodes[solid_id.0 as usize]
+        .children
+        .iter()
+        .all(|&c| walk(scene, c, protected))
+}
+
+/// Gather every mergeable leaf in a solid's subtree, grouped by material, each
+/// paired with its transform **relative to the solid** (the product of the
+/// intermediate group transforms; the solid's own transform is excluded because
+/// the merged nodes are emitted as its direct children). First-seen traversal
+/// order is preserved so the output is deterministic without hashing.
+fn collect_deep_leaves(
+    scene: &SceneGraph,
+    ids: &[NodeId],
+    accum: Mat4,
+    protected: &HashSet<NodeId>,
+    groups: &mut LeafGroups,
+) {
+    for &id in ids {
+        let n = &scene.nodes[id.0 as usize];
+        let world = accum * n.transform.to_mat4();
+        if is_mergeable(n, id, protected) {
+            match groups.iter_mut().find(|(m, _)| *m == n.material) {
+                Some((_, v)) => v.push((id, world)),
+                None => groups.push((n.material, vec![(id, world)])),
+            }
+        } else {
+            collect_deep_leaves(scene, &n.children, world, protected, groups);
+        }
+    }
+}
+
+/// Build the merged children of a deep-qualifying solid: one CSG-unioned node
+/// per material, baked into the solid's frame. Falls back to baking each leaf
+/// individually if a group's union collapses to nothing.
+fn deep_merge_solid_children(
+    scene: &SceneGraph,
+    solid_id: NodeId,
+    protected: &HashSet<NodeId>,
+    out: &mut SceneGraph,
+    new_parent: Option<NodeId>,
+    cleanup: CleanupMode,
+) -> Vec<NodeId> {
+    let mut groups: LeafGroups = Vec::new();
+    collect_deep_leaves(
+        scene,
+        &scene.nodes[solid_id.0 as usize].children,
+        Mat4::IDENTITY,
+        protected,
+        &mut groups,
+    );
+
+    let mut result = Vec::new();
+    for (material, leaves) in groups {
+        let mesh = merge_baked_leaves(scene, &leaves, cleanup);
+        if mesh.positions.is_empty() || mesh.indices.is_empty() {
+            // Union failed — keep the originals, each baked into solid-space so
+            // it still lands in the right place under the flattened solid.
+            for (lid, world) in &leaves {
+                let src = &scene.nodes[lid.0 as usize];
+                let baked = mogen_geom::transform_mesh(
+                    src.mesh.as_ref().expect("mergeable has mesh"),
+                    *world,
+                );
+                let node = SceneNode {
+                    mesh: Some(baked),
+                    material,
+                    parent: new_parent,
+                    transform: Transform::default(),
+                    children: Vec::new(),
+                    ..src.clone()
+                };
+                result.push(push_node(out, node));
+            }
+            continue;
+        }
+        let ids: Vec<NodeId> = leaves.iter().map(|(id, _)| *id).collect();
+        let merged = build_merged_node(scene, &ids, material, mesh, new_parent);
+        result.push(push_node(out, merged));
+    }
+    result
+}
+
+/// Like [`merge_group_meshes`] but bakes each leaf with a caller-supplied
+/// (solid-relative) transform instead of the leaf's own local transform.
+fn merge_baked_leaves(
+    scene: &SceneGraph,
+    leaves: &[(NodeId, Mat4)],
+    cleanup: CleanupMode,
+) -> Mesh {
+    let baked: Vec<Mesh> = leaves
+        .iter()
+        .map(|(id, world)| {
+            let mesh = scene.nodes[id.0 as usize]
+                .mesh
+                .as_ref()
+                .expect("is_mergeable ensures mesh is Some");
+            mogen_geom::transform_mesh(mesh, *world)
+        })
+        .collect();
+    let Some(unioned) = mogen_geom::try_union_many(&baked) else {
+        return Mesh::default();
+    };
+    let cleaned = mogen_geom::clean_csg_output(&unioned);
+    match cleanup {
+        CleanupMode::Standard => cleaned,
+        CleanupMode::Coplanar => mogen_geom::cull_coplanar_opposites(&cleaned),
     }
 }
 
@@ -484,6 +641,93 @@ mod tests {
             })
             .count();
         assert_eq!(plain_kids, 2, "non-solid parent must not merge its kids");
+    }
+
+    #[test]
+    fn deep_solid_merge_flattens_nested_groups() {
+        // A solid whose boxes live one group deep (as module-instantiated parts
+        // do) must still collapse into a single merged leaf directly under the
+        // solid — the intermediate group is flattened, its transform baked in.
+        let mut s = SceneGraph::new();
+        let oak = s.add_material(Material::new("oak"));
+
+        let solid_root = s.add_root("shell", "solid", Transform::default());
+        s.nodes[solid_root.0 as usize].tags.push("solid".into());
+        let grp = s.add_child(
+            solid_root,
+            "grp",
+            "group",
+            Transform::from_translation([1.0, 0.0, 0.0].into()),
+        );
+        let a = s.add_child(grp, "a", "box", Transform::default());
+        let b = s.add_child(
+            grp,
+            "b",
+            "box",
+            Transform::from_translation([0.5, 0.0, 0.0].into()),
+        );
+        s.set_mesh(a, box_mesh([1.0, 1.0, 1.0], mogen_core::UvMode::default()));
+        s.set_mesh(b, box_mesh([1.0, 1.0, 1.0], mogen_core::UvMode::default()));
+        s.set_material(a, oak);
+        s.set_material(b, oak);
+
+        let out = merge_solid_groups(&s, |_| {});
+
+        let merged: Vec<&SceneNode> = out.nodes.iter().filter(|n| n.kind == "merged").collect();
+        assert_eq!(merged.len(), 1, "nested boxes should collapse to one merged leaf");
+        let parent = merged[0].parent.expect("merged node has a parent");
+        assert!(
+            out.nodes[parent.0 as usize].tags.iter().any(|t| t == "solid"),
+            "merged leaf must hang directly off the solid, not the flattened group"
+        );
+        assert_eq!(
+            out.nodes.iter().filter(|n| n.kind == "group").count(),
+            0,
+            "the intermediate group should be flattened away"
+        );
+        // The union baked in the group's +1 X translation, so the geometry must
+        // sit around x = 1 (not the origin the leaves declared locally).
+        let m = merged[0].mesh.as_ref().unwrap();
+        let max_x = m.positions.iter().map(|p| p[0]).fold(f32::MIN, f32::max);
+        assert!(max_x > 1.0, "baked union should carry the group transform (max_x={max_x})");
+    }
+
+    #[test]
+    fn deep_solid_merge_falls_back_when_subtree_has_a_keeper() {
+        // If any leaf in the subtree is non-mergeable (here a cast_shadow=false
+        // opt-out), the deep merge must bail for the whole solid rather than
+        // fold the keeper away. Since the mergeable box sits under a group, the
+        // shallow fallback can't reach it either — both leaves survive.
+        let mut s = SceneGraph::new();
+        let oak = s.add_material(Material::new("oak"));
+
+        let solid_root = s.add_root("shell", "solid", Transform::default());
+        s.nodes[solid_root.0 as usize].tags.push("solid".into());
+        let grp = s.add_child(solid_root, "grp", "group", Transform::default());
+        let a = s.add_child(grp, "a", "box", Transform::default());
+        let b = s.add_child(
+            grp,
+            "b",
+            "box",
+            Transform::from_translation([0.5, 0.0, 0.0].into()),
+        );
+        s.set_mesh(a, box_mesh([1.0, 1.0, 1.0], mogen_core::UvMode::default()));
+        s.set_mesh(b, box_mesh([1.0, 1.0, 1.0], mogen_core::UvMode::default()));
+        s.set_material(a, oak);
+        s.set_material(b, oak);
+        s.nodes[b.0 as usize].cast_shadow = false; // keeper → disqualifies deep merge
+
+        let out = merge_solid_groups(&s, |_| {});
+        assert_eq!(
+            out.nodes.iter().filter(|n| n.kind == "merged").count(),
+            0,
+            "a keeper in the subtree must disable the deep merge"
+        );
+        assert_eq!(
+            out.nodes.iter().filter(|n| n.mesh.is_some()).count(),
+            2,
+            "both leaves survive the safe fallback"
+        );
     }
 
     #[test]

--- a/crates/mogen-export/src/merge.rs
+++ b/crates/mogen-export/src/merge.rs
@@ -329,12 +329,21 @@ fn solid_qualifies_deep(scene: &SceneGraph, solid_id: NodeId, protected: &HashSe
 /// intermediate group transforms; the solid's own transform is excluded because
 /// the merged nodes are emitted as its direct children). First-seen traversal
 /// order is preserved so the output is deterministic without hashing.
+///
+/// A non-mergeable node with children (a transform-only wrapper group) is
+/// transparent — flattened away, its transform folded into `accum`. But a
+/// non-mergeable node with *no* children (e.g. a named anchor/locator with no
+/// mesh) carries no geometry to flatten through, so it is recorded in
+/// `keepers` instead of being silently dropped — `solid_qualifies_deep` lets
+/// such nodes through (they're neither a keeper mesh nor a skin/collider/slot),
+/// so without this the deep merge would erase them from the export.
 fn collect_deep_leaves(
     scene: &SceneGraph,
     ids: &[NodeId],
     accum: Mat4,
     protected: &HashSet<NodeId>,
     groups: &mut LeafGroups,
+    keepers: &mut Vec<(NodeId, Mat4)>,
 ) {
     for &id in ids {
         let n = &scene.nodes[id.0 as usize];
@@ -344,8 +353,10 @@ fn collect_deep_leaves(
                 Some((_, v)) => v.push((id, world)),
                 None => groups.push((n.material, vec![(id, world)])),
             }
+        } else if n.children.is_empty() {
+            keepers.push((id, world));
         } else {
-            collect_deep_leaves(scene, &n.children, world, protected, groups);
+            collect_deep_leaves(scene, &n.children, world, protected, groups, keepers);
         }
     }
 }
@@ -362,15 +373,28 @@ fn deep_merge_solid_children(
     cleanup: CleanupMode,
 ) -> Vec<NodeId> {
     let mut groups: LeafGroups = Vec::new();
+    let mut keepers: Vec<(NodeId, Mat4)> = Vec::new();
     collect_deep_leaves(
         scene,
         &scene.nodes[solid_id.0 as usize].children,
         Mat4::IDENTITY,
         protected,
         &mut groups,
+        &mut keepers,
     );
 
     let mut result = Vec::new();
+    for (id, world) in keepers {
+        // A childless, non-mergeable node (no mesh to fold into a union) is
+        // preserved as its own node, baked into solid-space so it keeps its
+        // place after the intermediate groups above it are flattened away.
+        let src = &scene.nodes[id.0 as usize];
+        let (scale, rotation, translation) = world.to_scale_rotation_translation();
+        let mut copied = src.clone();
+        copied.parent = new_parent;
+        copied.transform = Transform::from_trs(translation, rotation, scale);
+        result.push(push_node(out, copied));
+    }
     for (material, leaves) in groups {
         let mesh = merge_baked_leaves(scene, &leaves, cleanup);
         if mesh.positions.is_empty() || mesh.indices.is_empty() {
@@ -728,6 +752,88 @@ mod tests {
             2,
             "both leaves survive the safe fallback"
         );
+    }
+
+    #[test]
+    fn deep_solid_merge_preserves_meshless_marker_nodes() {
+        // A solid can otherwise fully qualify for the deep merge (no skins,
+        // colliders, slots, or non-mergeable meshes) while also containing a
+        // childless, mesh-free node — e.g. a named anchor/locator a downstream
+        // engine looks up by name. `solid_qualifies_deep` doesn't disqualify on
+        // such nodes (they're not a keeper mesh, skin, collider, or slot), so
+        // `collect_deep_leaves` must preserve them explicitly rather than
+        // silently dropping them while flattening intermediate groups away.
+        let mut s = SceneGraph::new();
+        let oak = s.add_material(Material::new("oak"));
+
+        let solid_root = s.add_root("shell", "solid", Transform::default());
+        s.nodes[solid_root.0 as usize].tags.push("solid".into());
+        let a = s.add_child(solid_root, "a", "box", Transform::default());
+        s.set_mesh(a, box_mesh([1.0, 1.0, 1.0], mogen_core::UvMode::default()));
+        s.set_material(a, oak);
+        let marker = s.add_child(
+            solid_root,
+            "spawn_point",
+            "group",
+            Transform::from_translation([2.0, 0.0, 0.0].into()),
+        );
+        s.nodes[marker.0 as usize].tags.push("spawn".into());
+
+        let out = merge_solid_groups(&s, |_| {});
+
+        let found = out.nodes.iter().find(|n| n.name == "spawn_point");
+        let found = found.expect("marker node with no mesh must survive the deep merge");
+        assert!(found.tags.iter().any(|t| t == "spawn"), "marker tags must be preserved");
+        assert_eq!(
+            found.transform.translation,
+            glam::Vec3::new(2.0, 0.0, 0.0),
+            "marker's solid-relative position must be preserved"
+        );
+        assert_eq!(
+            out.nodes.iter().filter(|n| n.kind == "merged").count(),
+            1,
+            "the mergeable box should still collapse normally"
+        );
+    }
+
+    #[test]
+    fn deep_solid_merge_groups_by_material() {
+        // Two materials nested under a common flattened group: the deep merge
+        // must produce one merged leaf per material, not lump them together or
+        // drop one.
+        let mut s = SceneGraph::new();
+        let oak = s.add_material(Material::new("oak"));
+        let pine = s.add_material(Material::new("pine"));
+
+        let solid_root = s.add_root("shell", "solid", Transform::default());
+        s.nodes[solid_root.0 as usize].tags.push("solid".into());
+        let grp = s.add_child(solid_root, "grp", "group", Transform::default());
+        let a = s.add_child(grp, "a", "box", Transform::default());
+        let b = s.add_child(
+            grp,
+            "b",
+            "box",
+            Transform::from_translation([0.5, 0.0, 0.0].into()),
+        );
+        let c = s.add_child(
+            grp,
+            "c",
+            "box",
+            Transform::from_translation([3.0, 0.0, 0.0].into()),
+        );
+        s.set_mesh(a, box_mesh([1.0, 1.0, 1.0], mogen_core::UvMode::default()));
+        s.set_mesh(b, box_mesh([1.0, 1.0, 1.0], mogen_core::UvMode::default()));
+        s.set_mesh(c, box_mesh([1.0, 1.0, 1.0], mogen_core::UvMode::default()));
+        s.set_material(a, oak);
+        s.set_material(b, oak);
+        s.set_material(c, pine);
+
+        let out = merge_solid_groups(&s, |_| {});
+
+        let merged: Vec<&SceneNode> = out.nodes.iter().filter(|n| n.kind == "merged").collect();
+        assert_eq!(merged.len(), 2, "one merged leaf per material");
+        let names: HashSet<&str> = merged.iter().map(|n| n.name.as_str()).collect();
+        assert!(names.contains("merged_oak") && names.contains("merged_pine"));
     }
 
     #[test]

--- a/docs/part-connection-ontology.md
+++ b/docs/part-connection-ontology.md
@@ -1,0 +1,215 @@
+# Part Connection Ontology
+
+Design note for a grid-based procedural **part system**: a catalog of blocky ("Mojang-style")
+parts, each authored as a mogen **module** whose oriented **connectors** let an algorithm snap
+parts together into good-looking models. This is *not* a Lego reproduction — the geometry is our
+own, coarse and voxel-pitched. What we borrow is the **connection vocabulary**: the finite,
+free-to-use set of *ways two parts can mate*.
+
+The vocabulary is grounded in the real LDraw/LDCad connectivity metadata (the LDCad *shadow
+library*), then re-expressed against `mogen-core::Connector` (`pos + Quat + tag + optional
+radius`).
+
+---
+
+## 1. What the real data actually does (and why it's simpler than expected)
+
+LDCad describes every official Lego connection with just **five** snap metas — not the ~8 "part
+types" you'd guess. Most connections collapse into one parametric cylinder:
+
+| LDCad meta  | Describes                        | Gender      | Key parameters                                  | Mates with                         |
+|-------------|----------------------------------|-------------|-------------------------------------------------|------------------------------------|
+| `SNAP_CYL`  | holes & pegs (the workhorse)     | male/female | radius, length, **cross-section** R/A/S, caps   | opposite-gender `SNAP_CYL`         |
+| `SNAP_CLP`  | clip-like shapes                 | always female | inner radius, length                          | male `SNAP_CYL`                    |
+| `SNAP_FGR`  | interlocking hinge fingers       | M/F ordering | finger widths, outer radius                    | other `SNAP_FGR` only              |
+| `SNAP_SPH`  | ball joints                      | male/female | radius                                          | opposite-gender `SNAP_SPH`         |
+| `SNAP_GEN`  | odd one-offs (plugs, glass)      | male/female | bounding shape + **group name**                 | same-group `SNAP_GEN` only         |
+
+**The load-bearing insight:** studs, anti-studs, pins, and axles are *all* `SNAP_CYL`. They differ
+only by **radius** and **cross-section profile** (`R` round, `A` axle-cross, `S` square) and
+**gender** (peg vs. hole). Lego's apparent variety is one primitive with parameters.
+
+This is why our `Connector` — `pos + Quat + tag + optional radius` — is already the right shape:
+the `radius` field *is* the `SNAP_CYL` radius; the `tag` carries kind + profile + gender; the
+`Quat` gives the mating axis the attach solver aligns.
+
+---
+
+## 2. The connector tag scheme
+
+A connector's `tag` is a structured, colon-delimited string:
+
+```
+<kind>:<profile>:<gender>[:<key>]
+```
+
+- **`kind`** — connection family: `stud` `pin` `axle` `clip` `bar` `hinge` `ball` `rail` `gear` `gen`
+- **`profile`** — cross-section / shape discriminator: `round` `cross` `square` (only meaningful for
+  cylinder-family kinds; use `-` otherwise)
+- **`gender`** — `m` (male / protruding / peg) or `f` (female / receiving / hole); `n` (neutral) for
+  symmetric mates like gears
+- **`key`** — optional group name for `gen` connectors and for size-class opt-in (see §4)
+
+The `radius` field on the `Connector` carries the physical size; the tag carries the *type*. Both
+participate in the mate test.
+
+Examples:
+
+| Connector                       | Meaning                                         |
+|---------------------------------|-------------------------------------------------|
+| `stud:round:m`  (radius = R_stud) | a stud on top of a brick                        |
+| `stud:round:f`  (radius = R_stud) | an anti-stud / tube socket underneath a brick   |
+| `pin:round:m`                    | a friction pin peg                              |
+| `axle:cross:f`                   | an axle hole (transmits rotation)               |
+| `clip:-:f`                       | a clip (grips a bar)                            |
+| `bar:round:m`                    | a bar (gripped by clips, or entered by cylinders)|
+| `hinge:-:m`                      | a hinge knuckle, male finger ordering           |
+| `ball:-:m` / `socket:-:f`        | ball-and-socket pair                            |
+| `gen:-:m:usb`                    | a keyed generic plug in group `usb`             |
+
+---
+
+## 3. The mate predicate
+
+Two connectors **A** and **B** may snap iff **all** hold:
+
+1. **Kind compatibility** — `kind(A)` and `kind(B)` are a legal pair (table below).
+2. **Gender opposition** — `{m, f}` for cylinder/ball/clip families; `{n, n}` allowed for gears.
+3. **Profile match** — for cylinder-family kinds, `profile(A) == profile(B)`
+   (a round pin does not enter an axle-cross hole).
+4. **Size match** — `|radius(A) − radius(B)| ≤ ε`, *or* both carry the same size-class `key`.
+5. **Frame opposition** — the connector local **+Z axes point into each other** (anti-parallel);
+   the attach solver already computes the rigid transform that makes this true.
+
+### Legal kind pairs
+
+| kind A  | mates with kind B      | notes                                                        |
+|---------|------------------------|-------------------------------------------------------------|
+| `stud`  | `stud` (opp. gender)   | the primary building grid; peg-into-tube                    |
+| `pin`   | `pin`                  | friction connector; round profile                           |
+| `axle`  | `axle`                 | cross profile; the mate can transmit rotation               |
+| `clip`  | `bar`, `pin`, `stud`   | clip is always `f`; grips any male round cylinder           |
+| `bar`   | `clip`                 | bar is `m`; also enterable by female round cylinders        |
+| `hinge` | `hinge`                | interleaved fingers; alternating M/F ordering, mate in-plane|
+| `ball`  | `socket`               | 3-DOF rotation retained after mate                          |
+| `rail`  | `rail`                 | opp. gender; 1-DOF slide retained after mate                |
+| `gear`  | `gear`                 | neutral gender; mate = teeth mesh at pitch-radius distance  |
+| `gen`   | `gen` (same `key`)     | matched by group name only; fully custom pairs              |
+
+Everything not in this table is **incompatible** — the generator never proposes it.
+
+---
+
+## 4. The grid — the one constraint that makes it look right
+
+Lego's visual coherence comes from a fixed ratio baked into every part: **stud pitch : plate
+height = 5 : 2** (in LDraw units, 20 LDU wide × 8 LDU tall per plate). Everything is a multiple.
+
+We adopt the same discipline with our own unit. Define:
+
+- **`U`** — the grid pitch (horizontal stud spacing). One "cell" is `U × U`.
+- **`H`** — the layer height. Fix `H / U = 2 / 5` to inherit Lego's proportions, or pick our own
+  ratio — but **pick exactly one and make every part a multiple of it.**
+
+Rules that follow:
+
+- Every connector sits at a grid coordinate: `pos = (i·U, j·H, k·U)` for integers `i, j, k`.
+- Every part's bounding footprint is an integer number of cells.
+- **Size classes** (the `key` field) are named radii on the grid — e.g. `stud` radius is a fixed
+  fraction of `U`, `pin`/`axle` another. Two connectors with the same size-class `key` match in
+  step 4 without a floating-point radius compare.
+
+On-grid connectors are what make both **snapping** deterministic *and* **greedy meshing** possible
+(next section). The grid is not decoration — it is the precondition for the whole pipeline.
+
+---
+
+## 5. Two layers: semantic parts vs. merged geometry
+
+The part graph and the shipped geometry are **different layers** and must stay decoupled:
+
+- **Semantic layer** — parts + connectors. One node per part. This is where snapping, the "part 253
+  connects to part 231" structure, and editing live. Legible, algorithm-friendly.
+- **Geometry layer** — what actually lands in the `.glb`. Minimal triangles; adjacent same-material
+  parts fused; interior faces gone.
+
+Part count is a *generation-time* abstraction; merging is a *compile-time* optimization that
+discards the abstraction once it has done its job. Two collapse strategies, both watertight
+(required — we never ship holes):
+
+1. **Greedy meshing** *(preferred for grid-aligned flat/box runs)* — the canonical voxel-world
+   technique: sweep the grid and coalesce runs of identical adjacent faces into the largest
+   rectangle possible. A 10×10 tile field becomes **one quad**, not ten unioned boxes. Crucially it
+   **preserves tiling UVs**, so textured parts survive the merge. Viable *because* parts are
+   grid-aligned — the §4 grid pays off twice.
+2. **CSG union** *(fallback for non-grid or overlapping bits)* — this already exists as
+   `mogen-export/merge.rs`: CSG-unions same-material, non-skinned sibling leaf meshes into one
+   watertight node. General-purpose, but drops per-vertex UVs on merged groups.
+
+Because the aesthetic wants flat per-face materials anyway, nothing of value is lost in the
+collapse.
+
+### Verified behaviour + the module-nesting gap (2026-07-09)
+
+Tested against `examples/parts/lego_bricks.mog`. Findings:
+
+- The `solid { … }` CSG merge **works and fires automatically** (no export flag) — but the
+  `mogen build` *summary line* reports pre-merge scene counts, so always `inspect` the GLB to see
+  the merged result. A flat control (`box` siblings directly under `solid`) collapses correctly:
+  `nodes=2, meshes=1` with a single `merged_<material>` node.
+- **Parts instantiated with `use` do NOT merge.** `is_mergeable` (in `merge.rs`) rejects any node
+  with children, and a `use` always wraps its geometry in a group (the module-body group *plus*
+  `use`'s implicit transform group). So module-placed parts are never *direct leaf children* of the
+  `solid`, and the merge can't reach them — the demo build keeps all 30 nodes separate.
+
+**Implication for this system:** parts are modules, so the merge as it stands will never collapse
+them. To make "minimum parts" real we need one of:
+
+1. a **deep solid merge** — recurse through pass-through groups and merge all same-material
+   *descendant* leaves of a `solid`, not just direct children (smallest change; keeps the module
+   authoring model intact), or
+2. **greedy meshing** as a new grid-aware pass (bigger; also the UV-preserving win), or
+3. emitting parts **without** a wrapping group so their single mesh lands as a direct `solid` child
+   (fights `use`'s implicit group; least attractive).
+
+Recommendation: (1) first — it unblocks the current design with the least disruption — then (2) for
+the flat-field UV case.
+
+---
+
+## 6. How this lands in mogen
+
+- **A part is a `module`** (`module "name" (p=default) { … }`) whose declared `connector`s use the
+  §2 tag scheme and sit at §4 grid coordinates.
+- **A part catalog is a stdlib of such modules** — the algorithm's building blocks.
+- **The generator's job reduces to**: pick parts → find compatible connector pairs (the §3
+  predicate) → `attach` (the existing connector-frame solver aligns the frames) → repeat.
+- **Export merges** via greedy-mesh + CSG-union fallback, leaving the semantic graph intact for
+  re-editing.
+
+No new subsystem — this is an extension of modules + connectors + attach + merge, all of which
+already exist.
+
+---
+
+## 7. Open decisions
+
+- Exact value of `U` and the `H/U` ratio (adopt 2/5, or choose our own).
+- The named size-class set (how many distinct connector radii the catalog uses).
+- Whether `gear` and `rail` ship in v1 (they retain a DOF after mating — only meaningful for
+  animated/mechanical models; static scenery may not need them).
+- Whether greedy meshing lands as a new export pass or an upgrade to `merge.rs`.
+- **Blocking:** whether to add a *deep solid merge* (merge same-material descendant leaves, not just
+  direct children) so module-instantiated parts actually collapse — see §5. Without this, no
+  part-based build ever merges.
+
+---
+
+## Sources
+
+- [LDCad metas](https://www.melkert.net/LDCad/tech/meta) — authoritative snap-meta reference.
+- [LDCad shadow library](https://www.melkert.net/LDCad/tech/shadowLib) — how connectivity metadata
+  overlays LDraw parts.
+- [Part Snapping Language Extension — LDraw.org Wiki](https://wiki.ldraw.org/wiki/Part_Snapping_Language_Extension)
+- [LDCadShadowLibrary (GitHub)](https://github.com/RolandMelkert/LDCadShadowLibrary) — the real
+  connectivity data set.

--- a/docs/part-connection-ontology.md
+++ b/docs/part-connection-ontology.md
@@ -149,31 +149,30 @@ discards the abstraction once it has done its job. Two collapse strategies, both
 Because the aesthetic wants flat per-face materials anyway, nothing of value is lost in the
 collapse.
 
-### Verified behaviour + the module-nesting gap (2026-07-09)
+### Verified behaviour + the deep solid merge (2026-07-09)
 
-Tested against `examples/parts/lego_bricks.mog`. Findings:
+Tested against `examples/parts/lego_bricks.mog`. Note the `mogen build` *summary line* reports
+pre-merge scene counts — always `inspect` the GLB to see the merged result.
 
-- The `solid { … }` CSG merge **works and fires automatically** (no export flag) — but the
-  `mogen build` *summary line* reports pre-merge scene counts, so always `inspect` the GLB to see
-  the merged result. A flat control (`box` siblings directly under `solid`) collapses correctly:
-  `nodes=2, meshes=1` with a single `merged_<material>` node.
-- **Parts instantiated with `use` do NOT merge.** `is_mergeable` (in `merge.rs`) rejects any node
-  with children, and a `use` always wraps its geometry in a group (the module-body group *plus*
-  `use`'s implicit transform group). So module-placed parts are never *direct leaf children* of the
-  `solid`, and the merge can't reach them — the demo build keeps all 30 nodes separate.
+**The original gap:** `is_mergeable` (in `merge.rs`) rejects any node with children, and a `use`
+always wraps its geometry in a group (the module-body group *plus* `use`'s implicit transform
+group). So module-placed parts were never *direct leaf children* of the `solid`, and the shallow
+merge couldn't reach them — the demo built to 30 separate nodes.
 
-**Implication for this system:** parts are modules, so the merge as it stands will never collapse
-them. To make "minimum parts" real we need one of:
+**Resolved — deep solid merge** (`merge.rs`, `merge_solid_groups`): when a `solid`'s *entire*
+subtree is mergeable leaves (no skins / colliders / slots / protected nodes / non-manifold meshes /
+`cast_shadow=false` opt-outs), the pass now collapses **all same-material descendant leaves** — not
+just direct children — into one CSG-unioned mesh per material, baking each leaf's transform relative
+to the solid and flattening the intermediate groups away. Any keeper in the subtree disqualifies the
+solid, which falls back to the safe shallow direct-child merge. Watertight by construction (same
+`try_union_many` → `clean_csg_output` path as in-DSL CSG).
 
-1. a **deep solid merge** — recurse through pass-through groups and merge all same-material
-   *descendant* leaves of a `solid`, not just direct children (smallest change; keeps the module
-   authoring model intact), or
-2. **greedy meshing** as a new grid-aware pass (bigger; also the UV-preserving win), or
-3. emitting parts **without** a wrapping group so their single mesh lands as a direct `solid` child
-   (fights `use`'s implicit group; least attractive).
+Result on the demo: **30 nodes / 5 meshes → 8 nodes / 3 meshes** — each `solid` course collapses to
+one `merged_<material>` leaf; the standalone tile (not in a `solid`) stays separate, as intended.
 
-Recommendation: (1) first — it unblocks the current design with the least disruption — then (2) for
-the flat-field UV case.
+**Still ahead:** **greedy meshing** as a grid-aware pass — the UV-preserving win for large flat
+same-material fields, where CSG union drops per-vertex UVs. The deep merge unblocks the part model
+today; greedy meshing is the later optimisation for textured flat runs.
 
 ---
 
@@ -198,10 +197,9 @@ already exist.
 - The named size-class set (how many distinct connector radii the catalog uses).
 - Whether `gear` and `rail` ship in v1 (they retain a DOF after mating — only meaningful for
   animated/mechanical models; static scenery may not need them).
-- Whether greedy meshing lands as a new export pass or an upgrade to `merge.rs`.
-- **Blocking:** whether to add a *deep solid merge* (merge same-material descendant leaves, not just
-  direct children) so module-instantiated parts actually collapse — see §5. Without this, no
-  part-based build ever merges.
+- Whether greedy meshing lands as a new export pass or an upgrade to `merge.rs` (the UV-preserving
+  win for flat same-material fields; the deep solid merge in §5 already handles the part-collapse
+  case, but via CSG union which drops per-vertex UVs).
 
 ---
 

--- a/examples/parts/lego_bricks.mog
+++ b/examples/parts/lego_bricks.mog
@@ -1,0 +1,97 @@
+// Seed part library — proves the connection ontology end-to-end.
+// See docs/part-connection-ontology.md for the design.
+//
+// GRID (real Lego, ratio 5:2):
+//   stud pitch  P = 8 mm      (horizontal cell)
+//   plate       H = 3.2 mm    (one layer)
+//   brick         = 9.6 mm    (3 plates)
+//   stud radius   = 2.4 mm,  stud height = 1.8 mm
+//
+// CONNECTOR TAGS (kind:profile:gender):
+//   "stud:round:m"  top peg      "stud:round:f"  bottom socket
+// A top stud of one part mates with the bottom socket of the part above:
+// same kind+profile, opposite gender, radii equal, frames anti-parallel.
+
+meta (
+  name = "lego_bricks",
+  description = "Studded bricks on a real-Lego grid with typed connectors, plus a demo build.",
+  tags = ["parts", "lego", "connectors", "demo"],
+)
+
+material "red"    (color=[0.70, 0.05, 0.05], roughness=0.35)
+material "yellow" (color=[0.90, 0.70, 0.05], roughness=0.35)
+material "blue"   (color=[0.05, 0.20, 0.70], roughness=0.35)
+
+// --- Part library ---------------------------------------------------------
+// Each part omits `mat=` so it inherits the colour from the `use` wrapper.
+
+// 1x1 brick — one stud up, one socket down.
+module "brick_1x1" () {
+  group "brick_1x1" {
+    box "body" (size=[8mm, 9.6mm, 8mm], anchor=bottom) {
+      connector "top"    (at=[0, 9.6mm, 0], dir=[0,  1, 0], tag="stud:round:m", radius=2.4mm)
+      connector "bottom" (at=[0, 0,     0], dir=[0, -1, 0], tag="stud:round:f", radius=2.4mm)
+    }
+    cylinder "stud" (pos=[0, 9.6mm, 0], radius=2.4mm, height=1.8mm, segments=8, anchor=bottom)
+  }
+}
+
+// 1x1 plate — a third of a brick tall; same stud/socket pair.
+module "plate_1x1" () {
+  group "plate_1x1" {
+    box "body" (size=[8mm, 3.2mm, 8mm], anchor=bottom) {
+      connector "top"    (at=[0, 3.2mm, 0], dir=[0,  1, 0], tag="stud:round:m", radius=2.4mm)
+      connector "bottom" (at=[0, 0,     0], dir=[0, -1, 0], tag="stud:round:f", radius=2.4mm)
+    }
+    cylinder "stud" (pos=[0, 3.2mm, 0], radius=2.4mm, height=1.8mm, segments=8, anchor=bottom)
+  }
+}
+
+// 1x1 tile — plate height, SMOOTH top (no stud): presents a socket below only.
+module "tile_1x1" () {
+  group "tile_1x1" {
+    box "body" (size=[8mm, 3.2mm, 8mm], anchor=bottom) {
+      connector "bottom" (at=[0, 0, 0], dir=[0, -1, 0], tag="stud:round:f", radius=2.4mm)
+    }
+  }
+}
+
+// 2x1 brick — two studs along X, two sockets below.
+module "brick_2x1" () {
+  group "brick_2x1" {
+    box "body" (size=[16mm, 9.6mm, 8mm], anchor=bottom) {
+      connector "top_a"    (at=[-4mm, 9.6mm, 0], dir=[0,  1, 0], tag="stud:round:m", radius=2.4mm)
+      connector "top_b"    (at=[ 4mm, 9.6mm, 0], dir=[0,  1, 0], tag="stud:round:m", radius=2.4mm)
+      connector "bottom_a" (at=[-4mm, 0,     0], dir=[0, -1, 0], tag="stud:round:f", radius=2.4mm)
+      connector "bottom_b" (at=[ 4mm, 0,     0], dir=[0, -1, 0], tag="stud:round:f", radius=2.4mm)
+    }
+    cylinder "stud_a" (pos=[-4mm, 9.6mm, 0], radius=2.4mm, height=1.8mm, segments=8, anchor=bottom)
+    cylinder "stud_b" (pos=[ 4mm, 9.6mm, 0], radius=2.4mm, height=1.8mm, segments=8, anchor=bottom)
+  }
+}
+
+// --- Demo build -----------------------------------------------------------
+// Parts placed on the 8 mm grid via `use` x/y/z shortcuts — the snap the
+// generator performs by pairing compatible connectors reduces to integer
+// grid coordinates. `solid` requests the export-time same-material merge.
+
+scene {
+  // Base course: a 2x2 footprint of red 1x1 bricks at y = 0.
+  solid "course_0" (mat="red") {
+    use "brick_1x1" (x=0,   z=0)
+    use "brick_1x1" (x=8mm, z=0)
+    use "brick_1x1" (x=0,   z=8mm)
+    use "brick_1x1" (x=8mm, z=8mm)
+  }
+
+  // Second course: two yellow bricks bridging diagonally, at y = 9.6 mm.
+  solid "course_1" (mat="yellow") {
+    use "brick_1x1" (x=0,   y=9.6mm, z=0)
+    use "brick_1x1" (x=8mm, y=9.6mm, z=8mm)
+  }
+
+  // Cap one column with a smooth blue tile (no stud on top).
+  group "cap" (mat="blue") {
+    use "tile_1x1" (x=8mm, y=19.2mm, z=8mm)
+  }
+}


### PR DESCRIPTION
## What & why

Groundwork for a blocky, grid-based **part system** where parts are authored as mogen `module`s with typed, oriented `connector`s so an algorithm can snap them into models. The connection vocabulary is mined from Lego (specifically the LDCad shadow-library snapping metas) — *not* its geometry, so there's no copyright entanglement — and the parts use real Lego measurements.

Along the way this fixes a concrete blocker: the export merge couldn't collapse parts built from modules, which defeats the whole "minimum geometry" premise.

## Changes

**1. Ontology + seed parts** (`36da4fa`)
- `docs/part-connection-ontology.md` — the design: connection taxonomy grounded in the real LDCad metas (`SNAP_CYL/CLP/FGR/SPH/GEN`; studs/pins/axles collapse into one parametric cylinder, mapping onto `Connector`'s `pos+quat+tag+radius`), the tag scheme `kind:profile:gender[:key]`, the mate predicate, the Lego 5:2 grid, and the two-layer semantic/geometry split.
- `examples/parts/lego_bricks.mog` — `brick_1x1` / `plate_1x1` / `tile_1x1` / `brick_2x1` with connectors at real Lego dimensions (stud pitch 8mm, plate 3.2mm, brick 9.6mm), plus a demo build. Validates clean, builds to GLB.

**2. Deep solid merge** (`dd8fd69`)
- `solid { … }` previously only merged **direct** leaf-mesh children. A `use` always wraps its geometry in a group (module body + `use`'s implicit transform group), so module-instantiated parts were never direct children and never merged.
- `merge_solid_groups` now does a **deep merge**: when a solid's *entire* subtree is mergeable leaves, it collapses all same-material **descendant** leaves into one CSG-unioned mesh per material, baking each leaf's solid-relative transform and flattening the intermediate groups. Any keeper (skin / collider / slot / non-manifold mesh / `cast_shadow=false` opt-out / skin-or-clip-referenced node) disqualifies the solid, which falls back to the existing shallow direct-child merge.
- Watertight by construction — same `try_union_many` → `clean_csg_output` path as in-DSL CSG.

## Verification
- Demo GLB: **30 nodes / 5 meshes → 8 nodes / 3 meshes** (each `solid` course collapses to one `merged_<material>` leaf; the standalone tile, not in a `solid`, stays separate as intended).
- All 25 `mogen-export` tests pass, including two new deep-merge tests (nested-group flatten+merge; keeper triggers safe fallback). Clippy clean on the new code.

## Reviewer notes
- The `mogen build` **summary line reports pre-merge scene counts** — `inspect` the GLB to see the merged result. (This tripped me up mid-development; worth knowing.)
- Behaviour change is scoped to `solid`-tagged subtrees; the global `merge_sibling_meshes` pass and the shallow path are untouched.
- Known follow-up (documented, not in scope here): CSG union drops per-vertex UVs, so **greedy meshing** is the future UV-preserving win for large flat same-material fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)