### PR TITLE
Add user-authored GLSL shaders to the DSL (water as first client)

### DIFF
--- a/crates/mogen-core/src/graph.rs
+++ b/crates/mogen-core/src/graph.rs
@@ -9,7 +9,7 @@ use glam::{Quat, Vec3};
 
 use crate::{
     Aabb, Clip, Connector, Joint, Light, Material, MaterialId, Mesh, Meta, PhysicsBody,
-    PhysicsId, PhysicsMaterial, Skin, SkinId, Span, Transform,
+    PhysicsId, PhysicsMaterial, ShaderDecl, Skin, SkinId, Span, Transform,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -340,6 +340,13 @@ pub struct SceneGraph {
     /// resolved into a per-node [`PhysicsBody`] snapshot at lowering time.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub physics: Vec<PhysicsMaterial>,
+    /// Declared `shader "<name>" { … }` preview shaders, hoisted in the same
+    /// pass as materials and seeded with the built-in presets (e.g. `water`).
+    /// Materials reference these by name via `shader=`. Studio compiles the
+    /// referenced GLSL for live preview; export ignores the source but projects
+    /// name + params into `node.extras`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub shaders: Vec<ShaderDecl>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub joints: Vec<Joint>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -493,6 +500,31 @@ impl SceneGraph {
             return Some(PhysicsId(idx as u32));
         }
         self.find_physics(name)
+    }
+
+    pub fn add_shader(&mut self, shader: ShaderDecl) {
+        self.shaders.push(shader);
+    }
+
+    /// Whether a shader `<name>` exists — either declared or a built-in preset.
+    pub fn has_shader(&self, name: &str) -> bool {
+        crate::shader::builtin_names().contains(&name)
+            || self.shaders.iter().any(|s| s.name == name)
+    }
+
+    /// Look up a declared shader by name, preferring one from the caller's file
+    /// (`origin`), then any bare-name match. Mirrors [`Self::find_material_scoped`].
+    /// Built-in presets that were never seeded (or were shadowed away) return
+    /// `None` here — callers that only need the name use [`Self::has_shader`].
+    pub fn find_shader_scoped(&self, name: &str, origin: Option<&Path>) -> Option<&ShaderDecl> {
+        if let Some(s) = self
+            .shaders
+            .iter()
+            .find(|s| s.name == name && s.origin.as_deref() == origin)
+        {
+            return Some(s);
+        }
+        self.shaders.iter().find(|s| s.name == name)
     }
 
     /// Rewrite every relative texture path on every material so it's anchored

--- a/crates/mogen-core/src/lib.rs
+++ b/crates/mogen-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod material;
 pub mod mesh;
 pub mod meta;
 pub mod physics;
+pub mod shader;
 pub mod skin;
 pub mod transform;
 
@@ -22,8 +23,9 @@ pub use graph::{
 pub use gradient::{Gradient, GradientAxis, GradientKind, GradientStop};
 pub use meta::Meta;
 pub use light::{Light, LightKind};
-pub use material::{AlphaMode, Material, MaterialId, MaterialShader, TextureRef, UvMode};
+pub use material::{AlphaMode, Material, MaterialId, TextureRef, UvMode};
 pub use mesh::Mesh;
 pub use physics::{PhysicsBody, PhysicsId, PhysicsMaterial};
+pub use shader::{ShaderDecl, ShaderParamDef, ShaderParamType, ShaderParamValue};
 pub use skin::{Skin, SkinId};
 pub use transform::Transform;

--- a/crates/mogen-core/src/material.rs
+++ b/crates/mogen-core/src/material.rs
@@ -1,8 +1,10 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
 use crate::gradient::Gradient;
+use crate::shader::ShaderParamValue;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct MaterialId(pub u32);
@@ -37,36 +39,6 @@ pub enum UvMode {
     #[default]
     Tile,
     Fit,
-}
-
-/// Per-material override for the studio's preview shader. `Standard` is the
-/// PBR path everyone else uses; `Water` swaps in an animated waves +
-/// fresnel-blue + sky-reflection branch. The exporter ignores this field —
-/// glTF can't carry custom shaders, so the .glb falls back to whatever PBR
-/// scalars the material was authored with.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub enum MaterialShader {
-    #[default]
-    Standard,
-    Water,
-}
-
-impl MaterialShader {
-    /// Integer handed to the fragment shader via `u_material_shader`. Keep in
-    /// sync with the branches in `viewer/shaders.rs`.
-    pub fn shader_id(self) -> i32 {
-        match self {
-            MaterialShader::Standard => 0,
-            MaterialShader::Water => 1,
-        }
-    }
-
-    /// Whether this shader animates in the preview and so needs continuous
-    /// repaints. Used by the viewer to keep ticking when the scene is
-    /// otherwise static.
-    pub fn animates(self) -> bool {
-        matches!(self, MaterialShader::Water)
-    }
 }
 
 /// A reference to an on-disk image used as a material texture. Paths are
@@ -122,12 +94,20 @@ pub struct Material {
     /// uses world-space UVs so texel density is constant across primitives;
     /// `Fit` keeps the legacy per-face `[0, 1]²` mapping for sign-style images.
     pub uv_mode: UvMode,
-    /// Studio-only shader override. `Standard` (default) goes through the
-    /// regular PBR path; `Water` selects an animated waves branch in the
-    /// viewer's fragment shader. Skipped during serde when default so saved
-    /// scenes stay roundtrip-clean for the common case.
-    #[serde(default, skip_serializing_if = "is_default_shader")]
-    pub shader: MaterialShader,
+    /// Name of the preview shader this material uses, resolved against the
+    /// graph's declared + built-in [`crate::ShaderDecl`]s. `None` (the common
+    /// case) is the standard PBR path. `Some("water")` selects the built-in
+    /// water preset; `Some("my_shader")` selects a user `shader "my_shader"`.
+    /// The exporter can't embed GLSL, so it projects this + `shader_params`
+    /// into the node's `extras.shader` as metadata; MoGen Studio compiles the
+    /// referenced GLSL for live preview. Skipped during serde when absent so
+    /// saved scenes stay roundtrip-clean for the common case.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shader_name: Option<String>,
+    /// Values fed to the referenced shader's declared `param`s. Overrides the
+    /// param defaults. Empty for standard-PBR materials.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub shader_params: BTreeMap<String, ShaderParamValue>,
     /// Per-axis multiplier applied to UVs at export. In `Tile` mode this sets
     /// "tiles per world unit" (e.g. `[2, 2]` doubles the tiling density on a
     /// brick wall). In `Fit` mode it scales the `[0, 1]` parameter — `> 1`
@@ -195,7 +175,8 @@ impl Material {
             transmission: 0.0,
             double_sided: false,
             uv_mode: UvMode::default(),
-            shader: MaterialShader::default(),
+            shader_name: None,
+            shader_params: BTreeMap::new(),
             uv_scale: [1.0, 1.0],
             base_color_texture: None,
             metallic_roughness_texture: None,
@@ -217,6 +198,3 @@ impl Material {
     }
 }
 
-fn is_default_shader(s: &MaterialShader) -> bool {
-    matches!(s, MaterialShader::Standard)
-}

--- a/crates/mogen-core/src/shader.rs
+++ b/crates/mogen-core/src/shader.rs
@@ -1,0 +1,151 @@
+//! User-authored preview shaders.
+//!
+//! A `shader "<name>" { source = "…"; param … }` declaration names an on-disk
+//! GLSL fragment snippet and the parameters materials may feed it. Like
+//! [`crate::Material`], shaders are hoisted into the [`crate::SceneGraph`] in a
+//! dedicated pass and referenced by name (`material (… shader="<name>")`).
+//!
+//! mogen itself never compiles or runs the GLSL — it only carries the path +
+//! parameter values as opaque metadata (see the exporter's `node.extras.shader`
+//! projection). MoGen Studio is the one component that actually compiles a
+//! shader for live preview. The built-in `water` preset is just the first
+//! client of this system: it goes through the exact same path a user shader
+//! does rather than being special-cased.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Name of the built-in water shader preset. Seeded into every graph (unless the
+/// user declares their own `shader "water"`) so `shader="water"` keeps working
+/// with no declaration, exactly as the old `MaterialShader::Water` enum did.
+pub const WATER: &str = "water";
+
+/// Every built-in shader name. Referenced by the validator (so `shader="water"`
+/// resolves without a declaration) and by the lowering seed.
+pub fn builtin_names() -> &'static [&'static str] {
+    &[WATER]
+}
+
+/// The declared type of a shader `param`. Determines the GLSL uniform type and
+/// which [`ShaderParamValue`] variant a supplied value must match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShaderParamType {
+    Float,
+    Vec2,
+    Vec3,
+    Vec4,
+    /// An RGB colour — same storage as `Vec3`, but authored as `[r, g, b]` and
+    /// declared as `type=color` for clarity in the DSL.
+    Color,
+}
+
+impl ShaderParamType {
+    /// Parse the DSL `type=` spelling. Returns `None` for an unknown type.
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "float" => ShaderParamType::Float,
+            "vec2" => ShaderParamType::Vec2,
+            "vec3" => ShaderParamType::Vec3,
+            "vec4" => ShaderParamType::Vec4,
+            "color" => ShaderParamType::Color,
+            _ => return None,
+        })
+    }
+
+    /// The GLSL uniform type this parameter compiles to. `Color` is a `vec3`.
+    pub fn glsl_type(self) -> &'static str {
+        match self {
+            ShaderParamType::Float => "float",
+            ShaderParamType::Vec2 => "vec2",
+            ShaderParamType::Vec3 | ShaderParamType::Color => "vec3",
+            ShaderParamType::Vec4 => "vec4",
+        }
+    }
+}
+
+/// A concrete value fed to a shader parameter. Deliberately small — the subset
+/// of DSL literals a GLSL uniform can take. `#[serde(untagged)]` keeps the
+/// `extras` JSON clean (`3.5`, `[0, 0.3, 0.5]`) rather than tagged variants.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ShaderParamValue {
+    Float(f32),
+    Vec2([f32; 2]),
+    Vec3([f32; 3]),
+    Vec4([f32; 4]),
+}
+
+impl ShaderParamValue {
+    /// Whether this value can populate a uniform of the given declared type.
+    /// `Color` accepts a `Vec3`.
+    pub fn matches(&self, ty: ShaderParamType) -> bool {
+        matches!(
+            (self, ty),
+            (ShaderParamValue::Float(_), ShaderParamType::Float)
+                | (ShaderParamValue::Vec2(_), ShaderParamType::Vec2)
+                | (
+                    ShaderParamValue::Vec3(_),
+                    ShaderParamType::Vec3 | ShaderParamType::Color
+                )
+                | (ShaderParamValue::Vec4(_), ShaderParamType::Vec4)
+        )
+    }
+}
+
+/// A single declared parameter of a [`ShaderDecl`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ShaderParamDef {
+    pub name: String,
+    pub ty: ShaderParamType,
+    /// Value used when a referencing material supplies no override. `None` means
+    /// the uniform falls back to GLSL's default (zero) if the material is silent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<ShaderParamValue>,
+}
+
+/// A hoisted `shader "<name>" { … }` declaration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ShaderDecl {
+    pub name: String,
+    /// Path to the GLSL fragment snippet, relative to the `.mog` that declared
+    /// it (resolved the same way as texture paths). Built-in presets carry a
+    /// `stdlib:`-keyed path that MoGen Studio resolves from bundled bytes.
+    pub source: PathBuf,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub params: Vec<ShaderParamDef>,
+    /// Canonical path of the imported `.mog` this shader was hoisted from, or
+    /// `None` for the file currently being lowered. Mirrors [`crate::Material::origin`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin: Option<PathBuf>,
+}
+
+impl ShaderDecl {
+    pub fn new(name: impl Into<String>, source: impl Into<PathBuf>) -> Self {
+        Self {
+            name: name.into(),
+            source: source.into(),
+            params: Vec::new(),
+            origin: None,
+        }
+    }
+
+    /// Resolve the effective value of `param`, preferring a material's override,
+    /// then the declared default. `None` when the param is unknown and
+    /// undefaulted.
+    pub fn resolve_param(
+        &self,
+        name: &str,
+        overrides: &BTreeMap<String, ShaderParamValue>,
+    ) -> Option<ShaderParamValue> {
+        if let Some(v) = overrides.get(name) {
+            return Some(v.clone());
+        }
+        self.params
+            .iter()
+            .find(|p| p.name == name)
+            .and_then(|p| p.default.clone())
+    }
+}

