### PR TITLE
Fix hull coplanar guard by testing volume, not emptiness

### DIFF
--- a/crates/mogen-dsl/src/lower/primitive.rs
+++ b/crates/mogen-dsl/src/lower/primitive.rs
@@ -6,7 +6,8 @@ use mogen_geom::{
     bezier_patch_mesh, box_mesh, capsule_mesh, chamfered_box_mesh, clean_csg_output, coil_mesh,
     cone_mesh, curved_plane_mesh, cylinder_mesh, difference_many, disc_mesh, ellipsoid_mesh,
     extrude_mesh, frustum_mesh, half_cylinder_mesh, heightfield_mesh, hemisphere_mesh, hull_mesh,
-    icosphere_mesh, inset_box_mesh, lathe_mesh, leaf_card_mesh, loft_mesh, mesh_from_glb_bytes,
+    icosphere_mesh, inset_box_mesh, is_degenerate_solid, lathe_mesh, leaf_card_mesh, loft_mesh,
+    mesh_from_glb_bytes,
     metaball_mesh, plane_mesh, poly_mesh, prism_mesh, pyramid_mesh, quad_mesh, read_glb_bytes,
     rounded_box_mesh, sphere_mesh, spline_ribbon_mesh, spline_tube_mesh, superellipsoid_mesh,
     sweep_mesh, torus_arc_mesh, torus_mesh, transform_mesh, tube_mesh, wedge_mesh,
@@ -307,9 +308,13 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Mesh
                 )));
             }
             let mesh = hull_mesh(&points);
