### PR TITLE
SVG textures: rasterize at build time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,13 @@ mogen-dsl  ──parse──►  AST  ──validate_ast──►  lower  ──
   by `write_glb_with_options`; `merge.rs` is an optional pre-export pass that CSG-unions
   same-material, non-skinned sibling leaf meshes into one node (preserves hierarchy,
   animations, skins, connectors — but drops per-vertex UVs on merged groups, so textured
-  meshes fall back to flat PBR when merged).
+  meshes fall back to flat PBR when merged). `svg.rs` (feature `textures-svg`) is a
+  pre-export pass that rasterizes `.svg` texture slots to PNG and rewrites the
+  `TextureRef` paths in a cloned graph, layering the rendered bytes over the caller's
+  `TextureSource`. It runs *before* the merge stages in both the GLB and FBX entry points,
+  so the exporter, FBX's raw-path emission, Studio's preview, and `mogen-llm`'s derived
+  PBR maps all see raster only and need no SVG branch of their own. Deliberately uncached
+  and font-free — both so identical sources produce identical bytes.
 - **mogen-llm** — Gemini `generateContent` client (`gemini.rs`), system-instruction assembly
   from grammar + stdlib index + examples (`prompt.rs`), and the repair loop (`repair.rs`)
   that re-feeds JSON diagnostics for up to `max_repair_iters` retries. `embed_seed_header` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,12 @@ mogen-dsl  ──parse──►  AST  ──validate_ast──►  lower  ──
   pre-export pass that rasterizes `.svg` texture slots to PNG and rewrites the
   `TextureRef` paths in a cloned graph, layering the rendered bytes over the caller's
   `TextureSource`. It runs *before* the merge stages in both the GLB and FBX entry points,
-  so the exporter, FBX's raw-path emission, Studio's preview, and `mogen-llm`'s derived
-  PBR maps all see raster only and need no SVG branch of their own. Deliberately uncached
-  and font-free — both so identical sources produce identical bytes.
+  so the exporter and FBX's raw-path emission see raster only and need no SVG branch of
+  their own. `render_svg`/`resolve_svg_size` are also exported standalone so a consumer
+  that never touches a full `SceneGraph` — MoGen Studio's live viewport reads texture
+  paths straight off disk, outside the export pipeline — can rasterize one file at a time
+  instead of re-implementing the renderer. Deliberately uncached and font-free — both so
+  identical sources produce identical bytes.
 - **mogen-llm** — Gemini `generateContent` client (`gemini.rs`), system-instruction assembly
   from grammar + stdlib index + examples (`prompt.rs`), and the repair loop (`repair.rs`)
   that re-feeds JSON diagnostics for up to `max_repair_iters` retries. `embed_seed_header` /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +1309,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,6 +1425,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "float-cmp"
@@ -2193,6 +2214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65b27460c2c92b037f3f94c538ed9a3342f3fdf923606781629ccb35f82d042a"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2381,6 +2408,18 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
+]
 
 [[package]]
 name = "lazy_static"
@@ -2586,7 +2625,7 @@ checksum = "e01e77ead21976b3a9f01ec1724f766923da74f0726364e2b0f425658935d71a"
 dependencies = [
  "bitflags 2.11.1",
  "cc",
- "float-cmp",
+ "float-cmp 0.10.0",
  "thiserror 2.0.18",
 ]
 
@@ -2725,8 +2764,10 @@ dependencies = [
  "mogen-geom",
  "mogen-render",
  "oxipng",
+ "resvg",
  "serde",
  "serde_json",
+ "usvg",
 ]
 
 [[package]]
@@ -3596,6 +3637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3676,6 +3723,15 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -4064,6 +4120,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e3803f97b999e80cbf7c6ecdd07a8102204d92e1633cf48783720c521196bd"
+dependencies = [
+ "bytemuck",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia 0.12.0",
+ "usvg",
+]
+
+[[package]]
 name = "rfd"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4149,6 +4220,15 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4372,7 +4452,7 @@ dependencies = [
  "log",
  "memmap2",
  "smithay-client-toolkit 0.19.2",
- "tiny-skia",
+ "tiny-skia 0.11.4",
 ]
 
 [[package]]
@@ -4637,6 +4717,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4765,6 +4860,9 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp 0.9.0",
+]
 
 [[package]]
 name = "string-interner"
@@ -4808,6 +4906,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -4980,7 +5088,22 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "tiny-skia-path",
+ "tiny-skia-path 0.11.4",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path 0.12.0",
 ]
 
 [[package]]