--- a/crates/mogen-core/src/shader.rs
+++ b/crates/mogen-core/src/shader.rs
@@ -149,3 +149,73 @@ impl ShaderDecl {
             .and_then(|p| p.default.clone())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn param_type_parse_round_trips_all_spellings() {
+        assert_eq!(ShaderParamType::parse("float"), Some(ShaderParamType::Float));
+        assert_eq!(ShaderParamType::parse("vec2"), Some(ShaderParamType::Vec2));
+        assert_eq!(ShaderParamType::parse("vec3"), Some(ShaderParamType::Vec3));
+        assert_eq!(ShaderParamType::parse("vec4"), Some(ShaderParamType::Vec4));
+        assert_eq!(ShaderParamType::parse("color"), Some(ShaderParamType::Color));
+        assert_eq!(ShaderParamType::parse("bogus"), None);
+    }
+
+    #[test]
+    fn glsl_type_maps_color_to_vec3() {
+        assert_eq!(ShaderParamType::Float.glsl_type(), "float");
+        assert_eq!(ShaderParamType::Vec2.glsl_type(), "vec2");
+        assert_eq!(ShaderParamType::Vec3.glsl_type(), "vec3");
+        assert_eq!(ShaderParamType::Color.glsl_type(), "vec3");
+        assert_eq!(ShaderParamType::Vec4.glsl_type(), "vec4");
+    }
+
+    #[test]
+    fn value_matches_accepts_color_as_vec3_but_not_other_mismatches() {
+        assert!(ShaderParamValue::Float(1.0).matches(ShaderParamType::Float));
+        assert!(ShaderParamValue::Vec3([0.0, 0.0, 0.0]).matches(ShaderParamType::Vec3));
+        assert!(ShaderParamValue::Vec3([0.0, 0.0, 0.0]).matches(ShaderParamType::Color));
+        assert!(!ShaderParamValue::Float(1.0).matches(ShaderParamType::Vec3));
+        assert!(!ShaderParamValue::Vec2([0.0, 0.0]).matches(ShaderParamType::Vec4));
+        assert!(!ShaderParamValue::Vec4([0.0, 0.0, 0.0, 0.0]).matches(ShaderParamType::Color));
+    }
+
+    #[test]
+    fn resolve_param_prefers_override_then_default_then_none() {
+        let mut decl = ShaderDecl::new("ripple", "shaders/ripple.glsl");
+        decl.params.push(ShaderParamDef {
+            name: "speed".to_string(),
+            ty: ShaderParamType::Float,
+            default: Some(ShaderParamValue::Float(2.0)),
+        });
+        decl.params.push(ShaderParamDef {
+            name: "undefaulted".to_string(),
+            ty: ShaderParamType::Float,
+            default: None,
+        });
+
+        let mut overrides = BTreeMap::new();
+        assert_eq!(
+            decl.resolve_param("speed", &overrides),
+            Some(ShaderParamValue::Float(2.0)),
+            "falls back to the declared default"
+        );
+        assert_eq!(decl.resolve_param("undefaulted", &overrides), None);
+        assert_eq!(decl.resolve_param("unknown_param", &overrides), None);
+
+        overrides.insert("speed".to_string(), ShaderParamValue::Float(9.0));
+        assert_eq!(
+            decl.resolve_param("speed", &overrides),
+            Some(ShaderParamValue::Float(9.0)),
+            "an override wins over the declared default"
+        );
+    }
+
+    #[test]
+    fn builtin_names_seeds_water() {
+        assert_eq!(builtin_names(), &[WATER]);
+    }
+}

--- a/crates/mogen-dsl/src/lower.rs
+++ b/crates/mogen-dsl/src/lower.rs
@@ -15,6 +15,7 @@ mod layout;
 mod light;
 mod lod;
 mod material;
+mod shader;
 mod node;
 mod physics;
 mod poi;
@@ -44,6 +45,7 @@ use crate::skin_lower::{bind_meshes, lower_skeleton};
 use anim::{is_anim_decl, lower_animations};
 use lod::{collect_origin_lods, extract_lod_scale, LodByOriginGuard};
 use material::collect_materials;
+use shader::{collect_shaders, ensure_builtin_shaders};
 use node::lower_into;
 use physics::collect_physics;
 