-            if mesh.positions.is_empty() {
+            // Degenerate input does not come back as an empty mesh: Manifold
+            // returns a zero-volume sheet for a coplanar point set, which would
+            // export as an invisible, non-watertight node. Test the volume the
+            // hull actually bounds rather than trusting it to come back empty.
+            if is_degenerate_solid(&mesh) {
                 return Some(Err(anyhow!(
-                    "`hull` produced no geometry — all points may be coplanar"
+                    "`hull` produced no solid geometry — the points bound no volume (all coplanar or collinear)"
                 )));
             }
             mesh

--- a/crates/mogen-geom/src/cleanup.rs
+++ b/crates/mogen-geom/src/cleanup.rs
@@ -138,29 +138,12 @@ pub fn is_closed_manifold(mesh: &Mesh) -> bool {
     edge_counts.values().all(|&c| c == 2)
 }
 
-/// Signed volume of a triangle mesh via the divergence theorem — positive for
-/// the outward winding the exporter expects. Only meaningful on a closed mesh;
-/// on an open one the result is the volume of the shell closed through the
-/// origin, which is why callers pair this with a closedness or emptiness check.
-pub fn mesh_volume(mesh: &Mesh) -> f32 {
-    // f64 accumulation: the per-triangle terms of a thin solid nearly cancel,
-    // and f32 rounding alone can swamp the residual we are testing for.
-    let mut sum = 0.0_f64;
-    for tri in mesh.indices.chunks_exact(3) {
-        let [a, b, c] = [tri[0] as usize, tri[1] as usize, tri[2] as usize];
-        let pa = Vec3::from_array(mesh.positions[a]).as_dvec3();
-        let pb = Vec3::from_array(mesh.positions[b]).as_dvec3();
-        let pc = Vec3::from_array(mesh.positions[c]).as_dvec3();
-        sum += pa.dot(pb.cross(pc));
-    }
-    (sum / 6.0) as f32
-}
-
 /// True when a mesh bounds no meaningful volume: it is empty, or it is a flat
-/// or collapsed shell whose signed volume vanishes relative to its own extent.
-/// Manifold happily returns such a sheet — the convex hull of coplanar points
-/// comes back as back-to-back triangle fans, not as an empty mesh — so anything
-/// that must produce a *solid* tests this rather than testing for emptiness.
+/// or collapsed shell whose enclosed volume vanishes relative to its own
+/// extent. Manifold happily returns such a sheet — the convex hull of coplanar
+/// points comes back as back-to-back triangle fans, not as an empty mesh — so
+/// anything that must produce a *solid* tests this rather than testing for
+/// emptiness.
 ///
 /// The tolerance is scale-relative (volume against the cube of the bounding
 /// diagonal), so a legitimately thin-but-solid slab still passes at any unit
@@ -180,7 +163,7 @@ pub fn is_degenerate_solid(mesh: &Mesh) -> bool {
     if !diag.is_finite() || diag <= 0.0 {
         return true;
     }
-    mesh_volume(mesh).abs() <= 1e-6 * diag * diag * diag
+    mesh.solid_volume() <= 1e-6 * diag * diag * diag
 }
 
 /// Drop triangles with (near) zero area, as well as any triangle whose indices
@@ -493,9 +476,11 @@ mod tests {
     }
 
     #[test]
-    fn box_volume_matches_its_dimensions() {
+    fn an_ordinary_box_is_not_degenerate() {
         let mesh = crate::box_mesh([2.0, 3.0, 4.0], mogen_core::UvMode::default());
-        let v = mesh_volume(&mesh);
+        // Sanity-check the volume the guard reads, so a failure below points at
+        // the threshold rather than at the measurement.
+        let v = mesh.solid_volume();
         assert!((v - 24.0).abs() < 1e-3, "got {v}");
         assert!(!is_degenerate_solid(&mesh));
     }

--- a/crates/mogen-geom/src/cleanup.rs
+++ b/crates/mogen-geom/src/cleanup.rs
@@ -138,6 +138,51 @@ pub fn is_closed_manifold(mesh: &Mesh) -> bool {
     edge_counts.values().all(|&c| c == 2)
 }
 
+/// Signed volume of a triangle mesh via the divergence theorem — positive for
+/// the outward winding the exporter expects. Only meaningful on a closed mesh;
+/// on an open one the result is the volume of the shell closed through the
+/// origin, which is why callers pair this with a closedness or emptiness check.
+pub fn mesh_volume(mesh: &Mesh) -> f32 {
+    // f64 accumulation: the per-triangle terms of a thin solid nearly cancel,
+    // and f32 rounding alone can swamp the residual we are testing for.
+    let mut sum = 0.0_f64;
+    for tri in mesh.indices.chunks_exact(3) {
+        let [a, b, c] = [tri[0] as usize, tri[1] as usize, tri[2] as usize];
+        let pa = Vec3::from_array(mesh.positions[a]).as_dvec3();
+        let pb = Vec3::from_array(mesh.positions[b]).as_dvec3();
+        let pc = Vec3::from_array(mesh.positions[c]).as_dvec3();
+        sum += pa.dot(pb.cross(pc));
+    }
+    (sum / 6.0) as f32
+}
+
+/// True when a mesh bounds no meaningful volume: it is empty, or it is a flat
+/// or collapsed shell whose signed volume vanishes relative to its own extent.
+/// Manifold happily returns such a sheet — the convex hull of coplanar points
+/// comes back as back-to-back triangle fans, not as an empty mesh — so anything
+/// that must produce a *solid* tests this rather than testing for emptiness.
+///
+/// The tolerance is scale-relative (volume against the cube of the bounding
+/// diagonal), so a legitimately thin-but-solid slab still passes at any unit
+/// scale while an exactly-planar hull does not.
+pub fn is_degenerate_solid(mesh: &Mesh) -> bool {
+    if mesh.positions.is_empty() || mesh.indices.len() < 3 {
+        return true;
+    }
+    let mut lo = Vec3::splat(f32::INFINITY);
+    let mut hi = Vec3::splat(f32::NEG_INFINITY);
+    for p in &mesh.positions {
+        let v = Vec3::from_array(*p);
+        lo = lo.min(v);
+        hi = hi.max(v);
+    }
+    let diag = (hi - lo).length();
+    if !diag.is_finite() || diag <= 0.0 {
+        return true;
+    }
+    mesh_volume(mesh).abs() <= 1e-6 * diag * diag * diag
+}
+
 /// Drop triangles with (near) zero area, as well as any triangle whose indices
 /// collapsed to fewer than three distinct vertices.
 pub fn cull_degenerate(mesh: &Mesh) -> Mesh {
@@ -445,6 +490,46 @@ mod tests {
     fn empty_mesh_is_not_closed() {
         let empty = Mesh::default();
         assert!(!is_closed_manifold(&empty));
+    }
+
+    #[test]
+    fn box_volume_matches_its_dimensions() {
+        let mesh = crate::box_mesh([2.0, 3.0, 4.0], mogen_core::UvMode::default());
+        let v = mesh_volume(&mesh);
+        assert!((v - 24.0).abs() < 1e-3, "got {v}");
+        assert!(!is_degenerate_solid(&mesh));
+    }
+
+    #[test]
+    fn a_flat_sheet_bounds_no_volume() {
+        // Two back-to-back triangle pairs spanning a unit square: closed enough
+        // to survive a CSG round trip, but enclosing nothing. This is the shape
+        // Manifold hands back for the convex hull of coplanar points.
+        let mesh = Mesh {
+            positions: vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ],
+            normals: vec![[0.0, 0.0, 1.0]; 4],
+            indices: vec![0, 1, 2, 0, 2, 3, 0, 2, 1, 0, 3, 2],
+            ..Default::default()
+        };
+        assert!(is_degenerate_solid(&mesh));
+    }
+
+    #[test]
+    fn a_thin_slab_is_still_a_solid() {
+        // The tolerance is scale-relative, so a wafer far thinner than any
+        // modelled part must not be mistaken for a degenerate sheet.
+        let mesh = crate::box_mesh([1.0, 1e-3, 1.0], mogen_core::UvMode::default());
+        assert!(!is_degenerate_solid(&mesh));
+    }
+
+    #[test]
+    fn empty_mesh_is_degenerate() {
+        assert!(is_degenerate_solid(&Mesh::default()));
     }
 
     #[test]

--- a/crates/mogen-geom/src/lib.rs
+++ b/crates/mogen-geom/src/lib.rs
@@ -14,7 +14,7 @@ pub mod xform;
 
 pub use cleanup::{
     clean_csg_output, cull_coplanar_opposites, cull_degenerate, is_closed_manifold,
-    recompute_normals, weld_vertices,
+    is_degenerate_solid, mesh_volume, recompute_normals, weld_vertices,
 };
 pub use conform::{
     build_path_frames, conform_mesh, conform_patch, subdivide_along_axis, Axis, AxisMap,

--- a/crates/mogen-geom/src/lib.rs
+++ b/crates/mogen-geom/src/lib.rs
@@ -14,7 +14,7 @@ pub mod xform;
 
 pub use cleanup::{
     clean_csg_output, cull_coplanar_opposites, cull_degenerate, is_closed_manifold,
-    is_degenerate_solid, mesh_volume, recompute_normals, weld_vertices,
+    is_degenerate_solid, recompute_normals, weld_vertices,
 };
 pub use conform::{
     build_path_frames, conform_mesh, conform_patch, subdivide_along_axis, Axis, AxisMap,


### PR DESCRIPTION
Fixes the pre-existing `lower::tests::hull::hull_rejects_coplanar_points` failure on `master`.

## Diagnosis

The guard added in f5eadd8 (#95) was never refactored away — it is still in `primitive.rs`. Its *condition* stopped matching. Probing `hull_mesh` directly with the test's four coplanar points:

```
raw from Manifold:      4 positions, 12 indices
after clean_csg_output: 12 positions, 12 indices
```

Manifold no longer returns an empty hull for a coplanar point set. It returns a **zero-volume sheet** — four triangles, all in the z=0 plane, wound back-to-back. So `mesh.positions.is_empty()` was false, the guard fell through, and lowering emitted a flat, invisible, non-watertight node instead of erroring.

## Change

Testing for emptiness was the fragile part: it keyed on an incidental Manifold behaviour rather than the property a `hull` node actually has to satisfy. It must produce a *solid*, so the guard now tests that directly.

Added to `mogen-geom/src/cleanup.rs`, alongside the existing `is_closed_manifold` query:

- **`is_degenerate_solid`** — true for empty meshes and for shells whose volume vanishes relative to their own extent. The tolerance is scale-relative (volume against the cube of the bounding diagonal), so it does not misfire on small models or on legitimately thin-but-solid slabs. The volume itself comes from the existing `mogen_core::Mesh::solid_volume`, which already accumulates the divergence-theorem sum in f64 — necessary here because the per-triangle terms of a thin solid nearly cancel and f32 rounding alone can swamp the residual being tested.

`primitive.rs` now rejects on `is_degenerate_solid(&mesh)`. The diagnostic is widened to name collinear/coincident input too, since the volume test catches those as well.

## Verification

- `cargo test -p mogen-dsl` — **453 passed, 0 failed**, including all five hull tests.
- `cargo test -p mogen-geom` — **127 passed, 0 failed**, with 4 new tests for the helper: an ordinary box, the flat sheet, a 1 mm-thin slab that must *not* trip the guard, and the empty mesh.
- `cargo test --workspace --no-fail-fast` — only `wall_door` and `simple_house` in `-p mogen --test goldens` fail. Confirmed identical on an unmodified `master` at ba55445, so they are pre-existing and unrelated; neither fixture uses `hull`.
- `cargo clippy -p mogen-geom` — no errors; the new code is clippy-clean (remaining warnings are pre-existing).
- Both real hull examples still build, confirming no false positives: `hull_ramp.mog` → 12 tris, `boat_hull.mog` → 196 tris.

## Reviewer notes

Two things worth flagging, both pre-existing and left alone:

- **The repo is not rustfmt-clean.** `cargo fmt -p mogen-geom -p mogen-dsl` rewrites 134 files. I reverted that entirely and hand-matched the surrounding style, so this diff stays at 3 files.
- **`cargo clippy` fails on `master`** with two `approx_constant` errors at `crates/mogen-dsl/src/conform/tests.rs:496-497` (`0.7071` vs `FRAC_1_SQRT_2`). Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