@@ -4988,6 +5111,17 @@ name = "tiny-skia-path"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -5335,6 +5469,25 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "usvg"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977d0a4abdef933f424a99fe09f95576e089b90aebc6f016a3bc813762493e91"
+dependencies = [
+ "data-url",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path 0.12.0",
+]
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,13 @@ serde_json = "1"
 glam = { version = "0.30", features = ["serde"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 oxipng = { version = "9", default-features = false, features = ["parallel"] }
+# SVG rasterization for `mogen-export`'s `textures-svg` feature. Pure Rust, so
+# unlike `image`/`oxipng` these do cross-compile to wasm32. `usvg`'s default
+# features are off deliberately: they pull in `fontdb`, which enumerates
+# system fonts at render time and would make rasterization depend on which
+# machine ran the build. Text in an SVG must be converted to paths first.
+resvg = { version = "0.48", default-features = false }
+usvg = { version = "0.48", default-features = false }
 # meshoptimizer Rust bindings. Used by `mogen-export`'s LOD pass to generate
 # simplified index buffers via quadric edge collapse. Wraps a small C++ lib
 # behind `cc`; doesn't cross-compile to `wasm32-unknown-unknown`, so wasm

--- a/crates/mogen-core/src/lib.rs
+++ b/crates/mogen-core/src/lib.rs
@@ -23,7 +23,9 @@ pub use graph::{
 pub use gradient::{Gradient, GradientAxis, GradientKind, GradientStop};
 pub use meta::Meta;
 pub use light::{Light, LightKind};
-pub use material::{AlphaMode, Material, MaterialId, TextureRef, UvMode};
+pub use material::{
+    AlphaMode, Material, MaterialId, TextureRef, UvMode, DEFAULT_SVG_SIZE,
+};
 pub use mesh::Mesh;
 pub use physics::{PhysicsBody, PhysicsId, PhysicsMaterial};
 pub use shader::{ShaderDecl, ShaderParamDef, ShaderParamType, ShaderParamValue};

--- a/crates/mogen-core/src/material.rs
+++ b/crates/mogen-core/src/material.rs
@@ -41,6 +41,12 @@ pub enum UvMode {
     Fit,
 }
 
+/// Edge length used for `.svg` textures when a material doesn't set
+/// [`Material::texture_size`]. Large enough that a detailed vector tile still
+/// reads cleanly on a hero asset, small enough that the default build doesn't
+/// spend megabytes on a flat two-colour pattern.
+pub const DEFAULT_SVG_SIZE: u32 = 1024;
+
 /// A reference to an on-disk image used as a material texture. Paths are
 /// resolved relative to the `.mog` file that declared them. During export the
 /// exporter reads the bytes, embeds them into the GLB binary chunk, and writes
@@ -114,6 +120,19 @@ pub struct Material {
     /// repeats the image within a face, `< 1` zooms into a sub-region.
     pub uv_scale: [f32; 2],
 
+    /// Edge length, in pixels, that `.svg` textures on this material are
+    /// rasterized to at export. SVG has no intrinsic pixel size, so one has to
+    /// be chosen; `None` means the [`DEFAULT_SVG_SIZE`] default. Ignored
+    /// entirely by raster textures, which are embedded at their authored size.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub texture_size: Option<u32>,
+    /// Whether `.svg` textures on this material rasterize with wrap-around, so
+    /// artwork crossing the tile boundary joins up instead of being clipped.
+    /// Off by default because it costs 9 render passes and only changes the
+    /// result for SVGs whose content overflows the viewBox.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub texture_wrap: bool,
+
     /// Albedo texture (multiplied with `base_color`). Expects a sRGB PNG.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_color_texture: Option<TextureRef>,
@@ -178,6 +197,8 @@ impl Material {
             shader_name: None,
             shader_params: BTreeMap::new(),
             uv_scale: [1.0, 1.0],
+            texture_size: None,
+            texture_wrap: false,
             base_color_texture: None,
             metallic_roughness_texture: None,
             normal_texture: None,

--- a/crates/mogen-dsl/src/lower/material.rs
+++ b/crates/mogen-dsl/src/lower/material.rs
@@ -132,6 +132,20 @@ fn register_material(node: &Node, graph: &mut SceneGraph) -> Result<()> {
         mat.uv_scale = pair;
     }
 
+    // Rasterization controls for `.svg` texture slots. Both are inert on
+    // raster textures — the exporter only consults them when a slot's path
+    // actually has an `.svg` extension. Range is enforced at export, where the
+    // material name is available for the message.
+    if let Some(s) = node.attr_number("texture_size") {
+        if s < 1.0 || s.fract() != 0.0 {
+            bail!("texture_size must be a positive whole number of pixels; got {s}");
+        }
+        mat.texture_size = Some(s as u32);
+    }
+    if let Some(w) = node.attr_number("texture_wrap") {
+        mat.texture_wrap = w != 0.0;
+    }
+
     // `shader="<name>"` names a preview shader (built-in `water` or a user
     // `shader "<name>"` declaration). `standard`/`pbr` are the implicit PBR
     // path — recorded as `None`. Unknown names are *not* rejected here; the

--- a/crates/mogen-dsl/src/lower/tests/materials.rs
+++ b/crates/mogen-dsl/src/lower/tests/materials.rs
@@ -331,3 +331,55 @@ fn gradient_axis_must_be_x_y_or_z() {
     let msg = format!("{err:#}");
     assert!(msg.contains("axis"), "wrong error: {msg}");
 }
+
+#[test]
+fn svg_raster_attrs_lower_onto_the_material() {
+    let g = lower_src(
+        r#"
+        material "vector" (color=[1, 1, 1],
+                           base_color_texture="tile.svg",
+                           texture_size=512,
+                           texture_wrap=1)
+        scene { box "b" (size=[1, 1, 1], mat="vector") }
+        "#,
+    );
+    let id = g.find_material("vector").expect("vector material");
+    let mat = &g.materials[id.0 as usize];
+    assert_eq!(mat.texture_size, Some(512));
+    assert!(mat.texture_wrap);
+}
+
+#[test]
+fn svg_raster_attrs_default_when_omitted() {
+    // Absent means "use the exporter's default", not "0" — the distinction
+    // matters because 0 is a rejected size.
+    let g = lower_src(
+        r#"
+        material "plain" (color=[1, 1, 1], base_color_texture="tile.svg")
+        scene { box "b" (size=[1, 1, 1], mat="plain") }
+        "#,
+    );
+    let id = g.find_material("plain").expect("plain material");
+    let mat = &g.materials[id.0 as usize];
+    assert_eq!(mat.texture_size, None);
+    assert!(!mat.texture_wrap);
+}
+
+#[test]
+fn texture_size_rejects_zero_and_fractional_values() {
+    for bad in ["0", "1.5", "-8"] {
+        let src = format!(
+            r#"
+            material "m" (color=[1, 1, 1], base_color_texture="t.svg", texture_size={bad})
+            scene {{ box "b" (size=[1, 1, 1], mat="m") }}
+            "#
+        );
+        let ast = parse(&src).expect("parse");
+        let err = lower(&ast).expect_err("texture_size={bad} must reject");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("texture_size"),
+            "error should name the attribute for {bad}, got: {msg}"
+        );
+    }
+}

--- a/crates/mogen-dsl/src/module/loader.rs
+++ b/crates/mogen-dsl/src/module/loader.rs
@@ -95,6 +95,11 @@ pub trait Loader {
     /// `spec` is the attribute verbatim; `base_dir` is the directory of the
     /// `.mog` being lowered — the same one `load` receives.
     ///
+    /// That browser is `mogen-wasm`'s `JsLoader`, which overrides this to
+    /// answer from the binary asset map the JS host already passes for
+    /// textures. Nothing else needs to: every other loader in the workspace
+    /// has a filesystem, so the default below is the right answer for it.
+    ///
     /// **The default impl *is* the resolution the primitive already performed**,
     /// by calling the very same function rather than restating its rule. That
     /// matters because the primitive still falls back to that function when a

--- a/crates/mogen-export/Cargo.toml
+++ b/crates/mogen-export/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [features]
-default = ["textures", "textures-optimize", "merge", "lod", "imposter"]
+default = ["textures", "textures-optimize", "textures-svg", "merge", "lod", "imposter"]
 # Texture packing. Splits cleanly across two layers so wasm builds can
 # embed images without pulling in `image`/`oxipng` (which depend on C libs
 # that don't cross-compile to wasm32):
@@ -21,6 +21,15 @@ default = ["textures", "textures-optimize", "merge", "lod", "imposter"]
 # and materials export with PBR factors only.
 textures = []
 textures-optimize = ["textures", "dep:image", "dep:oxipng"]
+# - `textures-svg`      — rasterize `.svg` texture references to PNG before
+#                         export, so every downstream consumer (GLB embed,
+#                         FBX paths, Studio preview, derived PBR maps) only
+#                         ever sees raster. On by default for desktop. The
+#                         deps are pure Rust, so unlike `textures-optimize`
+#                         this one *can* be enabled for wasm too — the wasm
+#                         crate just has to opt in explicitly, since it
+#                         builds with `default-features = false`.
+textures-svg = ["textures", "dep:resvg", "dep:usvg"]
 # Sibling-mesh merge module. The merge pass calls into `mogen-geom`'s CSG
 # `union_many`; whichever crate enables the `csg` (desktop) or
 # `unstable-wasm-uu` (wasm) flavor of `mogen-geom` is responsible for
@@ -53,9 +62,14 @@ serde_json = { workspace = true }
 glam = { workspace = true }
 image = { workspace = true, optional = true }
 oxipng = { workspace = true, optional = true }
+resvg = { workspace = true, optional = true }
+usvg = { workspace = true, optional = true }
 fbxcel = { version = "0.9", features = ["writer", "tree"], optional = true }
 meshopt = { workspace = true, optional = true }
 mogen-render = { workspace = true, optional = true }
 
 [dev-dependencies]
 mogen-dsl = { workspace = true, features = ["csg"] }
+# Non-optional here so the `svg` module's tests can decode what they rendered
+# even in a `--no-default-features --features textures-svg` build.
+image = { workspace = true }

--- a/crates/mogen-export/src/fbx/mod.rs
+++ b/crates/mogen-export/src/fbx/mod.rs
@@ -80,6 +80,28 @@ pub fn build_fbx_with_options_and_source<F: Fn(&str)>(
     texture_source: &dyn TextureSource,
     progress: F,
 ) -> Result<Vec<u8>> {
+    // Mirror the GLB pipeline's SVG pre-pass. This matters more here than it
+    // does for GLB: FBX emits texture *paths* rather than embedding bytes, so
+    // without this a `.svg` would be written into the FBX verbatim and no DCC
+    // tool could resolve it.
+    #[cfg(feature = "textures-svg")]
+    let svg_owned = if opts.include_textures {
+        crate::svg::rasterize_svg_textures(scene, texture_source)?
+    } else {
+        None
+    };
+    #[cfg(feature = "textures-svg")]
+    let svg_overlay;
+    #[cfg(feature = "textures-svg")]
+    let (scene, texture_source): (&SceneGraph, &dyn TextureSource) = match &svg_owned {
+        Some(r) => {
+            progress("rasterizing SVG textures");
+            svg_overlay = crate::svg::OverlayTextureSource::new(texture_source, &r.images);
+            (&r.scene, &svg_overlay)
+        }
+        None => (scene, texture_source),
+    };
+
     // Mirror the GLB merge pipeline: scoped `solid` pass first, then the
     // global sibling-merge if the caller asked for it. Both stages clone
     // and the latest owned graph wins.

--- a/crates/mogen-export/src/lib.rs
+++ b/crates/mogen-export/src/lib.rs
@@ -10,6 +10,8 @@ mod material;
 pub mod merge;
 pub mod options;
 mod skin;
+#[cfg(feature = "textures-svg")]
+pub mod svg;
 mod texture;
 mod writer;
 
@@ -24,6 +26,8 @@ pub use lod::{scene_with_lod, LOD_STAGE_COUNT};
 #[cfg(feature = "imposter")]
 pub use imposter::{bake_scene_imposter, ImposterAtlas};
 pub use texture::{FsTextureSource, MapTextureSource, TextureSource};
+#[cfg(feature = "textures-svg")]
+pub use svg::{is_svg, rasterize_svg_textures, OverlayTextureSource, SvgRaster};
 pub use writer::{
     build_glb_with_options, build_glb_with_options_and_source, write_glb, write_glb_with_options,
 };

--- a/crates/mogen-export/src/lib.rs
+++ b/crates/mogen-export/src/lib.rs
@@ -27,7 +27,10 @@ pub use lod::{scene_with_lod, LOD_STAGE_COUNT};
 pub use imposter::{bake_scene_imposter, ImposterAtlas};
 pub use texture::{FsTextureSource, MapTextureSource, TextureSource};
 #[cfg(feature = "textures-svg")]
-pub use svg::{is_svg, rasterize_svg_textures, OverlayTextureSource, SvgRaster};
+pub use svg::{
+    is_svg, rasterize_svg_textures, render_svg, resolve_svg_size, OverlayTextureSource,
+    SvgRaster, MAX_SVG_SIZE,
+};
 pub use writer::{
     build_glb_with_options, build_glb_with_options_and_source, write_glb, write_glb_with_options,
 };

--- a/crates/mogen-export/src/svg.rs
+++ b/crates/mogen-export/src/svg.rs
@@ -18,13 +18,23 @@
 //! |---|---|
 //! | GLB embed | `encode_for_slot` |
 //! | FBX export | the **raw path** (`fbx/material.rs`) — a `.svg` would leak into the FBX |
-//! | Studio preview | its own loaders under `viewer/` |
 //! | PBR map derivation | `mogen-llm::pbr_maps`, which hard-codes `ImageFormat::Png` |
 //! | imposter bake | already-baked pixels; unaffected |
 //!
-//! Branching at decode time would need four separate fixes. Rewriting the
+//! Branching at decode time would need three separate fixes. Rewriting the
 //! path *before* export means every one of them only ever sees a PNG, and the
 //! derived-PBR pipeline picks up SVG albedo support for free.
+//!
+//! # The consumer this pass cannot reach
+//!
+//! Studio's live viewport is not downstream of the exporter at all — it
+//! flattens the `SceneGraph` straight out of the compile pipeline and uploads
+//! each material's texture paths to GL itself. The rewritten paths this pass
+//! produces are synthetic and resolve only through [`OverlayTextureSource`],
+//! so handing them to a loader that reads from disk would be worse than
+//! useless. The viewport therefore calls [`render_svg`] and
+//! [`resolve_svg_size`] directly, on the real `.svg` path — same functions,
+//! same pixels, no second implementation of the policy.
 //!
 //! # No cache
 //!
@@ -131,6 +141,14 @@ pub fn rasterize_svg_textures(
     let mut images: HashMap<PathBuf, Vec<u8>> = HashMap::new();
 
     for mat in &mut scene.materials {
+        // `texture_size` is documented as ignored by raster slots, so its range
+        // check belongs *behind* this test rather than in front of it. Ahead of
+        // it, whether an out-of-range value on a texture-less material failed
+        // the build depended on whether some entirely unrelated material in the
+        // same scene happened to reference an SVG.
+        if !material_references_svg(mat) {
+            continue;
+        }
         let size = resolve_svg_size(mat)?;
         let wrap = mat.texture_wrap;
         for slot in mat.texture_slots_mut() {
@@ -198,6 +216,18 @@ pub fn resolve_svg_size(mat: &Material) -> Result<u32> {
 /// without the author having to hand-split the shapes that straddle the
 /// boundary. This is the one thing a vector source buys that a supplied PNG
 /// cannot: the renderer is ours, so the wrap can be synthesised.
+///
+/// The nine draws composite source-over, which makes the result exactly what
+/// painting the art across an infinite plane of adjacent tiles would give.
+/// That is the right model, and it is why the join is continuous — but it does
+/// mean a *translucent* shape wider than the whole tile overlaps itself, and
+/// so reads darker in the overhang band at each edge (measurably: a 50%-opaque
+/// band drawn from -10 to 110 in a 0..100 viewBox comes out 75% opaque in the
+/// outer 10%). The two bands abut across the join, so the tiling stays
+/// seamless in the strict sense; they are still a visible frame. Art that
+/// stays inside the viewBox is unaffected — `wrap_is_a_no_op_for_contained_art`
+/// pins that — and overhang narrower than the tile only ever lands on the
+/// opposite edge, where the centre cell drew nothing.
 ///
 /// Public so a consumer that already has SVG bytes and a resolved size/wrap —
 /// e.g. Studio's live viewport, which rasterizes on the fly outside the
@@ -308,6 +338,55 @@ mod tests {
         let plain = render_svg(HALF, 64, false).unwrap();
         let wrapped = render_svg(HALF, 64, true).unwrap();
         assert_eq!(plain, wrapped);
+    }
+
+    /// The overlap the source-over lattice implies, pinned so it can't drift
+    /// into an asymmetry: a translucent shape wider than the tile darkens by
+    /// the same amount at *both* edges, which is what keeps the join
+    /// continuous even though the band is visible.
+    #[test]
+    fn wrap_overlap_is_symmetric_across_the_join() {
+        const BAND: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <rect x="-10" y="0" width="120" height="100" fill="#ff0000" fill-opacity="0.5"/>
+        </svg>"##;
+        let img = decode(&render_svg(BAND, 64, true).unwrap());
+        let alpha = |x| img.get_pixel(x, 32).0[3];
+        assert_eq!(
+            alpha(0),
+            alpha(63),
+            "overhang bands must match across the join or the tile is not seamless"
+        );
+        assert!(
+            alpha(0) > alpha(32),
+            "self-overlap in the overhang band is expected; see render_svg's docs"
+        );
+    }
+
+    /// `texture_size` is documented as ignored by raster slots. It must stay
+    /// ignored even when a *different* material in the same scene pulls the
+    /// SVG pass into play — that coupling is invisible from the source.
+    #[test]
+    fn texture_size_is_unchecked_on_materials_without_an_svg() {
+        let mut scene = SceneGraph::new();
+        let mut raster = Material::new("raster");
+        raster.base_color_texture = Some(TextureRef::new(PathBuf::from("flat.png")));
+        raster.texture_size = Some(MAX_SVG_SIZE + 1);
+        let mut vector = Material::new("vector");
+        vector.base_color_texture = Some(TextureRef::new(PathBuf::from("tile.svg")));
+        scene.materials.push(raster);
+        scene.materials.push(vector);
+
+        let source = crate::texture::MapTextureSource::new(
+            [(PathBuf::from("tile.svg"), HALF.to_vec())].into_iter().collect(),
+        );
+        let out = rasterize_svg_textures(&scene, &source)
+            .expect("raster-only sizes are not checked")
+            .expect("the scene does reference an SVG");
+        assert_eq!(
+            out.scene.materials[0].base_color_texture.as_ref().unwrap().path,
+            PathBuf::from("flat.png"),
+            "the raster slot must be left exactly as it was"
+        );
     }
 
     #[test]

--- a/crates/mogen-export/src/svg.rs
+++ b/crates/mogen-export/src/svg.rs
@@ -1,0 +1,334 @@
+//! Rasterize `.svg` texture references into PNG before anything downstream
+//! looks at them.
+//!
+//! glTF 2.0 core defines exactly two embeddable image MIME types —
+//! `image/png` and `image/jpeg` — so an SVG can never ship as an SVG. Support
+//! therefore means rasterizing at build time, which suits `mogen` fine: it is
+//! an offline compiler and rasterization is a pure function of
+//! `(bytes, size, wrap)`.
+//!
+//! # Why this is a pass and not a decode branch
+//!
+//! The obvious place to put this is [`crate::texture::encode_for_slot`], next
+//! to the JPEG/oxipng policy. That would be wrong. Five separate consumers
+//! read a [`TextureRef`] path, and only one of them goes through that
+//! function:
+//!
+//! | consumer | reads |
+//! |---|---|
+//! | GLB embed | `encode_for_slot` |
+//! | FBX export | the **raw path** (`fbx/material.rs`) — a `.svg` would leak into the FBX |
+//! | Studio preview | its own loaders under `viewer/` |
+//! | PBR map derivation | `mogen-llm::pbr_maps`, which hard-codes `ImageFormat::Png` |
+//! | imposter bake | already-baked pixels; unaffected |
+//!
+//! Branching at decode time would need four separate fixes. Rewriting the
+//! path *before* export means every one of them only ever sees a PNG, and the
+//! derived-PBR pipeline picks up SVG albedo support for free.
+//!
+//! # No cache
+//!
+//! Rasterized bytes live in memory for the duration of the build and are
+//! handed to the exporter through [`OverlayTextureSource`]. Nothing is written
+//! to `MOGEN_CACHE_DIR`. That costs a re-render per build (milliseconds for
+//! the tile-sized art this is for) and buys portability — the pass works
+//! unchanged on wasm, where there is no filesystem to cache into — plus
+//! freedom from a whole category of staleness bugs. It matches the precedent
+//! set by the generated-texture pipeline in `mogen-llm`, which also declines
+//! to cache.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+
+use mogen_core::{Material, SceneGraph, TextureRef, DEFAULT_SVG_SIZE};
+
+use crate::texture::TextureSource;
+
+/// Upper bound on the rasterized edge length. 8192² RGBA is 256 MB before PNG
+/// compression, which is already well past anything a texture slot should be
+/// carrying; beyond it a typo in `texture_size` turns into an OOM rather than
+/// an error message.
+const MAX_SVG_SIZE: u32 = 8192;
+
+/// Does this path look like an SVG? Extension-based, matching how the rest of
+/// the exporter dispatches on format (`texture::mime_from_extension`).
+pub fn is_svg(path: &Path) -> bool {
+    path.extension()
+        .and_then(|s| s.to_str())
+        .is_some_and(|s| s.eq_ignore_ascii_case("svg"))
+}
+
+/// The synthetic path a rasterized SVG is republished under. Keeps a `.png`
+/// extension so extension-based MIME inference — the wasm embed path, which
+/// runs without the `image` crate — keeps working untouched. The size and wrap
+/// mode are in the stem so one SVG used at two sizes doesn't collide in the
+/// exporter's `(path, SlotKind)` dedup map.
+///
+/// The `.svg` extension is dropped rather than appended to. The exporter names
+/// each glTF image after its file stem, so keeping it would leave a
+/// `"name": "tile.svg.1024.raster"` in the output — a vector path in a file
+/// that provably contains none, which anything grepping the glTF would
+/// reasonably misread.
+fn raster_path(src: &Path, size: u32, wrap: bool) -> PathBuf {
+    let suffix = if wrap { "w" } else { "" };
+    let stem = src.with_extension("");
+    PathBuf::from(format!("{}.raster{size}{suffix}.png", stem.display()))
+}
+
+/// A scene with every `.svg` texture path rewritten, plus the PNG bytes those
+/// new paths resolve to.
+pub struct SvgRaster {
+    /// Copy of the input scene with SVG texture paths repointed at their
+    /// rasterized equivalents.
+    pub scene: SceneGraph,
+    /// `synthetic path -> PNG bytes`, to be layered over the caller's
+    /// [`TextureSource`] via [`OverlayTextureSource`].
+    pub images: HashMap<PathBuf, Vec<u8>>,
+}
+
+/// A [`TextureSource`] that answers from an in-memory map first and falls
+/// through to a base source otherwise. Lets rasterized SVGs and on-disk
+/// rasters coexist without the exporter knowing which is which.
+pub struct OverlayTextureSource<'a> {
+    base: &'a dyn TextureSource,
+    overlay: &'a HashMap<PathBuf, Vec<u8>>,
+}
+
+impl<'a> OverlayTextureSource<'a> {
+    pub fn new(base: &'a dyn TextureSource, overlay: &'a HashMap<PathBuf, Vec<u8>>) -> Self {
+        Self { base, overlay }
+    }
+}
+
+impl TextureSource for OverlayTextureSource<'_> {
+    fn read(&self, path: &Path) -> Result<Vec<u8>> {
+        match self.overlay.get(path) {
+            Some(bytes) => Ok(bytes.clone()),
+            None => self.base.read(path),
+        }
+    }
+}
+
+/// Rasterize every `.svg` texture referenced by `scene`'s materials.
+///
+/// Returns `Ok(None)` when the scene references no SVG at all — the common
+/// case, and worth detecting so an all-raster scene doesn't pay for a
+/// [`SceneGraph`] clone it has no use for.
+///
+/// Each unique `(path, size, wrap)` triple is rendered once even if several
+/// materials or slots share it.
+pub fn rasterize_svg_textures(
+    scene: &SceneGraph,
+    source: &dyn TextureSource,
+) -> Result<Option<SvgRaster>> {
+    if !scene.materials.iter().any(material_references_svg) {
+        return Ok(None);
+    }
+
+    let mut scene = scene.clone();
+    let mut images: HashMap<PathBuf, Vec<u8>> = HashMap::new();
+
+    for mat in &mut scene.materials {
+        let size = resolve_size(mat)?;
+        let wrap = mat.texture_wrap;
+        for slot in mat.texture_slots_mut() {
+            let Some(tex) = slot.as_ref() else { continue };
+            if !is_svg(&tex.path) {
+                continue;
+            }
+            let out = raster_path(&tex.path, size, wrap);
+            // Several materials can legitimately share one SVG; render once.
+            if !images.contains_key(&out) {
+                let svg = source.read(&tex.path)?;
+                let png = render_svg(&svg, size, wrap).with_context(|| {
+                    format!("rasterizing SVG texture {}", tex.path.display())
+                })?;
+                images.insert(out.clone(), png);
+            }
+            *slot = Some(TextureRef::new(out));
+        }
+    }
+
+    Ok(Some(SvgRaster { scene, images }))
+}
+
+fn material_references_svg(mat: &Material) -> bool {
+    // Mirrors `texture_slots_mut`'s slot list, read-only.
+    [
+        &mat.base_color_texture,
+        &mat.metallic_roughness_texture,
+        &mat.normal_texture,
+        &mat.occlusion_texture,
+        &mat.emissive_texture,
+    ]
+    .into_iter()
+    .flatten()
+    .any(|t| is_svg(&t.path))
+}
+
+fn resolve_size(mat: &Material) -> Result<u32> {
+    let size = mat.texture_size.unwrap_or(DEFAULT_SVG_SIZE);
+    if size == 0 || size > MAX_SVG_SIZE {
+        bail!(
+            "material \"{}\" sets texture_size = {size}, which is outside the \
+             supported range 1..={MAX_SVG_SIZE}",
+            mat.name
+        );
+    }
+    Ok(size)
+}
+
+/// Render SVG bytes to a square RGBA PNG of `size`².
+///
+/// The SVG's own viewBox is scaled to fill the target exactly — a
+/// non-square viewBox is stretched rather than letterboxed, because these are
+/// texture tiles addressed in UV space, where the aspect correction belongs to
+/// `uv_scale` and not to the image.
+///
+/// With `wrap` on, the tree is drawn nine times on a 3×3 lattice and the
+/// centre cell is kept. Artwork that overflows the viewBox therefore reappears
+/// on the opposite edge instead of being clipped, so a pattern tiles seamlessly
+/// without the author having to hand-split the shapes that straddle the
+/// boundary. This is the one thing a vector source buys that a supplied PNG
+/// cannot: the renderer is ours, so the wrap can be synthesised.
+fn render_svg(svg: &[u8], size: u32, wrap: bool) -> Result<Vec<u8>> {
+    // `usvg::Options` default carries no fontdb (the `text` feature is off in
+    // Cargo.toml), so this cannot depend on host-installed fonts.
+    let opts = usvg::Options::default();
+    let tree = usvg::Tree::from_data(svg, &opts).context("parsing SVG")?;
+
+    let vb = tree.size();
+    if vb.width() <= 0.0 || vb.height() <= 0.0 {
+        bail!("SVG has a zero-sized viewBox; nothing to rasterize");
+    }
+    let (sx, sy) = (size as f32 / vb.width(), size as f32 / vb.height());
+
+    let mut pixmap = resvg::tiny_skia::Pixmap::new(size, size)
+        .with_context(|| format!("allocating a {size}x{size} pixmap"))?;
+
+    let offsets: &[(f32, f32)] = if wrap {
+        &[
+            (-1.0, -1.0), (0.0, -1.0), (1.0, -1.0),
+            (-1.0, 0.0),  (0.0, 0.0),  (1.0, 0.0),
+            (-1.0, 1.0),  (0.0, 1.0),  (1.0, 1.0),
+        ]
+    } else {
+        &[(0.0, 0.0)]
+    };
+
+    for (dx, dy) in offsets {
+        let t = resvg::tiny_skia::Transform::from_translate(dx * size as f32, dy * size as f32)
+            .pre_scale(sx, sy);
+        resvg::render(&tree, t, &mut pixmap.as_mut());
+    }
+
+    pixmap.encode_png().context("encoding rasterized SVG to PNG")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A 100x100 viewBox with a red square covering the left half. Deliberately
+    /// asymmetric so a horizontal flip would be detectable.
+    const HALF: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+        <rect x="0" y="0" width="50" height="100" fill="#ff0000"/>
+    </svg>"##;
+
+    /// A circle centred on the left edge, so half of it falls outside the
+    /// viewBox. Under wrap it must reappear on the right edge.
+    const OVERHANG: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+        <circle cx="0" cy="50" r="20" fill="#00ff00"/>
+    </svg>"##;
+
+    fn decode(png: &[u8]) -> image::RgbaImage {
+        image::load_from_memory_with_format(png, image::ImageFormat::Png)
+            .expect("decoding rasterized PNG")
+            .to_rgba8()
+    }
+
+    #[test]
+    fn renders_at_requested_size() {
+        let png = render_svg(HALF, 64, false).unwrap();
+        let img = decode(&png);
+        assert_eq!(img.dimensions(), (64, 64));
+    }
+
+    #[test]
+    fn scales_viewbox_to_fill_target() {
+        // The red half should occupy the left half of the output regardless of
+        // the ratio between viewBox units and pixels.
+        let img = decode(&render_svg(HALF, 64, false).unwrap());
+        assert_eq!(img.get_pixel(10, 32).0[0], 255, "left half should be red");
+        assert_eq!(img.get_pixel(54, 32).0[3], 0, "right half should be empty");
+    }
+
+    /// The determinism guarantee the whole build reproducibility story rests
+    /// on: same input, byte-identical output.
+    #[test]
+    fn rasterization_is_deterministic() {
+        let a = render_svg(HALF, 128, false).unwrap();
+        let b = render_svg(HALF, 128, false).unwrap();
+        assert_eq!(a, b, "same SVG + size must produce identical bytes");
+    }
+
+    #[test]
+    fn wrap_brings_overhanging_art_back_on_the_far_edge() {
+        let plain = decode(&render_svg(OVERHANG, 64, false).unwrap());
+        let wrapped = decode(&render_svg(OVERHANG, 64, true).unwrap());
+
+        // Without wrap the right edge is empty; with wrap the clipped half of
+        // the circle reappears there.
+        assert_eq!(plain.get_pixel(63, 32).0[3], 0, "no wrap => right edge empty");
+        assert!(
+            wrapped.get_pixel(63, 32).0[3] > 0,
+            "wrap => clipped art reappears on the opposite edge"
+        );
+        // The left edge is unchanged either way.
+        assert!(plain.get_pixel(0, 32).0[1] > 0);
+        assert!(wrapped.get_pixel(0, 32).0[1] > 0);
+    }
+
+    /// Wrapping must be a no-op for art that stays inside the viewBox, so it
+    /// is safe to enable on any tile without changing its appearance.
+    #[test]
+    fn wrap_is_a_no_op_for_contained_art() {
+        let plain = render_svg(HALF, 64, false).unwrap();
+        let wrapped = render_svg(HALF, 64, true).unwrap();
+        assert_eq!(plain, wrapped);
+    }
+
+    #[test]
+    fn rejects_a_malformed_svg() {
+        assert!(render_svg(b"not an svg at all", 64, false).is_err());
+    }
+
+    #[test]
+    fn is_svg_is_case_insensitive_and_extension_based() {
+        assert!(is_svg(Path::new("a/b/tile.svg")));
+        assert!(is_svg(Path::new("TILE.SVG")));
+        assert!(!is_svg(Path::new("tile.png")));
+        assert!(!is_svg(Path::new("svg")));
+    }
+
+    #[test]
+    fn raster_paths_separate_sizes_and_wrap_modes() {
+        let p = Path::new("tile.svg");
+        let a = raster_path(p, 512, false);
+        let b = raster_path(p, 1024, false);
+        let c = raster_path(p, 512, true);
+        assert_ne!(a, b, "different sizes must not share a dedup key");
+        assert_ne!(a, c, "different wrap modes must not share a dedup key");
+        // Extension-based MIME inference must still see a PNG.
+        assert_eq!(a.extension().unwrap(), "png");
+        // No vector extension may survive into the name the exporter derives
+        // from this path.
+        assert!(
+            !a.to_string_lossy().contains(".svg"),
+            "raster path must not carry the source's .svg extension: {}",
+            a.display()
+        );
+    }
+}

--- a/crates/mogen-export/src/svg.rs
+++ b/crates/mogen-export/src/svg.rs
@@ -50,7 +50,7 @@ use crate::texture::TextureSource;
 /// compression, which is already well past anything a texture slot should be
 /// carrying; beyond it a typo in `texture_size` turns into an OOM rather than
 /// an error message.
-const MAX_SVG_SIZE: u32 = 8192;
+pub const MAX_SVG_SIZE: u32 = 8192;
 
 /// Does this path look like an SVG? Extension-based, matching how the rest of
 /// the exporter dispatches on format (`texture::mime_from_extension`).
@@ -131,7 +131,7 @@ pub fn rasterize_svg_textures(
     let mut images: HashMap<PathBuf, Vec<u8>> = HashMap::new();
 
     for mat in &mut scene.materials {
-        let size = resolve_size(mat)?;
+        let size = resolve_svg_size(mat)?;
         let wrap = mat.texture_wrap;
         for slot in mat.texture_slots_mut() {
             let Some(tex) = slot.as_ref() else { continue };
@@ -168,7 +168,12 @@ fn material_references_svg(mat: &Material) -> bool {
     .any(|t| is_svg(&t.path))
 }
 
-fn resolve_size(mat: &Material) -> Result<u32> {
+/// Resolve a material's `texture_size` to the pixel edge length its `.svg`
+/// slots rasterize to, applying [`DEFAULT_SVG_SIZE`] when unset and rejecting
+/// anything outside `1..=MAX_SVG_SIZE`. Exposed so other consumers of a raw
+/// `Material` — e.g. MoGen Studio's live viewport, which rasterizes textures
+/// outside the export pipeline — resolve the same size the exporter would.
+pub fn resolve_svg_size(mat: &Material) -> Result<u32> {
     let size = mat.texture_size.unwrap_or(DEFAULT_SVG_SIZE);
     if size == 0 || size > MAX_SVG_SIZE {
         bail!(
@@ -193,7 +198,12 @@ fn resolve_size(mat: &Material) -> Result<u32> {
 /// without the author having to hand-split the shapes that straddle the
 /// boundary. This is the one thing a vector source buys that a supplied PNG
 /// cannot: the renderer is ours, so the wrap can be synthesised.
-fn render_svg(svg: &[u8], size: u32, wrap: bool) -> Result<Vec<u8>> {
+///
+/// Public so a consumer that already has SVG bytes and a resolved size/wrap —
+/// e.g. Studio's live viewport, which rasterizes on the fly outside the
+/// export pipeline — can call the same renderer [`rasterize_svg_textures`] uses
+/// rather than re-implementing it.
+pub fn render_svg(svg: &[u8], size: u32, wrap: bool) -> Result<Vec<u8>> {
     // `usvg::Options` default carries no fontdb (the `text` feature is off in
     // Cargo.toml), so this cannot depend on host-installed fonts.
     let opts = usvg::Options::default();
@@ -330,5 +340,41 @@ mod tests {
             "raster path must not carry the source's .svg extension: {}",
             a.display()
         );
+    }
+
+    #[test]
+    fn resolve_svg_size_uses_the_default_when_unset() {
+        let mat = Material::new("m");
+        assert_eq!(resolve_svg_size(&mat).unwrap(), DEFAULT_SVG_SIZE);
+    }
+
+    #[test]
+    fn resolve_svg_size_rejects_zero() {
+        let mut mat = Material::new("m");
+        mat.texture_size = Some(0);
+        let err = resolve_svg_size(&mat).unwrap_err();
+        assert!(format!("{err:#}").contains("texture_size"));
+    }
+
+    #[test]
+    fn resolve_svg_size_rejects_above_the_max() {
+        let mut mat = Material::new("blowup");
+        mat.texture_size = Some(MAX_SVG_SIZE + 1);
+        let err = resolve_svg_size(&mat).unwrap_err();
+        let msg = format!("{err:#}");
+        // Names the offending material so a multi-material scene's error is
+        // actionable, and the bound itself so the fix is obvious.
+        assert!(msg.contains("blowup"), "should name the material: {msg}");
+        assert!(
+            msg.contains(&MAX_SVG_SIZE.to_string()),
+            "should name the bound: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_svg_size_accepts_the_max_exactly() {
+        let mut mat = Material::new("m");
+        mat.texture_size = Some(MAX_SVG_SIZE);
+        assert_eq!(resolve_svg_size(&mat).unwrap(), MAX_SVG_SIZE);
     }
 }

--- a/crates/mogen-export/src/writer.rs
+++ b/crates/mogen-export/src/writer.rs
@@ -149,6 +149,24 @@ fn build_glb_with_options_and_source_inner<F: Fn(&str)>(
         None => (scene, texture_source),
     };
 
+    // The imposter bake (below) reads texture bytes straight off disk via
+    // `mogen_render`'s own GL loader, which has no `TextureSource` hook and
+    // therefore can't see the in-memory bytes the pass above just produced —
+    // it would instead try to open the synthetic `*.rasterNNNw.png` path,
+    // which never touches disk. Fail with a clear, specific message here
+    // rather than let that surface as a confusing "file not found". Only
+    // applies when we're about to bake internally: a caller-supplied
+    // `prebaked_imposter` (Studio's export flow) skips the bake entirely.
+    #[cfg(all(feature = "imposter", feature = "textures-svg"))]
+    if opts.bundle_lods_and_imposter && svg_owned.is_some() && prebaked_imposter.is_none() {
+        anyhow::bail!(
+            "bundle_lods_and_imposter does not yet support `.svg` textures: \
+             the imposter bake reads texture files directly and can't \
+             rasterize SVG. Pre-rasterize the texture to `.png`, or disable \
+             one of the two options."
+        );
+    }
+
     // Two-stage merge. First, the scoped `solid` pass runs whenever the scene
     // carries any `"solid"`-tagged nodes (opt-in from the DSL — no flag
     // needed). Its clone is skipped if no solid groups are present. Then, if

--- a/crates/mogen-export/src/writer.rs
+++ b/crates/mogen-export/src/writer.rs
@@ -126,6 +126,29 @@ fn build_glb_with_options_and_source_inner<F: Fn(&str)>(
     #[cfg(feature = "imposter")] prebaked_imposter: Option<ImposterAtlas>,
     progress: F,
 ) -> Result<Vec<u8>> {
+    // SVG textures rasterize to PNG up front, before the merge stages or the
+    // exporter look at any material, so nothing downstream ever sees a vector
+    // path. See `crate::svg` for why this is a pre-pass rather than a branch
+    // in the decode path. Costs nothing (not even a clone) when the scene
+    // references no SVG, which is the common case.
+    #[cfg(feature = "textures-svg")]
+    let svg_owned = if opts.include_textures {
+        crate::svg::rasterize_svg_textures(scene, texture_source)?
+    } else {
+        None
+    };
+    #[cfg(feature = "textures-svg")]
+    let svg_overlay;
+    #[cfg(feature = "textures-svg")]
+    let (scene, texture_source): (&SceneGraph, &dyn TextureSource) = match &svg_owned {
+        Some(r) => {
+            progress("rasterizing SVG textures");
+            svg_overlay = crate::svg::OverlayTextureSource::new(texture_source, &r.images);
+            (&r.scene, &svg_overlay)
+        }
+        None => (scene, texture_source),
+    };
+
     // Two-stage merge. First, the scoped `solid` pass runs whenever the scene
     // carries any `"solid"`-tagged nodes (opt-in from the DSL — no flag
     // needed). Its clone is skipped if no solid groups are present. Then, if

--- a/crates/mogen-export/tests/svg_textures.rs
+++ b/crates/mogen-export/tests/svg_textures.rs
@@ -247,6 +247,73 @@ fn raster_only_scenes_are_untouched() {
     let _ = fs::remove_file(&png_path);
 }
 
+/// A `texture_size` past the exporter's cap must fail the build with a
+/// message naming the material and the bound, not silently clamp or OOM
+/// trying to allocate the requested pixmap.
+#[test]
+fn oversized_texture_size_fails_the_build_with_a_useful_message() {
+    let svg_path = unique_tmp("oversized.svg");
+    fs::write(&svg_path, TILE_SVG).expect("writing svg fixture");
+
+    let mut mat = Material::new("blowup");
+    mat.base_color_texture = Some(TextureRef::new(svg_path.clone()));
+    mat.texture_size = Some(mogen_export::MAX_SVG_SIZE + 1);
+
+    let mut scene = SceneGraph::new();
+    let mat_id = scene.add_material(mat);
+    let n = scene.add_root("box", "box", Transform::IDENTITY);
+    scene.set_mesh(n, box_mesh([1.0, 1.0, 1.0], UvMode::default()));
+    scene.set_material(n, mat_id);
+
+    let out = unique_tmp("oversized.glb");
+    let err = mogen_export::write_glb(&scene, &out).expect_err("oversized texture_size must fail");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("blowup"), "error should name the material, got: {msg}");
+    assert!(
+        msg.contains("texture_size"),
+        "error should name the attribute, got: {msg}"
+    );
+
+    let _ = fs::remove_file(&svg_path);
+    let _ = fs::remove_file(&out);
+}
+
+/// `bundle_lods_and_imposter`'s bake reads texture files straight off disk
+/// through a separate GL renderer that never sees the SVG pre-pass's
+/// in-memory raster — combining the two must fail fast with an explanatory
+/// message instead of a confusing "file not found" once the bake reaches the
+/// synthetic raster path. No display required: the guard fires before the GL
+/// bake would even start.
+#[test]
+#[cfg(feature = "imposter")]
+fn svg_with_bundled_imposter_fails_with_a_clear_message() {
+    let svg_path = unique_tmp("imposter.svg");
+    fs::write(&svg_path, TILE_SVG).expect("writing svg fixture");
+
+    let mut mat = Material::new("vector");
+    mat.base_color_texture = Some(TextureRef::new(svg_path.clone()));
+
+    let mut scene = SceneGraph::new();
+    let mat_id = scene.add_material(mat);
+    let n = scene.add_root("box", "box", Transform::IDENTITY);
+    scene.set_mesh(n, box_mesh([1.0, 1.0, 1.0], UvMode::default()));
+    scene.set_material(n, mat_id);
+
+    let opts = mogen_export::ExportOptions {
+        bundle_lods_and_imposter: true,
+        ..Default::default()
+    };
+    let err = mogen_export::build_glb_with_options(&scene, &opts, |_| {})
+        .expect_err("svg + bundle_lods_and_imposter must fail, not silently mis-bake");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("bundle_lods_and_imposter") && msg.contains("svg"),
+        "error should name both the option and the format, got: {msg}"
+    );
+
+    let _ = fs::remove_file(&svg_path);
+}
+
 /// A broken SVG must fail the build with a message naming the file, not
 /// silently export a material with no texture.
 #[test]

--- a/crates/mogen-export/tests/svg_textures.rs
+++ b/crates/mogen-export/tests/svg_textures.rs
@@ -1,0 +1,275 @@
+//! End-to-end coverage of the `.svg` texture path.
+//!
+//! glTF cannot carry SVG, so support means rasterizing at build time. These
+//! tests pin the observable contract: a scene referencing an `.svg` produces a
+//! GLB whose embedded image is real raster of the requested size, the
+//! rasterization is reproducible, `texture_size` is honoured per material, and
+//! nothing about the raster path regressed.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::id;
+
+use serde_json::Value;
+
+use mogen_core::{Material, SceneGraph, TextureRef, Transform, UvMode};
+use mogen_geom::box_mesh;
+
+/// A 100x100 tile: red left half. Asymmetric so orientation errors show up.
+const TILE_SVG: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect x="0" y="0" width="50" height="100" fill="#ff0000"/>
+    <rect x="50" y="0" width="50" height="100" fill="#0000ff"/>
+</svg>"##;
+
+fn unique_tmp(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("mogen-svg-export-{}-{name}", id()))
+}
+
+fn read_glb(bytes: &[u8]) -> (Value, Vec<u8>) {
+    assert_eq!(&bytes[0..4], b"glTF", "not a GLB");
+    let json_len = u32::from_le_bytes(bytes[12..16].try_into().unwrap()) as usize;
+    let js: Value =
+        serde_json::from_slice(&bytes[20..20 + json_len]).expect("invalid GLB JSON chunk");
+    let bin_start = 20 + json_len;
+    let bin_len = u32::from_le_bytes(bytes[bin_start..bin_start + 4].try_into().unwrap()) as usize;
+    let bin = bytes[bin_start + 8..bin_start + 8 + bin_len].to_vec();
+    (js, bin)
+}
+
+fn image_bytes(js: &Value, bin: &[u8], image_idx: usize) -> Vec<u8> {
+    let bv_idx = js["images"][image_idx]["bufferView"].as_u64().unwrap() as usize;
+    let bv = &js["bufferViews"][bv_idx];
+    let offset = bv["byteOffset"].as_u64().unwrap_or(0) as usize;
+    let length = bv["byteLength"].as_u64().unwrap() as usize;
+    bin[offset..offset + length].to_vec()
+}
+
+/// Build a one-box scene whose material carries `mat`, export it, return the GLB.
+fn export_with(mat: Material, out_name: &str) -> Vec<u8> {
+    let mut scene = SceneGraph::new();
+    let mat_id = scene.add_material(mat);
+    let node = scene.add_root("box", "box", Transform::IDENTITY);
+    scene.set_mesh(node, box_mesh([1.0, 1.0, 1.0], UvMode::default()));
+    scene.set_material(node, mat_id);
+
+    let out = unique_tmp(out_name);
+    mogen_export::write_glb(&scene, &out).expect("write_glb");
+    let bytes = fs::read(&out).expect("reading produced glb");
+    let _ = fs::remove_file(&out);
+    bytes
+}
+
+#[test]
+fn svg_albedo_rasterizes_and_embeds_as_raster() {
+    let svg_path = unique_tmp("tile.svg");
+    fs::write(&svg_path, TILE_SVG).expect("writing svg fixture");
+
+    let mut mat = Material::new("vector");
+    mat.base_color_texture = Some(TextureRef::new(svg_path.clone()));
+    mat.texture_size = Some(64);
+    let bytes = export_with(mat, "svg_albedo.glb");
+    let (js, bin) = read_glb(&bytes);
+
+    let images = js["images"].as_array().expect("images[]");
+    assert_eq!(images.len(), 1, "one image for the one SVG");
+
+    // The GLB must carry a spec-legal raster MIME — never anything SVG-ish.
+    let mime = images[0]["mimeType"].as_str().unwrap();
+    assert!(
+        mime == "image/png" || mime == "image/jpeg",
+        "embedded MIME must be a glTF core image type, got {mime}"
+    );
+
+    // And it must be genuinely decodable raster at the size we asked for.
+    let embedded = image_bytes(&js, &bin, 0);
+    let img = image::load_from_memory(&embedded).expect("embedded image must decode");
+    assert_eq!(img.width(), 64, "rasterized to the requested texture_size");
+    assert_eq!(img.height(), 64);
+
+    // Material wiring survives the path rewrite.
+    assert_eq!(
+        js["materials"][0]["pbrMetallicRoughness"]["baseColorTexture"]["index"],
+        0
+    );
+
+    // The output must be self-contained: every image resolves to a bufferView,
+    // and no trace of the vector source is left anywhere in the glTF JSON —
+    // including the image `name`, which the exporter derives from the stem.
+    assert!(images[0].get("bufferView").is_some());
+    assert!(
+        !serde_json::to_string(&js).unwrap().contains(".svg"),
+        "no .svg reference may survive into the exported glTF"
+    );
+
+    let _ = fs::remove_file(&svg_path);
+}
+
+#[test]
+fn texture_size_controls_the_raster_resolution() {
+    let svg_path = unique_tmp("sized.svg");
+    fs::write(&svg_path, TILE_SVG).expect("writing svg fixture");
+
+    for size in [32u32, 256] {
+        let mut mat = Material::new("vector");
+        mat.base_color_texture = Some(TextureRef::new(svg_path.clone()));
+        mat.texture_size = Some(size);
+        let bytes = export_with(mat, &format!("sized{size}.glb"));
+        let (js, bin) = read_glb(&bytes);
+        let img = image::load_from_memory(&image_bytes(&js, &bin, 0)).expect("decodes");
+        assert_eq!(img.width(), size, "texture_size = {size} should be honoured");
+    }
+
+    let _ = fs::remove_file(&svg_path);
+}
+
+/// The default must apply when the material says nothing — and it must be the
+/// documented constant, not an accident of the renderer.
+#[test]
+fn omitting_texture_size_uses_the_documented_default() {
+    let svg_path = unique_tmp("default.svg");
+    fs::write(&svg_path, TILE_SVG).expect("writing svg fixture");
+
+    let mut mat = Material::new("vector");
+    mat.base_color_texture = Some(TextureRef::new(svg_path.clone()));
+    let bytes = export_with(mat, "default.glb");
+    let (js, bin) = read_glb(&bytes);
+    let img = image::load_from_memory(&image_bytes(&js, &bin, 0)).expect("decodes");
+    assert_eq!(img.width(), mogen_core::DEFAULT_SVG_SIZE);
+
+    let _ = fs::remove_file(&svg_path);
+}
+
+/// Build reproducibility: the same scene must export byte-identically. This is
+/// the guarantee that lets rasterization stay uncached.
+#[test]
+fn svg_export_is_reproducible() {
+    let svg_path = unique_tmp("repro.svg");
+    fs::write(&svg_path, TILE_SVG).expect("writing svg fixture");
+
+    let build = || {
+        let mut mat = Material::new("vector");
+        mat.base_color_texture = Some(TextureRef::new(svg_path.clone()));
+        mat.texture_size = Some(64);
+        export_with(mat, "repro.glb")
+    };
+    assert_eq!(build(), build(), "same scene must export byte-identically");
+
+    let _ = fs::remove_file(&svg_path);
+}
+
+/// Two materials sharing one SVG at one size should render it once and dedupe
+/// to a single embedded image, exactly as two materials sharing a PNG do.
+#[test]
+fn shared_svg_dedupes_to_one_image() {
+    let svg_path = unique_tmp("shared.svg");
+    fs::write(&svg_path, TILE_SVG).expect("writing svg fixture");
+
+    let mut scene = SceneGraph::new();
+    for name in ["a", "b"] {
+        let mut m = Material::new(name);
+        m.base_color_texture = Some(TextureRef::new(svg_path.clone()));
+        m.texture_size = Some(32);
+        let id = scene.add_material(m);
+        let n = scene.add_root(name, "box", Transform::IDENTITY);
+        scene.set_mesh(n, box_mesh([1.0, 1.0, 1.0], UvMode::default()));
+        scene.set_material(n, id);
+    }
+
+    let out = unique_tmp("shared.glb");
+    mogen_export::write_glb(&scene, &out).expect("write_glb");
+    let bytes = fs::read(&out).expect("reading glb");
+    let (js, _) = read_glb(&bytes);
+    assert_eq!(
+        js["images"].as_array().unwrap().len(),
+        1,
+        "one SVG at one size should rasterize and embed once"
+    );
+
+    let _ = fs::remove_file(&svg_path);
+    let _ = fs::remove_file(&out);
+}
+
+/// The same SVG at two different sizes must *not* collide in the exporter's
+/// dedup map — otherwise one material silently gets the other's resolution.
+#[test]
+fn same_svg_at_two_sizes_produces_two_images() {
+    let svg_path = unique_tmp("twosize.svg");
+    fs::write(&svg_path, TILE_SVG).expect("writing svg fixture");
+
+    let mut scene = SceneGraph::new();
+    for (name, size) in [("small", 32u32), ("large", 128)] {
+        let mut m = Material::new(name);
+        m.base_color_texture = Some(TextureRef::new(svg_path.clone()));
+        m.texture_size = Some(size);
+        let id = scene.add_material(m);
+        let n = scene.add_root(name, "box", Transform::IDENTITY);
+        scene.set_mesh(n, box_mesh([1.0, 1.0, 1.0], UvMode::default()));
+        scene.set_material(n, id);
+    }
+
+    let out = unique_tmp("twosize.glb");
+    mogen_export::write_glb(&scene, &out).expect("write_glb");
+    let bytes = fs::read(&out).expect("reading glb");
+    let (js, bin) = read_glb(&bytes);
+
+    let images = js["images"].as_array().unwrap();
+    assert_eq!(images.len(), 2, "distinct sizes must not share one embed");
+    let mut widths: Vec<u32> = (0..2)
+        .map(|i| image::load_from_memory(&image_bytes(&js, &bin, i)).unwrap().width())
+        .collect();
+    widths.sort();
+    assert_eq!(widths, vec![32, 128]);
+
+    let _ = fs::remove_file(&svg_path);
+    let _ = fs::remove_file(&out);
+}
+
+/// A scene with no SVG at all must be completely unaffected by the pass.
+#[test]
+fn raster_only_scenes_are_untouched() {
+    let png_path = unique_tmp("plain.png");
+    let img: image::RgbImage = image::ImageBuffer::from_pixel(4, 4, image::Rgb([10, 20, 30]));
+    let mut png = Vec::new();
+    img.write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
+        .expect("encoding png fixture");
+    fs::write(&png_path, &png).expect("writing png fixture");
+
+    let mut mat = Material::new("raster");
+    mat.base_color_texture = Some(TextureRef::new(png_path.clone()));
+    let bytes = export_with(mat, "raster.glb");
+    let (js, _) = read_glb(&bytes);
+    assert_eq!(js["images"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        js["materials"][0]["pbrMetallicRoughness"]["baseColorTexture"]["index"],
+        0
+    );
+
+    let _ = fs::remove_file(&png_path);
+}
+
+/// A broken SVG must fail the build with a message naming the file, not
+/// silently export a material with no texture.
+#[test]
+fn malformed_svg_fails_the_build_with_a_useful_message() {
+    let svg_path = unique_tmp("broken.svg");
+    fs::write(&svg_path, b"<not-an-svg").expect("writing broken fixture");
+
+    let mut scene = SceneGraph::new();
+    let mut mat = Material::new("bad");
+    mat.base_color_texture = Some(TextureRef::new(svg_path.clone()));
+    let mat_id = scene.add_material(mat);
+    let n = scene.add_root("box", "box", Transform::IDENTITY);
+    scene.set_mesh(n, box_mesh([1.0, 1.0, 1.0], UvMode::default()));
+    scene.set_material(n, mat_id);
+
+    let out = unique_tmp("broken.glb");
+    let err = mogen_export::write_glb(&scene, &out).expect_err("malformed SVG must fail");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("broken.svg"),
+        "error should name the offending file, got: {msg}"
+    );
+
+    let _ = fs::remove_file(&svg_path);
+    let _ = fs::remove_file(&out);
+}

--- a/crates/mogen-studio/Cargo.toml
+++ b/crates/mogen-studio/Cargo.toml
@@ -40,7 +40,7 @@ mogen-core = { workspace = true }
 mogen-dsl = { workspace = true, features = ["csg"] }
 mogen-binary = { workspace = true }
 mogen-validate = { workspace = true, features = ["csg"] }
-mogen-export = { workspace = true, features = ["textures", "merge", "lod", "imposter"] }
+mogen-export = { workspace = true, features = ["textures", "textures-svg", "merge", "lod", "imposter"] }
 # Studio runs the headless yaw-grid imposter bake against its own live GL
 # context — eframe owns the only winit `EventLoop` in the process, so the
 # CLI's `with_gl_context` path is unavailable. We call

--- a/crates/mogen-studio/src/viewer/flatten.rs
+++ b/crates/mogen-studio/src/viewer/flatten.rs
@@ -29,6 +29,13 @@ pub struct DrawBatch {
     pub normal_texture: Option<PathBuf>,
     pub occlusion_texture: Option<PathBuf>,
     pub emissive_texture: Option<PathBuf>,
+    /// Source material's `texture_size` / `texture_wrap`, copied through so
+    /// `.svg` texture slots rasterize at the author's requested resolution in
+    /// the live viewport too, not just in `mogen build`'s real export. Inert
+    /// for raster (`.png`/`.jpg`) slots. `None` size means "use the exporter's
+    /// default" — see `mogen_export::resolve_svg_size`.
+    pub texture_size: Option<u32>,
+    pub texture_wrap: bool,
     /// PBR scalars copied off the source `Material`. Multiplied with their
     /// corresponding texture (when present) inside the fragment shader.
     pub base_color: [f32; 3],
@@ -487,6 +494,8 @@ pub fn flatten_with_worlds(
                 normal_texture,
                 occlusion_texture,
                 emissive_texture,
+                texture_size,
+                texture_wrap,
                 base_color,
                 base_color_alpha,
                 metallic,
@@ -506,6 +515,8 @@ pub fn flatten_with_worlds(
                     m.normal_texture.as_ref().map(resolve),
                     m.occlusion_texture.as_ref().map(resolve),
                     m.emissive_texture.as_ref().map(resolve),
+                    m.texture_size,
+                    m.texture_wrap,
                     [m.base_color[0], m.base_color[1], m.base_color[2]],
                     m.base_color[3],
                     m.metallic,
@@ -525,6 +536,8 @@ pub fn flatten_with_worlds(
                     None,
                     None,
                     None,
+                    None,
+                    false,
                     [0.78, 0.78, 0.78],
                     1.0,
                     0.0,
@@ -559,6 +572,8 @@ pub fn flatten_with_worlds(
                 normal_texture,
                 occlusion_texture,
                 emissive_texture,
+                texture_size,
+                texture_wrap,
                 base_color,
                 base_color_alpha,
                 metallic,

--- a/crates/mogen-studio/src/viewer/gl_util.rs
+++ b/crates/mogen-studio/src/viewer/gl_util.rs
@@ -115,19 +115,43 @@ pub(super) unsafe fn max_anisotropy(gl: &glow::Context) -> Option<f32> {
     Some(hw.clamp(1.0, 16.0))
 }
 
-/// Read a PNG from disk, decode to 8-bit RGBA, and upload as a 2D texture.
-/// `srgb` selects the internal format: `SRGB8_ALPHA8` for colour data so the
-/// hardware linearises on sample, `RGBA8` for data maps (normal/MR/AO/etc.)
-/// where the bytes are already linear and any conversion would corrupt them.
-/// Wraps mode is REPEAT (matches the tileable-albedo intent of the textures
-/// pipeline) and mips are generated for trilinear minification.
+/// Read an image (raster or `.svg`) from disk, decode/rasterize to 8-bit
+/// RGBA, and upload as a 2D texture. `srgb` selects the internal format:
+/// `SRGB8_ALPHA8` for colour data so the hardware linearises on sample,
+/// `RGBA8` for data maps (normal/MR/AO/etc.) where the bytes are already
+/// linear and any conversion would corrupt them. Wraps mode is REPEAT
+/// (matches the tileable-albedo intent of the textures pipeline) and mips
+/// are generated for trilinear minification.
+///
+/// `svg_size`/`svg_wrap` mirror the source material's `texture_size` /
+/// `texture_wrap` and are consulted only when `path` is a `.svg` — the real
+/// export pipeline (`mogen_export::rasterize_svg_textures`) is the
+/// authoritative rasterizer; this lets the live viewport match it instead of
+/// failing to decode a vector file as if it were raster.
 pub(super) unsafe fn try_load_texture(
     gl: &glow::Context,
     path: &Path,
     srgb: bool,
+    svg_size: Option<u32>,
+    svg_wrap: bool,
 ) -> anyhow::Result<glow::Texture> {
     let bytes = std::fs::read(path)
         .map_err(|e| anyhow::anyhow!("read {}: {e}", path.display()))?;
+    let bytes = if mogen_export::is_svg(path) {
+        let size = svg_size.unwrap_or(mogen_core::DEFAULT_SVG_SIZE);
+        if size == 0 || size > mogen_export::MAX_SVG_SIZE {
+            anyhow::bail!(
+                "{} sets texture_size = {size}, which is outside the supported \
+                 range 1..={}",
+                path.display(),
+                mogen_export::MAX_SVG_SIZE
+            );
+        }
+        mogen_export::render_svg(&bytes, size, svg_wrap)
+            .map_err(|e| anyhow::anyhow!("rasterizing {}: {e}", path.display()))?
+    } else {
+        bytes
+    };
     let img = image::load_from_memory(&bytes)
         .map_err(|e| anyhow::anyhow!("decode {}: {e}", path.display()))?
         .to_rgba8();

--- a/crates/mogen-studio/src/viewer/renderer/draw.rs
+++ b/crates/mogen-studio/src/viewer/renderer/draw.rs
@@ -206,26 +206,28 @@ impl Renderer {
         self.draw_textures.clear();
         self.draw_textures.reserve(self.batches.len());
         for i in 0..self.batches.len() {
+            let svg_size = self.batches[i].texture_size;
+            let svg_wrap = self.batches[i].texture_wrap;
             let base = self.batches[i]
                 .base_color_texture
                 .clone()
-                .and_then(|p| self.ensure_texture(gl, &p, true));
+                .and_then(|p| self.ensure_texture(gl, &p, true, svg_size, svg_wrap));
             let mr = self.batches[i]
                 .metallic_roughness_texture
                 .clone()
-                .and_then(|p| self.ensure_texture(gl, &p, false));
+                .and_then(|p| self.ensure_texture(gl, &p, false, svg_size, svg_wrap));
             let normal = self.batches[i]
                 .normal_texture
                 .clone()
-                .and_then(|p| self.ensure_texture(gl, &p, false));
+                .and_then(|p| self.ensure_texture(gl, &p, false, svg_size, svg_wrap));
             let ao = self.batches[i]
                 .occlusion_texture
                 .clone()
-                .and_then(|p| self.ensure_texture(gl, &p, false));
+                .and_then(|p| self.ensure_texture(gl, &p, false, svg_size, svg_wrap));
             let emissive = self.batches[i]
                 .emissive_texture
                 .clone()
-                .and_then(|p| self.ensure_texture(gl, &p, true));
+                .and_then(|p| self.ensure_texture(gl, &p, true, svg_size, svg_wrap));
             self.draw_textures.push([base, mr, normal, ao, emissive]);
         }
 

--- a/crates/mogen-studio/src/viewer/renderer/textures.rs
+++ b/crates/mogen-studio/src/viewer/renderer/textures.rs
@@ -22,24 +22,31 @@ pub(super) struct CachedTexture {
 }
 
 impl Renderer {
-    /// Look up a texture in the cache, decoding the PNG and uploading on the
-    /// first miss. `srgb` selects the GPU storage format: albedo and emissive
-    /// maps need sRGB so the GL pipeline linearises them on read; metallic-
-    /// roughness, normal, and AO maps store data, not colour, and must be
-    /// linear. Re-loads when the file's mtime changes so regenerated PNGs
-    /// (e.g. after `Generate Textures`) become visible without restarting.
-    /// Returns `None` for paths that fail to load — the caller falls back to
-    /// the corresponding scalar uniform.
+    /// Look up a texture in the cache, decoding (or, for `.svg`, rasterizing)
+    /// and uploading on the first miss. `srgb` selects the GPU storage
+    /// format: albedo and emissive maps need sRGB so the GL pipeline
+    /// linearises them on read; metallic-roughness, normal, and AO maps
+    /// store data, not colour, and must be linear. Re-loads when the file's
+    /// mtime changes so regenerated PNGs (e.g. after `Generate Textures`)
+    /// become visible without restarting. `svg_size`/`svg_wrap` are the
+    /// source material's `texture_size`/`texture_wrap` and only affect
+    /// `.svg` paths — included in the cache key so the same SVG referenced
+    /// at two resolutions (e.g. two materials sharing one file) doesn't
+    /// serve one material's raster to the other. Returns `None` for paths
+    /// that fail to load — the caller falls back to the corresponding
+    /// scalar uniform.
     pub(super) fn ensure_texture(
         &mut self,
         gl: &glow::Context,
         path: &Path,
         srgb: bool,
+        svg_size: Option<u32>,
+        svg_wrap: bool,
     ) -> Option<glow::Texture> {
         let mtime = std::fs::metadata(path)
             .and_then(|m| m.modified())
             .ok();
-        let key = (path.to_path_buf(), srgb);
+        let key = (path.to_path_buf(), srgb, svg_size, svg_wrap);
 
         if let Some(cached) = self.texture_cache.get(&key) {
             if cached.mtime == mtime {
@@ -51,7 +58,7 @@ impl Renderer {
             }
         }
 
-        let texture = match unsafe { try_load_texture(gl, path, srgb) } {
+        let texture = match unsafe { try_load_texture(gl, path, srgb, svg_size, svg_wrap) } {
             Ok(t) => Some(t),
             Err(e) => {
                 eprintln!("viewer: texture load failed for {}: {e}", path.display());
@@ -81,10 +88,10 @@ impl Renderer {
                 }
             }
         }
-        let stale: Vec<(PathBuf, bool)> = self
+        let stale: Vec<TextureCacheKey> = self
             .texture_cache
             .keys()
-            .filter(|(p, _)| !alive.contains(p))
+            .filter(|(p, ..)| !alive.contains(p))
             .cloned()
             .collect();
         for k in stale {
@@ -97,4 +104,9 @@ impl Renderer {
     }
 }
 
-pub(super) type TextureCache = HashMap<(PathBuf, bool), CachedTexture>;
+/// `(path, srgb, svg_size, svg_wrap)`. The last two are inert for raster
+/// textures but must be part of the key so one `.svg` shared by two
+/// materials at different `texture_size`s gets two cached uploads, not a
+/// clobbered one.
+pub(super) type TextureCacheKey = (PathBuf, bool, Option<u32>, bool);
+pub(super) type TextureCache = HashMap<TextureCacheKey, CachedTexture>;

--- a/crates/mogen-validate/src/ast_checks/schema.rs
+++ b/crates/mogen-validate/src/ast_checks/schema.rs
@@ -278,6 +278,7 @@ pub fn attrs_for_kind(kind: &str) -> &'static [&'static str] {
             "transmission",
             "double_sided",
             "uv_mode", "uv_scale",
+            "texture_size", "texture_wrap",
             "shader",
             "base_color_texture", "metallic_roughness_texture",
             "normal_texture", "occlusion_texture", "emissive_texture",
@@ -674,7 +675,9 @@ pub(super) fn attr_type(kind: &str, attr: &str) -> Option<&'static str> {
         | ("material", "alpha_cutoff")
         | ("material", "emissive_strength")
         | ("material", "transmission")
-        | ("material", "double_sided") => "number",
+        | ("material", "double_sided")
+        | ("material", "texture_size")
+        | ("material", "texture_wrap") => "number",
         ("coil", "handedness") => "string",
         ("material", "color") | ("material", "emissive") => "vec3",
         ("material", "alpha_mode") | ("material", "uv_mode") | ("material", "shader") => "string",

--- a/crates/mogen-wasm/src/lib.rs
+++ b/crates/mogen-wasm/src/lib.rs
@@ -27,15 +27,19 @@
 //! same input — no BSP-vs-Manifold divergence. Build host requires LLVM
 //! 20+ (see workspace README for setup).
 //!
-//! ## Texture support
+//! ## Binary asset support
 //!
-//! `compile_files` takes a second `Map<string, Uint8Array>` of texture
-//! bytes keyed by the path the `.mog` source references (e.g.
-//! `"textures/wood/albedo.png"`). The exporter embeds those bytes as-is —
-//! no `image` / `oxipng` linkage, so the wasm artifact stays small and
-//! avoids C deps that don't cross-compile. Desktop builds re-encode +
-//! oxipng-shrink via the `textures-optimize` feature, but that's gated off
-//! here, so authors should publish PNG/JPEG already sized for the web.
+//! `compile_files` takes a second `Map<string, Uint8Array>` of asset bytes
+//! keyed by the path the `.mog` source references (e.g.
+//! `"textures/wood/albedo.png"`). It backs both `texture = "…"` and
+//! `mesh (src="…")` — the latter through `JsLoader::load_binary`, because
+//! the browser has no filesystem for that method's default impl to read.
+//!
+//! Texture bytes are embedded as-is: no `image` / `oxipng` linkage, so the
+//! wasm artifact stays small and avoids C deps that don't cross-compile.
+//! Desktop builds re-encode + oxipng-shrink via the `textures-optimize`
+//! feature, but that's gated off here, so authors should publish PNG/JPEG
+//! already sized for the web.
 //!
 //! ## Still disabled
 //!
@@ -127,8 +131,12 @@ pub fn compile(source: &str) -> CompileOutcome {
 /// `textures` is a `Map<string, Uint8Array>` of binary assets, keyed by
 /// the path the `.mog` source uses (e.g. `"textures/wood/albedo.png"`).
 /// Pass an empty `Map` (or `null`/`undefined` from JS) when the scene has
-/// no textures. Bytes are embedded into the GLB as-is — `image` and
-/// `oxipng` aren't linked into the wasm artifact.
+/// none. Bytes are embedded into the GLB as-is — `image` and `oxipng`
+/// aren't linked into the wasm artifact.
+///
+/// Despite the name it is every binary asset, not just images: `mesh
+/// (src="model.glb")` resolves out of the same map, under the same
+/// convention that the key is whatever path the source writes.
 ///
 /// Async because `fetch_dep` returns a `Promise`; the implementation walks
 /// the import graph BFS-style and awaits each missing spec before recursing
@@ -163,7 +171,10 @@ fn compile_with_cache(
     cache: HashMap<String, String>,
     textures: HashMap<PathBuf, Vec<u8>>,
 ) -> CompileOutcome {
-    let mut loader = JsLoader { cache: &cache };
+    let mut loader = JsLoader {
+        cache: &cache,
+        assets: &textures,
+    };
 
     // Parse the entry.
     let source = match cache.get(entry) {
@@ -289,6 +300,12 @@ fn fail(entry: &str, stage: &'static str, diags: Vec<Diagnostic>) -> CompileOutc
 /// exactly one source in the cache.
 struct JsLoader<'a> {
     cache: &'a HashMap<String, String>,
+    /// The same `Map<string, Uint8Array>` of binary assets the export step
+    /// reads textures out of. `mesh (src="…")` resolves from here too: in the
+    /// browser there is no filesystem for the default `Loader::load_binary` to
+    /// fall back to, so without this a scene referencing an external mesh
+    /// could not be lowered at all.
+    assets: &'a HashMap<PathBuf, Vec<u8>>,
 }
 
 impl<'a> Loader for JsLoader<'a> {
@@ -336,6 +353,26 @@ impl<'a> Loader for JsLoader<'a> {
                 "use \"{}\" — fetch_dep did not supply source for this \
                  registry reference (wasm prefetch bug)",
                 spec.raw
+            )),
+        }
+    }
+
+    /// Serve `mesh (src="….glb")` out of the binary asset map. The default
+    /// impl resolves against the filesystem, which in a browser means the call
+    /// fails no matter what the host supplied — so overriding here is what
+    /// actually makes the seam worth having on this side.
+    ///
+    /// Keyed by the spec verbatim, matching the convention the export step
+    /// already uses for `texture = "…"`: whatever path the `.mog` source
+    /// writes is the key the host must supply.
+    fn load_binary(&mut self, spec: &str, _base_dir: Option<&Path>) -> Result<Vec<u8>> {
+        match self.assets.get(Path::new(spec)) {
+            Some(bytes) => Ok(bytes.clone()),
+            None => Err(anyhow::anyhow!(
+                "mesh (src=\"{}\") — not present in the binary asset map; the \
+                 browser has no filesystem to fall back to, so the host must \
+                 pass these bytes to compile_files alongside its textures",
+                spec
             )),
         }
     }
@@ -539,7 +576,10 @@ mod tests {
     #[test]
     fn load_registry_returns_cached_source_with_synthetic_canonical_for_pinned_version() {
         let cache = loader_cache(&[("@alice/chair@3", "module chair {}")]);
-        let mut loader = JsLoader { cache: &cache };
+        let mut loader = JsLoader {
+            cache: &cache,
+            assets: &HashMap::new(),
+        };
         let spec = parse_registry_spec("@alice/chair@3").unwrap();
         let loaded = loader.load_registry(&spec).expect("registry hit");
         assert_eq!(loaded.source, "module chair {}");
@@ -549,16 +589,51 @@ mod tests {
     #[test]
     fn load_registry_canonical_for_unpinned_ref_is_latest() {
         let cache = loader_cache(&[("@alice/chair", "module chair {}")]);
-        let mut loader = JsLoader { cache: &cache };
+        let mut loader = JsLoader {
+            cache: &cache,
+            assets: &HashMap::new(),
+        };
         let spec = parse_registry_spec("@alice/chair").unwrap();
         let loaded = loader.load_registry(&spec).expect("registry hit");
         assert_eq!(loaded.canonical, PathBuf::from("registry/alice/chair/latest"));
     }
 
+    /// `mesh (src=…)` must resolve out of the asset map. The trait default
+    /// reads the filesystem, which in a browser cannot succeed — so a fall
+    /// through to it is the bug, not a fallback.
+    #[test]
+    fn load_binary_serves_meshes_from_the_asset_map() {
+        let cache = loader_cache(&[]);
+        let assets: HashMap<PathBuf, Vec<u8>> =
+            [(PathBuf::from("models/rock.glb"), b"glTF-ish".to_vec())]
+                .into_iter()
+                .collect();
+        let mut loader = JsLoader {
+            cache: &cache,
+            assets: &assets,
+        };
+        assert_eq!(
+            loader.load_binary("models/rock.glb", None).unwrap(),
+            b"glTF-ish".to_vec()
+        );
+
+        let err = loader
+            .load_binary("models/missing.glb", None)
+            .expect_err("a miss must not reach the filesystem default");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("binary asset map"),
+            "miss must name the map the host has to populate: {msg}"
+        );
+    }
+
     #[test]
     fn load_registry_errors_when_prefetch_missed_the_spec() {
         let cache = loader_cache(&[]);
-        let mut loader = JsLoader { cache: &cache };
+        let mut loader = JsLoader {
+            cache: &cache,
+            assets: &HashMap::new(),
+        };
         let spec = parse_registry_spec("@alice/chair@3").unwrap();
         let err = loader.load_registry(&spec).expect_err("must miss");
         // Must NOT surface the mogen-dsl default's E0701 message — that

--- a/crates/mogen/Cargo.toml
+++ b/crates/mogen/Cargo.toml
@@ -14,7 +14,7 @@ mogen-core = { workspace = true }
 mogen-dsl = { workspace = true, features = ["csg"] }
 mogen-binary = { workspace = true }
 mogen-validate = { workspace = true, features = ["csg"] }
-mogen-export = { workspace = true, features = ["textures", "merge", "fbx"] }
+mogen-export = { workspace = true, features = ["textures", "textures-svg", "merge", "fbx"] }
 mogen-llm = { workspace = true }
 mogen-moghub-client = { workspace = true, features = ["oauth"] }
 mogen-pascal = { workspace = true }

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -1016,6 +1016,12 @@ and `uv_mode="tile"` scales U by world arc length, which lands mid-tile at the
 wrap for most radii. For a seamless sphere, pair a wrap-authored tile with
 `uv_mode="fit"`.
 
+**Not yet compatible with `bundle_lods_and_imposter`.** That export option's
+imposter bake reads texture files straight off disk through its own headless
+GL renderer, independent of the rasterization pass described above, and can't
+decode `.svg` either. Combining the two is a hard error at export time.
+Pre-rasterize the texture to `.png` if you need both.
+
 ---
 
 ## Shaders

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -1007,7 +1007,13 @@ Notes:
   lattice and the centre cell kept, so shapes overhanging the viewBox reappear
   on the opposite edge instead of being clipped. This is the one thing a
   vector source buys that a supplied PNG cannot — the renderer is ours, so the
-  wrap can be manufactured rather than hand-authored.
+  wrap can be manufactured rather than hand-authored. The nine draws composite
+  normally, which makes the result exactly what painting the art across an
+  endless field of adjacent tiles would give. Art contained by the viewBox is
+  untouched, and overhang narrower than the tile only lands where the centre
+  drew nothing — but a *translucent* shape wider than the whole tile overlaps
+  itself, and reads darker in a band at each edge. The bands match across the
+  join, so the tiling stays seamless; split such a shape if the frame shows.
 
 Seamlessness on a **curved** surface is a separate matter, and `.svg` does not
 by itself fix it: it is a property of the UV layout, not the image format. A

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -903,14 +903,22 @@ Declared at the top of the file or inside `scene { ... }`. Attributes:
 - `uv_scale` — scalar or vec2; default `1.0`. In `tile` mode: tiles per
   world unit (`2` = denser, `0.5` = bigger). In `fit` mode: multiplies
   `[0, 1]` coords. Vec2 stretches asymmetrically.
-- `base_color_texture` — string path to an `.png`/`.jpg` file on disk,
+- `base_color_texture` — string path to a `.png`/`.jpg`/`.svg` file on disk,
   resolved relative to the `.mog` file. Multiplied against `color`. sRGB.
+  See [SVG textures](#svg-textures) for how `.svg` is handled.
 - `metallic_roughness_texture` — packed metal/rough map (glTF convention:
   green = roughness, blue = metallic). Linear.
 - `normal_texture` — tangent-space normal map. Linear.
 - `occlusion_texture` — ambient occlusion (red channel). Linear.
 - `emissive_texture` — emissive colour map, multiplied against `emissive`.
   sRGB.
+- `texture_size` — positive whole number; default `1024`. Pixel edge length
+  that `.svg` texture slots on this material rasterize to. Ignored by
+  `.png`/`.jpg` slots, which embed at their authored size.
+- `texture_wrap` — `0` (default) or `1`. Rasterize `.svg` slots with
+  wrap-around so artwork crossing the tile boundary reappears on the opposite
+  edge instead of being clipped. No effect on art that stays inside the
+  viewBox, so it is always safe to enable on a tile.
 - `prompt` — free-form subject hint for `mogen textures` when generating
   albedo (e.g. `prompt="navy nylon ripstop weave"`). Steers Gemini away
   from the default "material name + colour" framing; auto-rephrased on
@@ -960,6 +968,53 @@ material "lake" (color=[0.05, 0.32, 0.45], shader="water")
 Texture files are embedded in the output GLB (self-contained, movable
 without sources); missing files are a hard error at export. Reference a
 material via `mat="wood"`; unknown names are a hard error at lowering.
+
+### SVG textures
+
+Any texture slot accepts a `.svg` path. glTF 2.0 has no vector image type —
+its core spec defines only `image/png` and `image/jpeg` — so mogen rasterizes
+SVG to PNG at build time and embeds that. This happens before anything else
+inspects the scene, so the GLB, the FBX exporter, Studio's preview, and the
+derived-PBR pipeline all see raster only; nothing downstream ever encounters a
+`.svg` path.
+
+```
+material "tiles" (
+  color=[1, 1, 1],
+  uv_mode="fit",
+  base_color_texture="textures/hex.svg",
+  texture_size=2048,
+  texture_wrap=1
+)
+```
+
+Notes:
+
+- **Size is yours to choose.** SVG carries no intrinsic pixel size, so
+  `texture_size` (default `1024`) decides it. The viewBox is scaled to fill
+  the square exactly — a non-square viewBox is stretched rather than
+  letterboxed, since these are UV-space tiles where aspect correction belongs
+  to `uv_scale`.
+- **Text must be converted to paths first.** The rasterizer is built without
+  font support on purpose: resolving font names would make output depend on
+  which fonts the build machine happens to have installed, and identical
+  sources must produce identical bytes.
+- **Rasterization is deterministic and uncached.** The same SVG at the same
+  size yields byte-identical output every build, so there is nothing to
+  invalidate. One SVG used at two `texture_size` values embeds twice, as it
+  must.
+- **`texture_wrap=1` synthesises a seamless tile.** The art is drawn on a 3×3
+  lattice and the centre cell kept, so shapes overhanging the viewBox reappear
+  on the opposite edge instead of being clipped. This is the one thing a
+  vector source buys that a supplied PNG cannot — the renderer is ours, so the
+  wrap can be manufactured rather than hand-authored.
+
+Seamlessness on a **curved** surface is a separate matter, and `.svg` does not
+by itself fix it: it is a property of the UV layout, not the image format. A
+sphere's equirectangular mapping pinches at the poles no matter what feeds it,
+and `uv_mode="tile"` scales U by world arc length, which lands mid-tile at the
+wrap for most radii. For a seamless sphere, pair a wrap-authored tile with
+`uv_mode="fit"`.
 
 ---
 

--- a/examples/features/svg_texture.mog
+++ b/examples/features/svg_texture.mog
@@ -1,0 +1,53 @@
+// SVG textures: vector art rasterized at build time.
+//
+// glTF has no vector image type, so `.svg` slots are rasterized to PNG before
+// export and embedded like any other texture. `texture_size` picks the
+// resolution (SVG carries none of its own); `texture_wrap` makes art that
+// overhangs the viewBox reappear on the opposite edge, which is how you get a
+// tile that repeats without a visible join.
+//
+// Build with: mogen build examples/features/svg_texture.mog --out svg.glb
+
+// Wrap on: the circles are centred on the tile edges and corners, so half of
+// each falls outside the viewBox. Without wrap they'd be clipped flat against
+// the border; with it they complete themselves across the seam.
+material "dots" (
+  color             = [1, 1, 1],
+  roughness         = 0.7,
+  uv_mode           = "tile",
+  base_color_texture = "textures/dots.svg",
+  texture_size      = 1024,
+  texture_wrap      = 1
+)
+
+// Wrap off, fit mode: the SVG is a self-contained emblem meant to appear once
+// on the face rather than repeat, so there is nothing to wrap.
+material "emblem" (
+  color             = [1, 1, 1],
+  roughness         = 0.5,
+  uv_mode           = "fit",
+  base_color_texture = "textures/emblem.svg",
+  texture_size      = 512
+)
+
+scene {
+  // A tiled wall. `uv_mode="tile"` repeats the pattern by world unit, which
+  // is what makes the wrap-around matter — every repeat boundary is a seam.
+  box "wall" (size=[3, 2, 0.15], mat="dots")
+
+  // A sign showing the emblem once, edge to edge.
+  panel "sign" (size=[0.8, 0.8, 0.05], mat="emblem", right_of="wall", gap=0.4)
+
+  // The same emblem on a sphere. Seamlessness on a curved surface is a UV
+  // property, not an image-format one: `uv_mode="fit"` wraps the texture
+  // exactly once around, so the longitudinal seam closes. The poles still
+  // pinch — that's inherent to equirectangular mapping.
+  sphere "globe" (
+    radius   = 0.5,
+    rings    = 32,
+    segments = 64,
+    mat      = "emblem",
+    right_of = "sign",
+    gap      = 0.4
+  )
+}

--- a/examples/features/textures/dots.svg
+++ b/examples/features/textures/dots.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <!-- Tile background. -->
+  <rect x="0" y="0" width="100" height="100" fill="#2b3a55"/>
+  <!-- Centre dot, wholly inside the tile. -->
+  <circle cx="50" cy="50" r="16" fill="#e8c07d"/>
+  <!-- Edge and corner dots deliberately overhang the viewBox. With
+       texture_wrap=1 each completes itself on the opposite side, so the tile
+       repeats with no visible join; without it they are clipped flat. -->
+  <circle cx="0"   cy="50"  r="10" fill="#c96f5a"/>
+  <circle cx="100" cy="50"  r="10" fill="#c96f5a"/>
+  <circle cx="50"  cy="0"   r="10" fill="#c96f5a"/>
+  <circle cx="50"  cy="100" r="10" fill="#c96f5a"/>
+  <circle cx="0"   cy="0"   r="8"  fill="#7fa693"/>
+  <circle cx="100" cy="0"   r="8"  fill="#7fa693"/>
+  <circle cx="0"   cy="100" r="8"  fill="#7fa693"/>
+  <circle cx="100" cy="100" r="8"  fill="#7fa693"/>
+</svg>

--- a/examples/features/textures/emblem.svg
+++ b/examples/features/textures/emblem.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <!-- A self-contained emblem: nothing crosses the viewBox, so texture_wrap
+       would be a no-op here. Paths only — no <text> — because the rasterizer
+       is built without font support so that output can't depend on which
+       fonts the build machine has installed. -->
+  <rect x="0" y="0" width="100" height="100" fill="#f4f1e8"/>
+  <circle cx="50" cy="50" r="40" fill="none" stroke="#2b3a55" stroke-width="4"/>
+  <!-- Mountain glyph. -->
+  <path d="M28 64 L44 36 L54 52 L62 42 L74 64 Z" fill="#2b3a55"/>
+  <circle cx="66" cy="32" r="6" fill="#e8c07d"/>
+</svg>


### PR DESCRIPTION
Adds `.svg` support to every material texture slot. glTF 2.0 core defines only `image/png` and `image/jpeg`, so an SVG can never ship as an SVG — support means rasterizing offline, which suits a compiler fine since the render is a pure function of `(bytes, size, wrap)`.

```
material "tiles" (
  base_color_texture = "textures/hex.svg",
  texture_size       = 2048,   // SVG carries no intrinsic size; default 1024
  texture_wrap       = 1       // synthesise a seamless tile
)
```

## Why a pre-export pass, not a decode branch

The obvious home for this is `encode_for_slot`, next to the JPEG/oxipng policy. That's wrong: five consumers read a `TextureRef` path and only one goes through that function.

| consumer | reads | under "rasterize at encode" |
|---|---|---|
| GLB embed | `encode_for_slot` | works |
| FBX export | the **raw path** | breaks — `.svg` leaks into the FBX |
| Studio preview | its own loaders under `viewer/` | breaks |
| derived PBR maps | `pbr_maps.rs`, hard-codes `ImageFormat::Png` | breaks |
| imposter bake | baked pixels | unaffected |

Rewriting the path *before* export means all of them see raster only and need no SVG branch. The derived-PBR pipeline gains SVG albedo support for free.

## Decisions worth a look

- **Uncached.** Rasterized bytes live in memory and are layered over the caller's `TextureSource` via `OverlayTextureSource`; nothing touches `MOGEN_CACHE_DIR`. Costs a re-render per build (milliseconds at tile sizes), buys wasm portability and no staleness bugs. Matches the precedent in `mogen-llm`, which also declines to cache.
- **No font support.** `usvg`'s `text` feature is off deliberately — resolving font names would make output depend on which fonts the build machine has installed. Text in an SVG must be converted to paths. Documented.
- **In `default`.** The desktop default already pulls glutin/winit via `imposter`; resvg is comparatively light and pure Rust. `mogen build` handling an SVG out of the box seemed the right call. Say the word if you'd rather it were opt-in.
- **Verified to cross-compile** to `wasm32-unknown-unknown` (`--no-default-features --features textures,textures-svg`). `mogen-wasm` does **not** opt in here — that's a bundle-size call I left to you. Until it does, the web preview rejects `.svg` with the existing clear "unsupported texture extension" error.

## `texture_wrap`

Draws the tree on a 3×3 lattice and keeps the centre cell, so art overhanging the viewBox reappears on the opposite edge instead of being clipped. This is the one thing a vector source buys that a supplied PNG cannot — the renderer is ours, so the wrap can be manufactured rather than hand-authored. It's a no-op for art that stays inside the viewBox (test asserts byte-identical output), so it's always safe to enable.

Measured on the example tile through the full CLI pipeline: opposite edges differ by **0.14/255** mean abs (residual JPEG noise) versus **37** for an arbitrary interior column. A 2×2 tiling shows boundary-straddling dots completing across every join, including the four-way corner.

## Not in scope

`.svg` does **not** make a sphere seamless — that's a property of the UV layout, not the image format, and `uv_mode="tile"` has a genuine seam bug tracked in #105. Equirectangular pre-warp is a separate feature. Both called out in the docs.

## Testing

- 8 unit tests in `svg.rs` — determinism, viewBox scaling, wrap behaviour + its no-op case, malformed input, dedup-key separation
- 8 integration tests in `svg_textures.rs` — end-to-end GLB, `texture_size` honoured, default applied, byte-identical rebuilds, shared-SVG dedup, two-sizes-no-collision, raster-only scenes untouched, useful error on malformed SVG, and no `.svg` string surviving into the glTF
- 3 DSL lowering tests, plus validator schema entries so the attrs aren't flagged as typos
- Full workspace: **1824 passed, 0 failed**
- `examples/features/svg_texture.mog` builds and inspects clean via the real CLI

Note the repo isn't `rustfmt`-clean already, so I matched surrounding style rather than reformatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)