@@ -233,6 +235,12 @@ pub fn lower_with_loader(
     // match, which is how user-declared materials shadow imported ones.
     collect_materials(&expanded, &mut graph)?;
     collect_materials(&imported_decls, &mut graph)?;
+    // Shader declarations hoist in the same pass and on the same dedupe rules;
+    // materials reference them by name via `shader=`. Built-in presets (water)
+    // are seeded last so a user `shader "water"` shadows them.
+    collect_shaders(&expanded, &mut graph)?;
+    collect_shaders(&imported_decls, &mut graph)?;
+    ensure_builtin_shaders(&mut graph);
     // Physics substances hoist in the same pass, on the same dedupe rules, so
     // `phys=` references resolve during Pass 2 exactly like `mat=`.
     collect_physics(&expanded, &mut graph)?;
@@ -243,6 +251,7 @@ pub fn lower_with_loader(
         match n.kind.as_str() {
             "material" => {} // already handled
             "physics" => {} // hoisted in Pass 1
+            "shader" => {} // hoisted in Pass 1
             "lod_scale" => {} // build-time setting, consumed above
             "meta" => {} // already lifted onto graph.meta
             k if is_anim_decl(k) => {} // pass 3
@@ -253,6 +262,7 @@ pub fn lower_with_loader(
                 for c in &n.children {
                     if c.kind == "material"
                         || c.kind == "physics"
+                        || c.kind == "shader"
                         || c.kind == "attach"
                         || c.kind == "conform"
                         || is_anim_decl(&c.kind)

--- a/crates/mogen-dsl/src/lower/cave/materials.rs
+++ b/crates/mogen-dsl/src/lower/cave/materials.rs
@@ -8,7 +8,7 @@
 
 use std::path::Path;
 
-use mogen_core::{AlphaMode, Material, MaterialShader, SceneGraph};
+use mogen_core::{AlphaMode, Material, SceneGraph};
 
 use crate::lower::material::ensure_named_defaults;
 
@@ -58,7 +58,7 @@ pub(super) fn ensure_defaults(graph: &mut SceneGraph, origin: Option<&Path>) {
             m.alpha_mode = AlphaMode::Blend;
             m.transmission = 0.9;
             m.double_sided = true;
-            m.shader = MaterialShader::Water;
+            m.shader_name = Some(mogen_core::shader::WATER.to_string());
             m
         }),
     ];

--- a/crates/mogen-dsl/src/lower/cave/tests.rs
+++ b/crates/mogen-dsl/src/lower/cave/tests.rs
@@ -526,9 +526,9 @@ cave "spring" (seed=1, size=[18, 8, 18], chambers=4, resolution=40, pools=2)
     let g = lower_src(src);
     let water = g.find_material("cave_water").expect("default water material");
     assert_eq!(
-        g.materials[water.0 as usize].shader,
-        mogen_core::MaterialShader::Water,
-        "cave water should use the animated water shader"
+        g.materials[water.0 as usize].shader_name.as_deref(),
+        Some(mogen_core::shader::WATER),
+        "cave water should use the built-in water shader"
     );
     let pools = g
         .nodes

--- a/crates/mogen-dsl/src/lower/material.rs
+++ b/crates/mogen-dsl/src/lower/material.rs
@@ -1,11 +1,12 @@
 use anyhow::{anyhow, bail, Result};
 
 use mogen_core::{
-    AlphaMode, Gradient, GradientAxis, GradientKind, GradientStop, Material, MaterialShader,
-    NodeId, SceneGraph, TextureRef, UvMode,
+    AlphaMode, Gradient, GradientAxis, GradientKind, GradientStop, Material, NodeId, SceneGraph,
+    TextureRef, UvMode,
 };
 
 use crate::ast::{GradientDef, Node, Value};
+use crate::lower::shader::value_to_param;
 
 pub(super) fn collect_materials(ast: &[Node], graph: &mut SceneGraph) -> Result<()> {
     for n in ast {
@@ -131,18 +132,29 @@ fn register_material(node: &Node, graph: &mut SceneGraph) -> Result<()> {
         mat.uv_scale = pair;
     }
 
-    let shader_attr = node
-        .attr("shader")
-        .and_then(|v| match v {
-            Value::String(s) | Value::Ident(s) => Some(s.as_str()),
-            _ => None,
-        });
-    if let Some(kind) = shader_attr {
-        mat.shader = match kind {
-            "standard" | "pbr" => MaterialShader::Standard,
-            "water" => MaterialShader::Water,
-            other => bail!("unknown shader \"{other}\" — expected standard or water"),
+    // `shader="<name>"` names a preview shader (built-in `water` or a user
+    // `shader "<name>"` declaration). `standard`/`pbr` are the implicit PBR
+    // path — recorded as `None`. Unknown names are *not* rejected here; the
+    // validator resolves references against declared + built-in shaders and
+    // emits a spanned diagnostic (E0106) so the error points at the material.
+    if let Some(kind) = node.attr_string("shader") {
+        mat.shader_name = match kind {
+            "standard" | "pbr" => None,
+            other => Some(other.to_string()),
         };
+    }
+    // `shader_params (speed=3.5, tint=[…])` — a child node whose attributes feed
+    // the referenced shader's declared params. Values that can't populate a
+    // uniform are dropped here; the validator warns on unknown/mistyped params.
+    for c in &node.children {
+        if c.kind != "shader_params" {
+            continue;
+        }
+        for (k, v) in &c.attrs {
+            if let Some(pv) = value_to_param(v) {
+                mat.shader_params.insert(k.clone(), pv);
+            }
+        }
     }
 
     mat.origin = node.origin.clone();

--- a/crates/mogen-dsl/src/lower/shader.rs
+++ b/crates/mogen-dsl/src/lower/shader.rs
@@ -1,0 +1,119 @@
+//! Hoist `shader "<name>" { … }` declarations into the graph.
+//!
+//! Mirrors [`super::material`]: a recursive collector dedupes by `(name, origin)`
+//! and each declaration becomes a [`ShaderDecl`] on the graph. Materials refer to
+//! shaders by name via `shader="<name>"`; resolution happens later (export /
+//! Studio), so this pass only records declarations — it does not check that a
+//! referencing material exists.
+
+use anyhow::{anyhow, bail, Result};
+
+use mogen_core::{
+    shader, SceneGraph, ShaderDecl, ShaderParamDef, ShaderParamType, ShaderParamValue,
+};
+
+use crate::ast::{Node, Value};
+
+pub(super) fn collect_shaders(ast: &[Node], graph: &mut SceneGraph) -> Result<()> {
+    for n in ast {
+        collect_shaders_recursive(n, graph)?;
+    }
+    Ok(())
+}
+
+/// Walk the whole subtree so a `shader` declared inside a wrapping `group`
+/// (e.g. an inlined module body) is still discoverable. Dedupe by
+/// `(name, origin)` keeps repeated walks idempotent.
+fn collect_shaders_recursive(node: &Node, graph: &mut SceneGraph) -> Result<()> {
+    if node.kind == "shader" {
+        register_shader(node, graph)?;
+    }
+    for c in &node.children {
+        collect_shaders_recursive(c, graph)?;
+    }
+    Ok(())
+}
+
+fn register_shader(node: &Node, graph: &mut SceneGraph) -> Result<()> {
+    let name = node
+        .name
+        .clone()
+        .ok_or_else(|| anyhow!("shader requires a name, e.g. `shader \"ripple\" {{ … }}`"))?;
+    // Dedupe by `(name, origin)` on the same rules as materials: two decls of the
+    // same name in one file collapse to the first; same name across imported
+    // files stay distinct and are addressable via `find_shader_scoped`.
+    if graph
+        .shaders
+        .iter()
+        .any(|s| s.name == name && s.origin.as_deref() == node.origin.as_deref())
+    {
+        return Ok(());
+    }
+
+    let source = node.attr_string("source").ok_or_else(|| {
+        anyhow!("shader \"{name}\" requires a `source=` path, e.g. `source=\"shaders/ripple.glsl\"`")
+    })?;
+    let mut decl = ShaderDecl::new(&name, source);
+
+    for c in &node.children {
+        if c.kind != "param" {
+            continue;
+        }
+        let pname = c.name.clone().ok_or_else(|| {
+            anyhow!("param in shader \"{name}\" requires a name, e.g. `param \"speed\" (type=float)`")
+        })?;
+        let ty_str = c.attr_string("type").ok_or_else(|| {
+            anyhow!("param \"{pname}\" in shader \"{name}\" requires a `type=` (float, vec2, vec3, vec4, or color)")
+        })?;
+        let ty = ShaderParamType::parse(ty_str).ok_or_else(|| {
+            anyhow!("param \"{pname}\" in shader \"{name}\" has unknown type \"{ty_str}\" — expected float, vec2, vec3, vec4, or color")
+        })?;
+        let default = match c.attr("default") {
+            Some(v) => {
+                let pv = value_to_param(v).ok_or_else(|| {
+                    anyhow!("param \"{pname}\" default in shader \"{name}\" is not a valid value")
+                })?;
+                if !pv.matches(ty) {
+                    bail!("param \"{pname}\" default in shader \"{name}\" does not match its `type={ty_str}`");
+                }
+                Some(pv)
+            }
+            None => None,
+        };
+        decl.params.push(ShaderParamDef {
+            name: pname,
+            ty,
+            default,
+        });
+    }
+
+    decl.origin = node.origin.clone();
+    graph.add_shader(decl);
+    Ok(())
+}
+
+/// Seed the built-in shader presets (currently just `water`) unless the user
+/// declared their own shader of the same name, which shadows the built-in.
+/// Mirrors `material::ensure_named_defaults`: user decl wins.
+pub(super) fn ensure_builtin_shaders(graph: &mut SceneGraph) {
+    if !graph.shaders.iter().any(|s| s.name == shader::WATER) {
+        // The source is a `stdlib:`-keyed path resolved from bundled bytes by
+        // MoGen Studio; export ignores the source entirely.
+        graph.add_shader(ShaderDecl::new(shader::WATER, "stdlib:shaders/water.glsl"));
+    }
+}
+
+/// Convert a DSL attribute value into a shader parameter value. Used for both
+/// `param` defaults and material `shader_params (…)` overrides. Returns `None`
+/// for shapes that can't populate a GLSL uniform.
+pub(super) fn value_to_param(v: &Value) -> Option<ShaderParamValue> {
+    match v {
+        Value::Number(n) => Some(ShaderParamValue::Float(*n)),
+        Value::Vec3(a) => Some(ShaderParamValue::Vec3(*a)),
+        Value::List(xs) if xs.len() == 2 => Some(ShaderParamValue::Vec2([xs[0], xs[1]])),
+        Value::List(xs) if xs.len() == 4 => {
+            Some(ShaderParamValue::Vec4([xs[0], xs[1], xs[2], xs[3]]))
+        }
+        _ => None,
+    }
+}

--- a/crates/mogen-dsl/src/lower/terrain/materials.rs
+++ b/crates/mogen-dsl/src/lower/terrain/materials.rs
@@ -8,7 +8,7 @@
 
 use std::path::Path;
 
-use mogen_core::{AlphaMode, Material, MaterialShader, SceneGraph};
+use mogen_core::{AlphaMode, Material, SceneGraph};
 
 use crate::lower::material::ensure_named_defaults;
 
@@ -53,7 +53,7 @@ pub(super) fn ensure_defaults(graph: &mut SceneGraph, origin: Option<&Path>) {
             m.alpha_mode = AlphaMode::Blend;
             m.transmission = 0.9;
             m.double_sided = true;
-            m.shader = MaterialShader::Water;
+            m.shader_name = Some(mogen_core::shader::WATER.to_string());
             m
         }),
     ];

--- a/crates/mogen-dsl/src/lower/tests/mod.rs
+++ b/crates/mogen-dsl/src/lower/tests/mod.rs
@@ -15,6 +15,7 @@ mod parametric_surfaces;
 mod physics;
 mod poly;
 mod primitives;
+mod shader;
 
 pub(super) fn lower_src(src: &str) -> SceneGraph {
     let ast = crate::parser::parse(src).expect("parse");

--- a/crates/mogen-dsl/src/lower/tests/shader.rs
+++ b/crates/mogen-dsl/src/lower/tests/shader.rs
@@ -1,0 +1,111 @@
+use super::*;
+use crate::lower::*;
+use crate::parser::parse;
+
+#[test]
+fn shader_declaration_and_material_reference_lower_cleanly() {
+    let g = lower_src(
+        r#"
+        shader "ripple" (source="shaders/ripple.glsl") {
+          param "speed" (type=float, default=2.0)
+          param "tint" (type=color, default=[0.0, 0.3, 0.5])
+        }
+        material "pond" (color=[0.1, 0.2, 0.3], shader="ripple") {
+          shader_params (speed=3.5, tint=[0.0, 0.4, 0.6])
+        }
+        scene { box "b" (size=[1,1,1], mat="pond") }
+        "#,
+    );
+    let decl = g.find_shader_scoped("ripple", None).expect("ripple shader declared");
+    assert_eq!(decl.params.len(), 2);
+
+    let mid = g.find_material("pond").expect("pond material");
+    let mat = &g.materials[mid.0 as usize];
+    assert_eq!(mat.shader_name.as_deref(), Some("ripple"));
+    assert_eq!(
+        mat.shader_params.get("speed"),
+        Some(&mogen_core::ShaderParamValue::Float(3.5))
+    );
+    assert_eq!(
+        mat.shader_params.get("tint"),
+        Some(&mogen_core::ShaderParamValue::Vec3([0.0, 0.4, 0.6]))
+    );
+}
+
+#[test]
+fn standard_and_pbr_shader_values_clear_shader_name() {
+    let g = lower_src(
+        r#"
+        material "a" (color=[0.1, 0.2, 0.3], shader="standard")
+        scene { box "b" (size=[1,1,1], mat="a") }
+        "#,
+    );
+    let mid = g.find_material("a").expect("material a");
+    assert_eq!(g.materials[mid.0 as usize].shader_name, None);
+}
+
+#[test]
+fn builtin_water_shader_is_seeded_without_declaration() {
+    let g = lower_src(r#"scene { box "b" (size=[1,1,1]) }"#);
+    assert!(g.has_shader(mogen_core::shader::WATER));
+    assert!(g.find_shader_scoped(mogen_core::shader::WATER, None).is_some());
+}
+
+#[test]
+fn user_declared_water_shader_shadows_the_builtin() {
+    let g = lower_src(
+        r#"
+        shader "water" (source="my_water.glsl")
+        scene { box "b" (size=[1,1,1]) }
+        "#,
+    );
+    let decl = g
+        .find_shader_scoped(mogen_core::shader::WATER, None)
+        .expect("water shader");
+    assert_eq!(decl.source, std::path::PathBuf::from("my_water.glsl"));
+}
+
+#[test]
+fn duplicate_shader_declaration_in_same_file_dedupes_to_first() {
+    let g = lower_src(
+        r#"
+        shader "ripple" (source="first.glsl") { param "speed" (type=float, default=1.0) }
+        shader "ripple" (source="second.glsl")
+        scene { box "b" (size=[1,1,1]) }
+        "#,
+    );
+    let matches: Vec<_> = g.shaders.iter().filter(|s| s.name == "ripple").collect();
+    assert_eq!(matches.len(), 1, "second declaration of the same name should be dropped");
+    assert_eq!(matches[0].source, std::path::PathBuf::from("first.glsl"));
+}
+
+#[test]
+fn shader_without_source_errors() {
+    let ast = parse(r#"shader "ripple" { param "speed" (type=float) }"#).unwrap();
+    assert!(lower(&ast).is_err(), "shader declaration requires a `source=`");
+}
+
+#[test]
+fn shader_param_without_type_errors() {
+    let ast = parse(r#"shader "ripple" (source="x.glsl") { param "speed" }"#).unwrap();
+    assert!(lower(&ast).is_err(), "shader param requires a `type=`");
+}
+
+#[test]
+fn shader_param_unknown_type_errors() {
+    let ast =
+        parse(r#"shader "ripple" (source="x.glsl") { param "speed" (type=matrix4) }"#).unwrap();
+    assert!(lower(&ast).is_err(), "unknown param type must error");
+}
+
+#[test]
+fn shader_param_default_type_mismatch_errors() {
+    let ast = parse(
+        r#"shader "ripple" (source="x.glsl") { param "speed" (type=float, default=[1,2,3]) }"#,
+    )
+    .unwrap();
+    assert!(
+        lower(&ast).is_err(),
+        "a vec3 default on a float param must error"
+    );
+}

--- a/crates/mogen-export/src/merge.rs
+++ b/crates/mogen-export/src/merge.rs
@@ -78,6 +78,7 @@ where
         roots: Vec::new(),
         materials: scene.materials.clone(),
         physics: scene.physics.clone(),
+        shaders: scene.shaders.clone(),
         joints: scene.joints.clone(),
         clips: scene.clips.clone(),
         skins: scene.skins.clone(),

--- a/crates/mogen-export/src/writer.rs
+++ b/crates/mogen-export/src/writer.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use anyhow::Result;
 use serde_json::{json, Value};
 
-use mogen_core::{ColliderShape, MaterialId, Mesh, NodeId, SceneGraph, SceneNode};
+use mogen_core::{ColliderShape, MaterialId, Mesh, NodeId, SceneGraph, SceneNode, ShaderParamValue};
 
 use crate::accessor::{
     push_colors, push_indices, push_joints, push_normals, push_positions, push_uvs, push_weights,
@@ -351,7 +351,12 @@ fn build_glb_with_options_and_source_inner<F: Fn(&str)>(
     let light_table = collect_lights(scene);
 
     for (i, n) in scene.nodes.iter().enumerate() {
-        nodes.push(emit_node(n, mesh_index_for_node[i], light_table.node_to_index[i]));
+        nodes.push(emit_node(
+            n,
+            mesh_index_for_node[i],
+            light_table.node_to_index[i],
+            shader_extras(scene, n.material),
+        ));
     }
 
     let mut materials: Vec<Value> = scene
@@ -531,7 +536,55 @@ fn build_glb_with_options_and_source_inner<F: Fn(&str)>(
     Ok(out)
 }
 
-fn emit_node(n: &SceneNode, mesh: Option<usize>, light: Option<usize>) -> Value {
+/// Project a material's preview shader (name + resolved params) into a JSON
+/// value for the referencing node's `extras.shader`. glTF has no place for
+/// shader code or a per-material `extras`, so the metadata rides on every node
+/// that binds the material. Params merge the shader's declared defaults with
+/// the material's overrides; keys are emitted in deterministic (sorted) order.
+/// Returns `None` for the standard-PBR common case.
+fn shader_extras(scene: &SceneGraph, mat: Option<MaterialId>) -> Option<Value> {
+    let m = mat.and_then(|id| scene.materials.get(id.0 as usize))?;
+    let name = m.shader_name.as_ref()?;
+
+    let mut params: std::collections::BTreeMap<String, Value> = std::collections::BTreeMap::new();
+    if let Some(decl) = scene.find_shader_scoped(name, m.origin.as_deref()) {
+        for p in &decl.params {
+            if let Some(v) = decl.resolve_param(&p.name, &m.shader_params) {
+                params.insert(p.name.clone(), param_to_json(&v));
+            }
+        }
+    }
+    // Overrides for params the referenced shader doesn't declare (or when the
+    // shader isn't in the graph) still ride along so nothing is silently lost.
+    for (k, v) in &m.shader_params {
+        params
+            .entry(k.clone())
+            .or_insert_with(|| param_to_json(v));
+    }
+
+    let mut obj = serde_json::Map::new();
+    obj.insert("name".into(), Value::String(name.clone()));
+    if !params.is_empty() {
+        obj.insert("params".into(), Value::Object(params.into_iter().collect()));
+    }
+    Some(Value::Object(obj))
+}
+
+fn param_to_json(v: &ShaderParamValue) -> Value {
+    match v {
+        ShaderParamValue::Float(f) => json!(f),
+        ShaderParamValue::Vec2(a) => json!(a),
+        ShaderParamValue::Vec3(a) => json!(a),
+        ShaderParamValue::Vec4(a) => json!(a),
+    }
+}
+
+fn emit_node(
+    n: &SceneNode,
+    mesh: Option<usize>,
+    light: Option<usize>,
+    shader: Option<Value>,
+) -> Value {
     let mut obj = serde_json::Map::new();
     obj.insert("name".into(), Value::String(n.name.clone()));
 
@@ -634,6 +687,12 @@ fn emit_node(n: &SceneNode, mesh: Option<usize>, light: Option<usize>) -> Value 
             phys.insert("center_of_gravity".into(), json!([c[0], c[1], c[2]]));
         }
         extras.insert("physics".into(), Value::Object(phys));
+    }
+    // Preview shader metadata projected from the node's material. mogen can't
+    // embed GLSL in glTF, so a downstream consumer (or MoGen Studio) reads this
+    // name + params and binds the real shader. See `shader_extras`.
+    if let Some(sh) = shader {
+        extras.insert("shader".into(), sh);
     }
     if !extras.is_empty() {
         obj.insert("extras".into(), Value::Object(extras));

--- a/crates/mogen-export/tests/shader.rs
+++ b/crates/mogen-export/tests/shader.rs
@@ -1,0 +1,72 @@
+//! A material's preview shader must ride to glTF `node.extras.shader` as
+//! `{name, params}` metadata — mogen never compiles GLSL, but a downstream
+//! consumer (or MoGen Studio) needs the name + resolved params to bind the
+//! real shader. Compiles a small `.mog` through the full pipeline and
+//! inspects the JSON chunk.
+
+use serde_json::Value;
+
+fn parse_glb_json(bytes: &[u8]) -> Value {
+    let json_len = u32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]) as usize;
+    let json_bytes = &bytes[20..20 + json_len];
+    serde_json::from_slice(json_bytes).expect("valid JSON chunk")
+}
+
+fn compile(src: &str) -> Vec<u8> {
+    let ast = mogen_dsl::parse(src).expect("parse");
+    let scene = mogen_dsl::lower(&ast).expect("lower");
+    mogen_export::build_glb_with_options(&scene, &mogen_export::ExportOptions::default(), |_| {})
+        .expect("export")
+}
+
+fn find_node<'a>(json: &'a Value, name: &str) -> &'a Value {
+    json["nodes"]
+        .as_array()
+        .expect("nodes")
+        .iter()
+        .find(|n| n["name"] == name)
+        .unwrap_or_else(|| panic!("no node {name}"))
+}
+
+#[test]
+fn declared_shader_params_merge_defaults_with_overrides() {
+    let src = r#"
+        shader "ripple" (source="shaders/ripple.glsl") {
+          param "speed" (type=float, default=2.0)
+          param "tint" (type=color, default=[0.0, 0.3, 0.5])
+        }
+        material "pond" (color=[0.1, 0.2, 0.3], shader="ripple") {
+          shader_params (speed=3.5)
+        }
+        scene { box "b" (size=[1,1,1], mat="pond") }
+    "#;
+    let json = parse_glb_json(&compile(src));
+    let sh = &find_node(&json, "b")["extras"]["shader"];
+
+    assert_eq!(sh["name"], "ripple");
+    // Override wins for speed; tint falls back to the declared default.
+    assert!((sh["params"]["speed"].as_f64().unwrap() - 3.5).abs() < 1e-6);
+    let tint = sh["params"]["tint"].as_array().expect("tint array");
+    assert!((tint[2].as_f64().unwrap() - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn builtin_water_shader_projects_name_with_no_declaration() {
+    let src = r#"
+        material "sea" (color=[0.0, 0.3, 0.5], shader="water")
+        scene { box "b" (size=[1,1,1], mat="sea") }
+    "#;
+    let json = parse_glb_json(&compile(src));
+    let sh = &find_node(&json, "b")["extras"]["shader"];
+    assert_eq!(sh["name"], "water");
+}
+
+#[test]
+fn standard_material_has_no_shader_extras() {
+    let src = r#"scene { box "plain" (size=[1,1,1]) }"#;
+    let json = parse_glb_json(&compile(src));
+    let node = find_node(&json, "plain");
+    if let Some(extras) = node.get("extras") {
+        assert!(extras.get("shader").is_none(), "unexpected shader extras: {extras:?}");
+    }
+}

--- a/crates/mogen-studio/src/app/ui_panels/materials/pbr.rs
+++ b/crates/mogen-studio/src/app/ui_panels/materials/pbr.rs
@@ -13,7 +13,7 @@ pub(super) fn render(
     mat: &mogen_core::Material,
     pending: &mut Vec<(String, &'static str, String)>,
 ) {
-    use mogen_core::{AlphaMode, MaterialShader, UvMode};
+    use mogen_core::{AlphaMode, UvMode};
 
     // Colour + alpha
     ui.horizontal(|ui| {
@@ -325,31 +325,27 @@ pub(super) fn render(
     // join this dropdown when added.
     ui.horizontal(|ui| {
         ui.label("Shader");
-        let mut shader = mat.shader;
+        // Studio-only preview shader. `None`/`standard` = the regular PBR path;
+        // `water` is the built-in preset. User `shader "…"` declarations are
+        // authored in source — this dropdown exposes the built-in options.
+        let current = mat.shader_name.as_deref().unwrap_or("standard");
+        let mut choice = current.to_string();
         let shader_id = egui::Id::new(("shader", idx, mat.name.as_str()));
         egui::ComboBox::from_id_salt(shader_id)
-            .selected_text(match shader {
-                MaterialShader::Standard => "standard (PBR)",
-                MaterialShader::Water => "water",
+            .selected_text(match current {
+                "standard" => "standard (PBR)",
+                other => other,
             })
             .show_ui(ui, |ui| {
                 let mut changed = false;
                 changed |= ui
-                    .selectable_value(
-                        &mut shader,
-                        MaterialShader::Standard,
-                        "standard (PBR)",
-                    )
+                    .selectable_value(&mut choice, "standard".to_string(), "standard (PBR)")
                     .changed();
                 changed |= ui
-                    .selectable_value(&mut shader, MaterialShader::Water, "water")
+                    .selectable_value(&mut choice, "water".to_string(), "water")
                     .changed();
                 if changed {
-                    let v = match shader {
-                        MaterialShader::Standard => "\"standard\"",
-                        MaterialShader::Water => "\"water\"",
-                    };
-                    pending.push((mat.name.clone(), "shader", v.to_string()));
+                    pending.push((mat.name.clone(), "shader", format!("\"{choice}\"")));
                 }
             });
     });

--- a/crates/mogen-studio/src/viewer/flatten.rs
+++ b/crates/mogen-studio/src/viewer/flatten.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use glam::{Mat4, Vec3};
-use mogen_core::{AlphaMode, MaterialShader, NodeId, SceneGraph, Transform};
+use mogen_core::{AlphaMode, NodeId, SceneGraph, Transform};
 
 use super::anim::world_transforms_from_locals;
 
@@ -95,11 +95,10 @@ pub struct DrawBatch {
     /// member shares this flag — `flatten_with_worlds` keys grouping by it so
     /// a single batch is always all-cast or all-skip.
     pub cast_shadow: bool,
-    /// Per-material shader override copied off the source [`Material`].
-    /// `Standard` (default) routes through the regular PBR path; non-default
-    /// shaders (e.g. `Water`) take a dedicated branch in the FS keyed by
-    /// `MaterialShader::shader_id`.
-    pub shader: MaterialShader,
+    /// Name of the per-material preview shader copied off the source
+    /// [`Material`]. `None` routes through the regular PBR path; `Some("water")`
+    /// (or a user shader name) selects a dedicated program in the renderer.
+    pub shader_name: Option<String>,
     /// Baked render-LOD band `(min_distance, max_distance)` copied off the
     /// node's [`mogen_core::Lod`]. When `Some`, the renderer draws this batch
     /// only while the camera distance to `centroid` falls within the band, so a
@@ -221,7 +220,9 @@ impl FlatMesh {
     /// (currently just water). The viewport uses this to keep requesting
     /// repaints when the scene is otherwise static so the waves keep moving.
     pub fn has_animated_shader(&self) -> bool {
-        self.batches.iter().any(|b| b.shader.animates())
+        self.batches
+            .iter()
+            .any(|b| b.shader_name.as_deref() == Some(mogen_core::shader::WATER))
     }
 
     /// The pick BVH for this mesh, built on first use. Rest-pose world-baked
@@ -497,7 +498,7 @@ pub fn flatten_with_worlds(
                 alpha_mode,
                 alpha_cutoff,
                 double_sided,
-                shader,
+                shader_name,
             ) = match material {
                 Some(m) => (
                     m.base_color_texture.as_ref().map(resolve),
@@ -516,7 +517,7 @@ pub fn flatten_with_worlds(
                     m.alpha_mode,
                     m.alpha_cutoff,
                     m.double_sided,
-                    m.shader,
+                    m.shader_name.clone(),
                 ),
                 None => (
                     None,
@@ -535,7 +536,7 @@ pub fn flatten_with_worlds(
                     AlphaMode::Opaque,
                     0.5,
                     false,
-                    MaterialShader::Standard,
+                    None,
                 ),
             };
             let (centroid, radius) = if bmin.is_finite() && bmax.is_finite() {
@@ -575,7 +576,7 @@ pub fn flatten_with_worlds(
                 palette_id,
                 material_id: mat_id,
                 cast_shadow,
-                shader,
+                shader_name,
                 lod,
             });
         }

--- a/crates/mogen-studio/src/viewer/renderer/draw.rs
+++ b/crates/mogen-studio/src/viewer/renderer/draw.rs
@@ -311,7 +311,14 @@ impl Renderer {
             let uv_scale = b.uv_scale;
             let emissive = b.emissive;
             let emissive_strength = b.emissive_strength;
-            let shader_id = b.shader.shader_id();
+            // Preview shader selector for the monolithic program's branch.
+            // Phase 3 replaces this with a per-material program cache; for now
+            // only the built-in water shader has a dedicated branch.
+            let shader_id = if b.shader_name.as_deref() == Some(mogen_core::shader::WATER) {
+                1
+            } else {
+                0
+            };
             let index_start = b.index_start;
             let index_count = b.index_count;
             let textures = self.draw_textures[idx];

--- a/crates/mogen-studio/src/viewer/renderer/mod.rs
+++ b/crates/mogen-studio/src/viewer/renderer/mod.rs
@@ -25,7 +25,8 @@ use super::gl_util::{bytes_of_f32, bytes_of_u32, compile_program};
 use super::grid_gl::GridGl;
 use super::lights::{ResolvedLight, MAX_LIGHTS};
 use super::lights_gl::LightsGl;
-use super::shaders::{FS_SRC, VS_SRC};
+use super::shaders::user_shader;
+use super::shaders::VS_SRC;
 use super::shadows::{ShadowFrame, ShadowQuality, ShadowSystem};
 
 use textures::TextureCache;
@@ -232,7 +233,12 @@ fn light_eq(a: &ResolvedLight, b: &ResolvedLight) -> bool {
 impl Renderer {
     pub fn new(gl: &glow::Context) -> anyhow::Result<Self> {
         unsafe {
-            let program = compile_program(gl, VS_SRC, FS_SRC)?;
+            // Compile the standard fragment program via the user-shader
+            // assembler with no injections: this fills the injection marker with
+            // the dispatch stub. Behaviour is identical to the pre-feature
+            // shader — ids 0/1 never enter the (inert) dispatch branch.
+            let standard_fs = user_shader::assemble_fs(&[]);
+            let program = compile_program(gl, VS_SRC, &standard_fs)?;
 
             let vao = gl
                 .create_vertex_array()

--- a/crates/mogen-studio/src/viewer/shaders.rs
+++ b/crates/mogen-studio/src/viewer/shaders.rs
@@ -9,6 +9,7 @@ mod grid;
 mod imposter;
 mod mesh;
 mod shadow;
+pub(super) mod user_shader;
 
 pub(super) use gizmo::{GIZMO_FS, GIZMO_VS};
 pub(super) use grid::{GRID_FS, GRID_VS};

--- a/crates/mogen-studio/src/viewer/shaders/mesh.rs
+++ b/crates/mogen-studio/src/viewer/shaders/mesh.rs
@@ -441,7 +441,25 @@ void brdf_direct(vec3 N, vec3 V, vec3 L, vec3 albedo, float metallic, float roug
     spec_out = spec * NdL;
 }
 
+// User-shader injection point. `user_shader::assemble_fs` replaces this marker
+// with either a `mogen_user_dispatch` stub (the standard program) or the
+// injected `fragment_N()` functions + dispatch (when the scene declares
+// shaders). Keep this text byte-for-byte in sync with `user_shader::PLACEHOLDER`.
+//@MOGEN_USER_SHADER_DISPATCH@
+
 void main() {
+    // Per-material preview shaders with id >= 2 are user/injected GLSL: run the
+    // dispatch and take its RGBA as the final colour (the "replace" contract).
+    // id 0 (standard PBR) and id 1 (built-in water) fall through to the paths
+    // below; this branch is inert in the standard program (dispatch is a stub).
+    if (u_material_shader >= 2) {
+        vec4 uc = mogen_user_dispatch(u_material_shader);
+        if (u_alpha_mode == 1 && uc.a < u_alpha_cutoff) {
+            discard;
+        }
+        frag = uc;
+        return;
+    }
     vec2 uv = v_uv;
     // Gather material samples. Per-vertex COLOR_0 multiplies the base colour
     // per the glTF spec (white default when the mesh has no colour channel),

--- a/crates/mogen-studio/src/viewer/shaders/user_shader.rs
+++ b/crates/mogen-studio/src/viewer/shaders/user_shader.rs
@@ -1,0 +1,195 @@
+//! Assembly of the mesh fragment program from user-authored GLSL snippets.
+//!
+//! The viewport runs a single fragment program. To preview user shaders without
+//! rewriting the per-material uniform/draw path, we keep that one program and
+//! *inject* each user shader as its own `fragment_N()` function, wired up by a
+//! generated `mogen_user_dispatch(int id)`. The base program in
+//! [`super::mesh`] carries a text marker ([`PLACEHOLDER`]) just before `main`;
+//! [`assemble_fs`] swaps it for either a no-op stub (standard program) or the
+//! injected functions.
+//!
+//! ## The fragment ABI
+//!
+//! A user `.glsl` snippet is a *body*, not a whole program. It runs against the
+//! prelude the base shader already defines — the varyings (`v_world_pos`,
+//! `v_normal`, `v_uv`, `v_color`), the material/frame uniforms (`u_time`,
+//! `u_camera_pos`, `u_base_color`, `u_roughness`, …), and the helper functions
+//! (`sample_sky`, `fresnel`, the water turbulence, …). It must define
+//! `vec4 fragment()` returning the final RGBA ("replace" contract — the shader
+//! does its own lighting; standard PBR is bypassed).
+//!
+//! Each shader's declared `param`s become uniforms, namespaced per shader id so
+//! two shaders can both declare a `speed` without colliding, and `#define`d back
+//! to their bare names inside the snippet so the author just writes `speed`.
+
+use mogen_core::ShaderParamType;
+
+/// Marker in the base fragment source that [`assemble_fs`] replaces. Must match
+/// the literal line in [`super::mesh`]'s `FS_SRC` exactly.
+pub const PLACEHOLDER: &str = "//@MOGEN_USER_SHADER_DISPATCH@";
+
+/// The first material-shader id handed to injected user shaders. `0` is standard
+/// PBR and `1` is the built-in water branch (still hard-coded in `main` for
+/// now), so user shaders start at `2`. Consumed by the flatten→renderer
+/// integration that assigns ids to the scene's declared shaders.
+// TODO(shader-preview): wired once flatten bakes the used-shader list.
+#[allow(dead_code)]
+pub const FIRST_USER_SHADER_ID: i32 = 2;
+
+/// One shader to inject into the fragment program.
+#[derive(Debug, Clone)]
+pub struct InjectedShader {
+    /// Material-shader id this snippet answers to (matches `u_material_shader`).
+    /// Must be `>= FIRST_USER_SHADER_ID`.
+    pub id: i32,
+    /// The user GLSL snippet — defines `vec4 fragment()`.
+    pub source: String,
+    /// Declared parameters, surfaced as namespaced uniforms.
+    pub params: Vec<ParamDecl>,
+}
+
+/// A single declared parameter (name + GLSL type). Mirrors the relevant fields
+/// of [`mogen_core::ShaderParamDef`] without pulling defaults into the renderer.
+#[derive(Debug, Clone)]
+pub struct ParamDecl {
+    pub name: String,
+    pub ty: ShaderParamType,
+}
+
+/// The GLSL uniform name a shader parameter compiles to. Namespaced by shader id
+/// so distinct shaders never collide at file scope. The draw path uploads each
+/// material's resolved value to this uniform.
+pub fn param_uniform_name(id: i32, param: &str) -> String {
+    format!("u_sh{id}_{param}")
+}
+
+/// Build the complete fragment shader source. `shaders` empty yields the
+/// standard program (marker → dispatch stub), byte-identical in behaviour to
+/// the pre-feature shader. Otherwise the marker becomes the injected
+/// `fragment_N()` functions plus the dispatch that `main` calls for ids >= 2.
+pub fn assemble_fs(shaders: &[InjectedShader]) -> String {
+    let block = if shaders.is_empty() {
+        // Stub: keeps `main`'s `mogen_user_dispatch` call well-defined when the
+        // scene declares no shaders. Never reached (main only calls it for
+        // id >= 2, which can't occur without an injected shader).
+        "vec4 mogen_user_dispatch(int id) { return vec4(0.0); }\n".to_string()
+    } else {
+        let mut s = String::new();
+        for sh in shaders {
+            s.push_str(&format!("// ---- injected shader id {} ----\n", sh.id));
+            // Namespaced param uniforms, then `#define`s so the snippet can use
+            // the bare param name.
+            for p in &sh.params {
+                s.push_str(&format!(
+                    "uniform {} {};\n",
+                    p.ty.glsl_type(),
+                    param_uniform_name(sh.id, &p.name)
+                ));
+            }
+            for p in &sh.params {
+                s.push_str(&format!(
+                    "#define {} {}\n",
+                    p.name,
+                    param_uniform_name(sh.id, &p.name)
+                ));
+            }
+            // Rename the snippet's `fragment` entrypoint to a unique symbol via
+            // the preprocessor (whole-token match — leaves other identifiers
+            // untouched), so multiple snippets coexist.
+            s.push_str(&format!("#define fragment fragment_{}\n", sh.id));
+            s.push_str(&sh.source);
+            s.push_str("\n#undef fragment\n");
+            for p in &sh.params {
+                s.push_str(&format!("#undef {}\n", p.name));
+            }
+        }
+        s.push_str("vec4 mogen_user_dispatch(int id) {\n");
+        for sh in shaders {
+            s.push_str(&format!(
+                "    if (id == {}) return fragment_{}();\n",
+                sh.id, sh.id
+            ));
+        }
+        s.push_str("    return vec4(0.0);\n}\n");
+        s
+    };
+
+    debug_assert!(
+        super::FS_SRC.contains(PLACEHOLDER),
+        "base fragment source is missing the user-shader placeholder"
+    );
+    super::FS_SRC.replace(PLACEHOLDER, &block)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn placeholder_present_in_base_source() {
+        assert!(
+            super::super::FS_SRC.contains(PLACEHOLDER),
+            "mesh FS_SRC must carry the injection marker"
+        );
+        // `main` must call the dispatch so injected shaders are reachable.
+        assert!(super::super::FS_SRC.contains("mogen_user_dispatch(u_material_shader)"));
+    }
+
+    #[test]
+    fn standard_program_defines_stub_and_no_user_functions() {
+        let fs = assemble_fs(&[]);
+        assert!(!fs.contains(PLACEHOLDER), "marker must be replaced");
+        assert!(fs.contains("vec4 mogen_user_dispatch(int id) { return vec4(0.0); }"));
+        // No injected entrypoints or dispatch branches in the standard program.
+        assert!(!fs.contains("#define fragment fragment_"));
+        assert!(!fs.contains("return fragment_"));
+        // The standard main body is preserved.
+        assert!(fs.contains("void main()"));
+        assert!(fs.contains("out vec4 frag;"));
+    }
+
+    #[test]
+    fn injected_shader_wires_dispatch_params_and_entrypoint() {
+        let shaders = vec![InjectedShader {
+            id: 2,
+            source: "vec4 fragment() { return vec4(tint * speed, 1.0); }".to_string(),
+            params: vec![
+                ParamDecl { name: "speed".into(), ty: ShaderParamType::Float },
+                ParamDecl { name: "tint".into(), ty: ShaderParamType::Color },
+            ],
+        }];
+        let fs = assemble_fs(&shaders);
+        // Namespaced uniforms with correct GLSL types (color -> vec3).
+        assert!(fs.contains("uniform float u_sh2_speed;"));
+        assert!(fs.contains("uniform vec3 u_sh2_tint;"));
+        // Bare-name defines so the snippet compiles unchanged.
+        assert!(fs.contains("#define speed u_sh2_speed"));
+        assert!(fs.contains("#define tint u_sh2_tint"));
+        // Entrypoint rename + dispatch wiring.
+        assert!(fs.contains("#define fragment fragment_2"));
+        assert!(fs.contains("if (id == 2) return fragment_2();"));
+        assert!(fs.contains("#undef fragment"));
+        assert!(!fs.contains(PLACEHOLDER));
+    }
+
+    #[test]
+    fn multiple_shaders_get_distinct_namespaces() {
+        let shaders = vec![
+            InjectedShader {
+                id: 2,
+                source: "vec4 fragment() { return vec4(speed); }".into(),
+                params: vec![ParamDecl { name: "speed".into(), ty: ShaderParamType::Float }],
+            },
+            InjectedShader {
+                id: 3,
+                source: "vec4 fragment() { return vec4(speed); }".into(),
+                params: vec![ParamDecl { name: "speed".into(), ty: ShaderParamType::Float }],
+            },
+        ];
+        let fs = assemble_fs(&shaders);
+        assert!(fs.contains("uniform float u_sh2_speed;"));
+        assert!(fs.contains("uniform float u_sh3_speed;"));
+        assert!(fs.contains("if (id == 2) return fragment_2();"));
+        assert!(fs.contains("if (id == 3) return fragment_3();"));
+    }
+}

--- a/crates/mogen-validate/src/ast_checks/mod.rs
+++ b/crates/mogen-validate/src/ast_checks/mod.rs
@@ -73,9 +73,16 @@ pub fn validate_ast_with_source(ast: &[Node], base_dir: Option<&Path>) -> Vec<Di
     check_meta_blocks(ast, &mut diags);
     // Shaders aren't merged across imports, so a material referencing a shader
     // declared in an imported file can't be resolved here — suppress the
-    // unknown-shader error whenever the file has imports, mirroring how the
-    // unknown-module check backs off. Local param-name warnings still fire.
-    check_shader_refs(ast, has_imports, &mut diags);
+    // unknown-shader error the same way the unknown-module check does: only
+    // when imports are actually present but couldn't be resolved (no
+    // `base_dir`, or resolution failed). Once imports resolve, a reference to
+    // a genuinely undeclared shader is a real error — including references to
+    // a shader that only exists nested inside an imported file's `scene`
+    // block, which today's importer doesn't hoist to top level either way.
+    // Using `has_imports` here instead of `suppress_unknown_module` would
+    // silently swallow every local shader-name typo in any file that happens
+    // to import something unrelated.
+    check_shader_refs(ast, suppress_unknown_module, &mut diags);
     for n in ast {
         walk(n, &materials, &physics, &modules, suppress_unknown_module, false, false, &mut diags);
     }

--- a/crates/mogen-validate/src/ast_checks/mod.rs
+++ b/crates/mogen-validate/src/ast_checks/mod.rs
@@ -16,7 +16,7 @@ mod terrain_rules;
 #[cfg(test)]
 mod tests;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use mogen_core::Diagnostic;
@@ -71,10 +71,89 @@ pub fn validate_ast_with_source(ast: &[Node], base_dir: Option<&Path>) -> Vec<Di
         ImportResolution::Skipped => has_imports,
     };
     check_meta_blocks(ast, &mut diags);
+    // Shaders aren't merged across imports, so a material referencing a shader
+    // declared in an imported file can't be resolved here — suppress the
+    // unknown-shader error whenever the file has imports, mirroring how the
+    // unknown-module check backs off. Local param-name warnings still fire.
+    check_shader_refs(ast, has_imports, &mut diags);
     for n in ast {
         walk(n, &materials, &physics, &modules, suppress_unknown_module, false, false, &mut diags);
     }
     diags
+}
+
+/// Validate `shader="<name>"` references on materials against declared +
+/// built-in shaders, and check `shader_params` override names against the
+/// referenced shader's declared params. A dedicated pass so the main `walk`
+/// signature stays unchanged.
+fn check_shader_refs(ast: &[Node], suppress_unknown: bool, diags: &mut Vec<Diagnostic>) {
+    let mut decls: HashMap<String, HashSet<String>> = HashMap::new();
+    collect_shader_param_names(ast, &mut decls);
+    walk_shader_refs(ast, &decls, suppress_unknown, diags);
+}
+
+/// Map each declared shader name to the set of its declared `param` names.
+/// First declaration of a name wins (matches lowering's dedupe).
+fn collect_shader_param_names(ast: &[Node], out: &mut HashMap<String, HashSet<String>>) {
+    for n in ast {
+        if n.kind == "shader" {
+            if let Some(name) = &n.name {
+                let params: HashSet<String> = n
+                    .children
+                    .iter()
+                    .filter(|c| c.kind == "param")
+                    .filter_map(|c| c.name.clone())
+                    .collect();
+                out.entry(name.clone()).or_insert(params);
+            }
+        }
+        collect_shader_param_names(&n.children, out);
+    }
+}
+
+fn walk_shader_refs(
+    ast: &[Node],
+    decls: &HashMap<String, HashSet<String>>,
+    suppress_unknown: bool,
+    diags: &mut Vec<Diagnostic>,
+) {
+    for n in ast {
+        if n.kind == "material" {
+            if let Some(name) = n.attr("shader").and_then(as_string_or_ident) {
+                // `standard`/`pbr` are the implicit PBR path, not a reference.
+                let is_pbr = matches!(name, "standard" | "pbr");
+                let is_builtin = mogen_core::shader::builtin_names().contains(&name);
+                let declared = decls.contains_key(name);
+                if !is_pbr && !is_builtin && !declared && !suppress_unknown {
+                    diags.push(
+                        Diagnostic::error("E0106", format!("unknown shader \"{name}\""))
+                            .with_span(n.span),
+                    );
+                }
+                // Check override names only when we know the shader's params
+                // (i.e. it's declared locally — built-ins expose none here).
+                if let Some(params) = decls.get(name) {
+                    for c in &n.children {
+                        if c.kind != "shader_params" {
+                            continue;
+                        }
+                        for (k, _v) in &c.attrs {
+                            if !params.contains(k) {
+                                diags.push(
+                                    Diagnostic::warning(
+                                        "W0108",
+                                        format!("shader \"{name}\" has no parameter \"{k}\""),
+                                    )
+                                    .with_span(c.span),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        walk_shader_refs(&n.children, decls, suppress_unknown, diags);
+    }
 }
 
 /// Walk the AST recursively for `use` nodes whose name parses as a
@@ -311,6 +390,11 @@ fn walk(
                 );
             }
         }
+        // A material-side `shader_params (…)` override block carries arbitrary
+        // param-name attributes; the closed attr-vocabulary check doesn't
+        // apply. Names + types are validated against the referenced shader's
+        // declared params by `check_shader_refs`.
+        "shader_params" => {}
         _ if KNOWN_KINDS.contains(&n.kind.as_str()) => {
             check_attrs(n, materials, physics, inherited_skin, inherited_phys, diags);
             check_anim_required(n, diags);

--- a/crates/mogen-validate/src/ast_checks/schema.rs
+++ b/crates/mogen-validate/src/ast_checks/schema.rs
@@ -6,7 +6,7 @@
 use mogen_dsl::ast::Value;
 
 pub const KNOWN_KINDS: &[&str] = &[
-    "scene", "group", "solid", "material", "physics", "connector", "attach", "conform", "mirror", "array",
+    "scene", "group", "solid", "material", "physics", "shader", "param", "shader_params", "connector", "attach", "conform", "mirror", "array",
     "stack", "grid",
     "meta",
     "box", "plane", "quad", "cylinder", "cone", "sphere", "capsule", "torus",
@@ -120,7 +120,7 @@ pub fn common_attrs_for_kind(kind: &str) -> &'static [&'static str] {
         "skeleton" | "bone" => TRANSFORM_COMMON_ATTRS,
         "light" => LIGHT_COMMON_ATTRS,
         "decal" => DECAL_COMMON_ATTRS,
-        "material" | "physics" | "connector" | "attach"
+        "material" | "physics" | "shader" | "param" | "shader_params" | "connector" | "attach"
         | "joint" | "clip" | "track"
         | "spin" | "open_close" | "wave" | "flap" | "idle"
         | "lod_scale" | "meta"
@@ -289,6 +289,11 @@ pub fn attrs_for_kind(kind: &str) -> &'static [&'static str] {
         "wave" | "flap" => &["target", "axis", "amplitude", "hz", "easing"],
         "idle" => &["target", "amplitude", "hz", "easing"],
         "skeleton" => &[],
+        // Shader declaration + its `param` children. `shader_params` (the
+        // material-side override block) carries arbitrary param names, so it's
+        // handled specially in the walker rather than by a closed attr list.
+        "shader" => &["source"],
+        "param" => &["type", "default"],
         "bone" => &["envelope"],
         "attach" => &["parent", "child", "socket", "plug", "offset", "twist"],
         "conform" => &[
@@ -666,6 +671,9 @@ pub(super) fn attr_type(kind: &str, attr: &str) -> Option<&'static str> {
         ("coil", "handedness") => "string",
         ("material", "color") | ("material", "emissive") => "vec3",
         ("material", "alpha_mode") | ("material", "uv_mode") | ("material", "shader") => "string",
+        // `shader` declaration source + `param` type spelling. `param` `default`
+        // is intentionally untyped — it varies with the param's `type`.
+        ("shader", "source") | ("param", "type") => "string",
         ("material", "uv_scale") => "number or vec2",
         ("material", "base_color_texture")
         | ("material", "metallic_roughness_texture")

--- a/crates/mogen-validate/src/ast_checks/tests.rs
+++ b/crates/mogen-validate/src/ast_checks/tests.rs
@@ -1327,3 +1327,145 @@ mod physics_validator_tests {
         );
     }
 }
+
+mod shader_validator_tests {
+    use super::super::*;
+    use mogen_core::Diagnostic;
+    use std::path::Path;
+
+    fn diags_for(src: &str) -> Vec<Diagnostic> {
+        let ast = mogen_dsl::parse(src).expect("parse");
+        validate_ast(&ast)
+    }
+
+    fn diags_for_with_source(src: &str, base: Option<&Path>) -> Vec<Diagnostic> {
+        let ast = mogen_dsl::parse(src).expect("parse");
+        validate_ast_with_source(&ast, base)
+    }
+
+    #[test]
+    fn unknown_shader_reference_errors() {
+        let src = r#"material "pond" (color=[0.1,0.2,0.3], shader="bogus")"#;
+        let diags = diags_for(src);
+        assert!(
+            diags.iter().any(|d| d.code == "E0106"),
+            "expected E0106 for unknown shader, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn standard_and_pbr_shader_values_are_not_flagged() {
+        let src = r#"
+            material "a" (color=[0.1,0.2,0.3], shader="standard")
+            material "b" (color=[0.1,0.2,0.3], shader="pbr")
+        "#;
+        let diags = diags_for(src);
+        assert!(
+            !diags.iter().any(|d| d.code == "E0106"),
+            "standard/pbr are the implicit PBR path, not a reference, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn builtin_water_shader_is_valid_without_declaration() {
+        let src = r#"material "sea" (color=[0,0.3,0.5], shader="water")"#;
+        let diags = diags_for(src);
+        assert!(
+            !diags.iter().any(|d| d.code == "E0106"),
+            "built-in water shader should not need a declaration, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn declared_shader_reference_is_valid() {
+        let src = r#"
+            shader "ripple" (source="shaders/ripple.glsl") {
+              param "speed" (type=float, default=2.0)
+            }
+            material "pond" (color=[0.1,0.2,0.3], shader="ripple") {
+              shader_params (speed=3.5)
+            }
+        "#;
+        let diags = diags_for(src);
+        assert!(
+            !diags.iter().any(|d| d.code == "E0106" || d.code == "W0108"),
+            "declared shader + known param should validate clean, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_shader_param_warns() {
+        let src = r#"
+            shader "ripple" (source="shaders/ripple.glsl") {
+              param "speed" (type=float, default=2.0)
+            }
+            material "pond" (color=[0.1,0.2,0.3], shader="ripple") {
+              shader_params (tint=[0,0.4,0.6])
+            }
+        "#;
+        let diags = diags_for(src);
+        assert!(
+            diags.iter().any(|d| d.code == "W0108"),
+            "expected W0108 for a param the shader never declared, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_shader_reference_not_suppressed_by_unrelated_import() {
+        // Regression test: an import elsewhere in the file must not blanket-
+        // suppress the unknown-shader check for materials that don't reference
+        // anything from the import. Only genuinely unresolved imports should
+        // back off (mirrors the unknown-module check).
+        let dir = write_tmp(
+            "shader_unrelated_import",
+            &[("lib.mog", r#"material "brick" (color=[0.5,0.3,0.2])"#)],
+        );
+        let src = r#"
+            import "lib.mog"
+            scene {
+              box "b" (size=[1,1,1], mat="pond_mat")
+              material "pond_mat" (color=[0.1,0.2,0.3], shader="totally_bogus_typo")
+            }
+        "#;
+        let diags = diags_for_with_source(src, Some(dir.as_path()));
+        assert!(
+            diags.iter().any(|d| d.code == "E0106"),
+            "unrelated import must not suppress a local shader typo, got: {diags:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unknown_shader_reference_suppressed_without_import_source() {
+        // Without a base dir we can't resolve imports at all, so we can't rule
+        // out the shader being declared in the imported file — suppress, same
+        // as the unknown-module check.
+        let src = r#"
+            import "lib.mog"
+            scene { box "b" (size=[1,1,1], mat="pond_mat") }
+            material "pond_mat" (color=[0.1,0.2,0.3], shader="maybe_in_lib")
+        "#;
+        let diags = diags_for_with_source(src, None);
+        assert!(
+            !diags.iter().any(|d| d.code == "E0106"),
+            "unknown-shader must be suppressed when imports can't be resolved, got: {diags:?}"
+        );
+    }
+
+    fn write_tmp(label: &str, files: &[(&str, &str)]) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "mogen-validate-shaders-{}-{}-{}",
+            std::process::id(),
+            id,
+            label
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        for (name, contents) in files {
+            std::fs::write(dir.join(name), contents).unwrap();
+        }
+        dir
+    }
+}

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -915,13 +915,17 @@ Declared at the top of the file or inside `scene { ... }`. Attributes:
   albedo (e.g. `prompt="navy nylon ripstop weave"`). Steers Gemini away
   from the default "material name + colour" framing; auto-rephrased on
   recitation rejection.
-- `shader` — `"standard"` (default) or `"water"`. Studio-preview only — the
-  exported `.glb` always uses standard PBR. `"water"` reinterprets the
-  standard knobs as a procedural water shader: `color` is the body tint,
-  `uv_scale` is ripple density, `roughness` controls chop/foam (`0.05`
-  glassy → `1.0` whitecaps), `metallic` lerps toward liquid-metal Fresnel,
-  `transmission` + `alpha_mode="blend"` lets the floor show through, and
-  `normal_texture`/`base_color_texture` blend into the procedural waves.
+- `shader` — `"standard"`/`"pbr"` (default, the regular PBR path), the
+  built-in `"water"` preset, or the name of a user-declared `shader "<name>"`
+  (see [Shaders](#shaders) below). Studio-preview only — the exported `.glb`
+  always uses standard PBR scalars; the shader name + `shader_params` ride
+  along as `node.extras.shader` metadata for downstream consumers. `"water"`
+  reinterprets the standard knobs as a procedural water shader: `color` is
+  the body tint, `uv_scale` is ripple density, `roughness` controls
+  chop/foam (`0.05` glassy → `1.0` whitecaps), `metallic` lerps toward
+  liquid-metal Fresnel, `transmission` + `alpha_mode="blend"` lets the floor
+  show through, and `normal_texture`/`base_color_texture` blend into the
+  procedural waves.
 - `gradient` — optional ramp baked into per-vertex `COLOR_0` at export
   time. Four surface forms, all colours are vec3 in sRGB `[0..1]`:
   - `linear(from=[…], to=[…], axis=x|y|z)` — interpolates between two
@@ -956,6 +960,52 @@ material "lake" (color=[0.05, 0.32, 0.45], shader="water")
 Texture files are embedded in the output GLB (self-contained, movable
 without sources); missing files are a hard error at export. Reference a
 material via `mat="wood"`; unknown names are a hard error at lowering.
+
+---
+
+## Shaders
+
+A `shader "<name>" { ... }` declaration names an on-disk GLSL fragment
+snippet and the parameters materials may feed it. mogen never compiles or
+runs the GLSL — it only carries the path + resolved parameter values as
+`node.extras.shader` metadata on the glTF nodes bound to a referencing
+material. MoGen Studio is the one component that actually compiles a
+declared shader, for live preview. The built-in `water` preset (see
+`shader=` above) is just the first client of this system — declaring your
+own `shader "water" { ... }` shadows it.
+
+```
+shader "ripple" (source="shaders/ripple.glsl") {
+  param "speed" (type=float, default=2.0)
+  param "tint"  (type=color, default=[0.0, 0.3, 0.5])
+}
+
+material "pond" (color=[0.1, 0.2, 0.3], shader="ripple") {
+  shader_params (speed=3.5, tint=[0.0, 0.4, 0.6])
+}
+```
+
+`shader` attributes:
+
+- `source` — path to the GLSL fragment snippet, resolved relative to the
+  `.mog` file the same way texture paths are.
+
+Each `param "<name>" { ... }` child declares one uniform the snippet may
+use:
+
+- `type` — `float`, `vec2`, `vec3`, `vec4`, or `color` (an RGB `vec3`
+  authored as `[r, g, b]`).
+- `default` — value used when a referencing material supplies no override
+  via `shader_params`. Must match the declared `type`.
+
+A material opts in with `shader="<name>"` (built-in `water`, or a declared
+name) and overrides individual parameter values with a `shader_params (...)`
+child block — any attribute name matching a declared `param` name; names
+that don't match warn (`W0108`) but don't fail the build. Referencing an
+undeclared, non-built-in shader name is a hard error (`E0106`) at
+validation time. Shaders declared in an imported file aren't currently
+visible to the importing file's materials — declare shaders in the file
+that uses them.
 
 ---
 


### PR DESCRIPTION
## Why

Water was a hard-coded preview effect: a material carried a two-value
`MaterialShader { Standard, Water }` enum and Studio's monolithic fragment
program branched on it. This makes water *one preset* in an open system — users
declare their own GLSL fragment shaders in `.mog`, and the built-in `water`
becomes the first client of the exact same path instead of a special case.

mogen stays plain-glTF: it carries the shader **path + params as metadata only**
and never compiles or runs GLSL. MoGen Studio is the consumer that previews it.

## What's in this PR

**Phase 1 — DSL + core** (tested)
- New `mogen_core::shader`: `ShaderDecl`, `ShaderParamDef`, `ShaderParamType`,
  `ShaderParamValue`; `graph.shaders` + `add_shader`/`find_shader_scoped`/
  `has_shader` mirroring the material registry.
- `Material.shader` enum → `shader_name: Option<String>` + `shader_params`.
- `lower/shader.rs` collects declarations, seeds the shadowable `water` built-in,
  and reads material `shader=` + `shader_params (…)`.
- Validation: new `shader`/`param`/`shader_params` kinds, **E0106** unknown
  shader ref, **W0108** unknown param name.

**Phase 2 — metadata export** (tested)
- Materials project onto `node.extras.shader = { name, params }` (defaults
  merged with overrides, deterministic key order).

**Phase 3 — Studio assembler core** (unit-tested; live wiring not yet included)
- `viewer/shaders/user_shader.rs` assembles the fragment program by injecting
  each user shader as a `fragment_N()` behind a generated dispatch; params become
  per-shader-namespaced uniforms `#define`d to bare names inside the snippet.
- `mesh.rs` carries the injection marker + an inert dispatch hook in `main`.
- The standard program compiles through `assemble_fs(&[])`, so **standard/water
  rendering (ids 0/1) is byte-identical and untouched**.

### DSL surface
```
shader "ripple" (source="shaders/ripple.glsl") {
  param "speed" (type=float, default=2.0)
  param "tint"  (type=color, default=[0.0,0.3,0.5])
}
material "pond" (color=[0.1,0.2,0.3], shader="ripple") {
  shader_params (speed=3.5, tint=[0.0,0.4,0.6])
}
material "sea" (shader="water")   # built-in preset, no declaration needed
```
Exports to: `node "pond".extras.shader = {name:"ripple", params:{speed:3.5, tint:[…]}}`.

## Architecture note
Rather than a per-material program cache (which forces a ~55-site uniform-location
refactor + frame-constant re-upload on every switch), Studio keeps its **single**
program and injects user shaders into it. This leaves the entire proven
uniform/draw path untouched — the new path is fully isolated, so a bug in it
can't regress existing rendering.

## Not in this PR (follow-up, needs a GL context to verify)
- Phase 3 wiring: bake the used-shader list into `FlatMesh`, make the renderer's
  uniform-location fetch re-callable so the program can recompile, per-material
  param upload, `draw` using `batch.shader_id`, hot-reload, error surfacing.
- Phase 4: extract water into `stdlib/shaders/water.glsl` against the ABI and
  drop the hard-coded branch (dogfood).

## Testing
- `cargo test` green for `mogen-core`, `mogen-dsl`, `mogen-validate`,
  `mogen-export`, and the new `user_shader` assembler (4 tests).
- Verified end-to-end via CLI: `check` (E0106/W0108 fire correctly), `dump-scene`
  (shaders + resolved params), and `build` + GLB inspection (`extras.shader`).
- Three unrelated golden/hull tests (`hull_rejects_coplanar_points`,
  `simple_house`, `wall_door`) fail identically on clean `master` — a local
  Manifold library mismatch, not from this change (confirmed via worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)