### PR TITLE
svg: rasterization moves below the exporter; the water preset declares its absorption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,11 +2763,10 @@ dependencies = [
  "mogen-dsl",
  "mogen-geom",
  "mogen-render",
+ "mogen-svg",
  "oxipng",
- "resvg",
  "serde",
  "serde_json",
- "usvg",
 ]
 
 [[package]]
@@ -2894,6 +2893,17 @@ dependencies = [
  "tiny_http",
  "webbrowser",
  "zip",
+]
+
+[[package]]
+name = "mogen-svg"
+version = "0.1.12"
+dependencies = [
+ "anyhow",
+ "image",
+ "mogen-core",
+ "resvg",
+ "usvg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/mogen-moghub-client",
     "crates/mogen-registry",
     "crates/mogen-render",
+    "crates/mogen-svg",
     "crates/mogen-studio",
     "crates/mogen-update",
     "crates/mogen-wasm",
@@ -63,6 +64,9 @@ mogen-validate = { path = "crates/mogen-validate", default-features = false }
 mogen-anim = { path = "crates/mogen-anim" }
 mogen-binary = { path = "crates/mogen-binary" }
 mogen-export = { path = "crates/mogen-export", default-features = false }
+# Pure-Rust SVG rasterization. Sits below the exporter so Studio's viewport and
+# downstream engines can resolve the same pixels without linking one.
+mogen-svg = { path = "crates/mogen-svg" }
 mogen-llm = { path = "crates/mogen-llm" }
 mogen-pascal = { path = "crates/mogen-pascal" }
 mogen-moghub-client = { path = "crates/mogen-moghub-client" }

--- a/crates/mogen-core/src/shader.rs
+++ b/crates/mogen-core/src/shader.rs
@@ -28,6 +28,34 @@ pub fn builtin_names() -> &'static [&'static str] {
     &[WATER]
 }
 
+/// Name of the built-in water shader's one parameter: the depth, in world
+/// units, over which transmitted radiance falls to `1/e`.
+pub const WATER_ABSORPTION: &str = "absorption";
+
+/// Default for [`WATER_ABSORPTION`].
+///
+/// Deliberately **not** zero. Zero is the "behaves exactly like clear glass"
+/// case, so defaulting to it would make `shader="water"` a no-op that reports
+/// success. A metre and a half is a plausible pond and is visibly water.
+pub const WATER_ABSORPTION_DEFAULT: f32 = 1.5;
+
+/// The parameters the built-in [`WATER`] preset declares.
+///
+/// The preset carried none until now, which made `shader="water"` a bare
+/// on/off switch: an author had no way to say *how* absorbing the water is,
+/// and a consumer reading the lowered [`crate::Material`] had nothing to read.
+/// Declaring the parameter here means `shader_params (absorption=…)` resolves
+/// through the ordinary [`ShaderDecl::resolve_param`] path, exactly as it
+/// would for a user-declared shader — the built-in stays the first client of
+/// the general system rather than acquiring a special case.
+pub fn water_params() -> Vec<ShaderParamDef> {
+    vec![ShaderParamDef {
+        name: WATER_ABSORPTION.to_string(),
+        ty: ShaderParamType::Float,
+        default: Some(ShaderParamValue::Float(WATER_ABSORPTION_DEFAULT)),
+    }]
+}
+
 /// The declared type of a shader `param`. Determines the GLSL uniform type and
 /// which [`ShaderParamValue`] variant a supplied value must match.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/mogen-dsl/src/lower/shader.rs
+++ b/crates/mogen-dsl/src/lower/shader.rs
@@ -99,7 +99,9 @@ pub(super) fn ensure_builtin_shaders(graph: &mut SceneGraph) {
     if !graph.shaders.iter().any(|s| s.name == shader::WATER) {
         // The source is a `stdlib:`-keyed path resolved from bundled bytes by
         // MoGen Studio; export ignores the source entirely.
-        graph.add_shader(ShaderDecl::new(shader::WATER, "stdlib:shaders/water.glsl"));
+        let mut water = ShaderDecl::new(shader::WATER, "stdlib:shaders/water.glsl");
+        water.params = shader::water_params();
+        graph.add_shader(water);
     }
 }
 

--- a/crates/mogen-dsl/src/lower/tests/shader.rs
+++ b/crates/mogen-dsl/src/lower/tests/shader.rs
@@ -51,6 +51,49 @@ fn builtin_water_shader_is_seeded_without_declaration() {
     assert!(g.find_shader_scoped(mogen_core::shader::WATER, None).is_some());
 }
 
+/// The built-in preset declares `absorption`, so a material can carry *how*
+/// absorbing its water is rather than only that it is water. Resolution goes
+/// through the ordinary `resolve_param` path — no special case for the
+/// built-in.
+#[test]
+fn builtin_water_declares_absorption_and_resolves_an_override() {
+    use mogen_core::shader::{WATER, WATER_ABSORPTION, WATER_ABSORPTION_DEFAULT};
+    use mogen_core::ShaderParamValue;
+
+    let g = lower_src(
+        r#"
+        material "pond" (color=[0.15, 0.4, 0.45], shader="water") {
+          shader_params (absorption=2.5)
+        }
+        material "sea" (color=[0.1, 0.3, 0.4], shader="water")
+        scene { box "b" (size=[1,1,1], mat="pond") }
+        "#,
+    );
+    let decl = g.find_shader_scoped(WATER, None).expect("water shader");
+    assert_eq!(
+        decl.params.iter().map(|p| p.name.as_str()).collect::<Vec<_>>(),
+        [WATER_ABSORPTION],
+        "the preset declares exactly its one parameter"
+    );
+
+    let pond = &g.materials[g.find_material("pond").expect("pond").0 as usize];
+    assert_eq!(
+        decl.resolve_param(WATER_ABSORPTION, &pond.shader_params),
+        Some(ShaderParamValue::Float(2.5)),
+        "an authored override must win"
+    );
+
+    // The control: a material that says nothing gets the declared default, and
+    // that default is not the disabled value — otherwise `shader=\"water\"`
+    // would be a no-op reporting success.
+    let sea = &g.materials[g.find_material("sea").expect("sea").0 as usize];
+    assert_eq!(
+        decl.resolve_param(WATER_ABSORPTION, &sea.shader_params),
+        Some(ShaderParamValue::Float(WATER_ABSORPTION_DEFAULT))
+    );
+    assert!(WATER_ABSORPTION_DEFAULT > 0.0);
+}
+
 #[test]
 fn user_declared_water_shader_shadows_the_builtin() {
     let g = lower_src(

--- a/crates/mogen-export/Cargo.toml
+++ b/crates/mogen-export/Cargo.toml
@@ -29,7 +29,7 @@ textures-optimize = ["textures", "dep:image", "dep:oxipng"]
 #                         this one *can* be enabled for wasm too — the wasm
 #                         crate just has to opt in explicitly, since it
 #                         builds with `default-features = false`.
-textures-svg = ["textures", "dep:resvg", "dep:usvg"]
+textures-svg = ["textures", "dep:mogen-svg"]
 # Sibling-mesh merge module. The merge pass calls into `mogen-geom`'s CSG
 # `union_many`; whichever crate enables the `csg` (desktop) or
 # `unstable-wasm-uu` (wasm) flavor of `mogen-geom` is responsible for
@@ -62,8 +62,7 @@ serde_json = { workspace = true }
 glam = { workspace = true }
 image = { workspace = true, optional = true }
 oxipng = { workspace = true, optional = true }
-resvg = { workspace = true, optional = true }
-usvg = { workspace = true, optional = true }
+mogen-svg = { workspace = true, optional = true }
 fbxcel = { version = "0.9", features = ["writer", "tree"], optional = true }
 meshopt = { workspace = true, optional = true }
 mogen-render = { workspace = true, optional = true }

--- a/crates/mogen-export/src/svg.rs
+++ b/crates/mogen-export/src/svg.rs
@@ -1,11 +1,11 @@
-//! Rasterize `.svg` texture references into PNG before anything downstream
-//! looks at them.
+//! Rewrite `.svg` texture references to rasterized PNG before anything
+//! downstream looks at them.
 //!
-//! glTF 2.0 core defines exactly two embeddable image MIME types —
-//! `image/png` and `image/jpeg` — so an SVG can never ship as an SVG. Support
-//! therefore means rasterizing at build time, which suits `mogen` fine: it is
-//! an offline compiler and rasterization is a pure function of
-//! `(bytes, size, wrap)`.
+//! The renderer itself lives in [`mogen_svg`]; this module is the *pass* that
+//! applies it to a whole [`SceneGraph`] on the way into an exporter. The two
+//! were one module until the renderer had a second caller that was not
+//! downstream of export at all — see that crate's docs for why the policy
+//! moved down and the pass stayed here.
 //!
 //! # Why this is a pass and not a decode branch
 //!
@@ -25,16 +25,19 @@
 //! path *before* export means every one of them only ever sees a PNG, and the
 //! derived-PBR pipeline picks up SVG albedo support for free.
 //!
-//! # The consumer this pass cannot reach
+//! # The consumers this pass cannot reach
 //!
 //! Studio's live viewport is not downstream of the exporter at all — it
 //! flattens the `SceneGraph` straight out of the compile pipeline and uploads
 //! each material's texture paths to GL itself. The rewritten paths this pass
 //! produces are synthetic and resolve only through [`OverlayTextureSource`],
 //! so handing them to a loader that reads from disk would be worse than
-//! useless. The viewport therefore calls [`render_svg`] and
-//! [`resolve_svg_size`] directly, on the real `.svg` path — same functions,
-//! same pixels, no second implementation of the policy.
+//! useless. The same is true of any engine that consumes the lowered
+//! `SceneGraph` and decodes textures itself.
+//!
+//! Both therefore call [`mogen_svg::render_svg`] and
+//! [`mogen_svg::resolve_svg_size`] directly, on the real `.svg` path — same
+//! functions, same pixels, no second implementation of the policy.
 //!
 //! # No cache
 //!
@@ -50,25 +53,13 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 
-use mogen_core::{Material, SceneGraph, TextureRef, DEFAULT_SVG_SIZE};
+use mogen_core::{Material, SceneGraph, TextureRef};
 
 use crate::texture::TextureSource;
 
-/// Upper bound on the rasterized edge length. 8192² RGBA is 256 MB before PNG
-/// compression, which is already well past anything a texture slot should be
-/// carrying; beyond it a typo in `texture_size` turns into an OOM rather than
-/// an error message.
-pub const MAX_SVG_SIZE: u32 = 8192;
-
-/// Does this path look like an SVG? Extension-based, matching how the rest of
-/// the exporter dispatches on format (`texture::mime_from_extension`).
-pub fn is_svg(path: &Path) -> bool {
-    path.extension()
-        .and_then(|s| s.to_str())
-        .is_some_and(|s| s.eq_ignore_ascii_case("svg"))
-}
+pub use mogen_svg::{is_svg, render_svg, resolve_svg_size, MAX_SVG_SIZE};
 
 /// The synthetic path a rasterized SVG is republished under. Keeps a `.png`
 /// extension so extension-based MIME inference — the wasm embed path, which
@@ -186,181 +177,14 @@ fn material_references_svg(mat: &Material) -> bool {
     .any(|t| is_svg(&t.path))
 }
 
-/// Resolve a material's `texture_size` to the pixel edge length its `.svg`
-/// slots rasterize to, applying [`DEFAULT_SVG_SIZE`] when unset and rejecting
-/// anything outside `1..=MAX_SVG_SIZE`. Exposed so other consumers of a raw
-/// `Material` — e.g. MoGen Studio's live viewport, which rasterizes textures
-/// outside the export pipeline — resolve the same size the exporter would.
-pub fn resolve_svg_size(mat: &Material) -> Result<u32> {
-    let size = mat.texture_size.unwrap_or(DEFAULT_SVG_SIZE);
-    if size == 0 || size > MAX_SVG_SIZE {
-        bail!(
-            "material \"{}\" sets texture_size = {size}, which is outside the \
-             supported range 1..={MAX_SVG_SIZE}",
-            mat.name
-        );
-    }
-    Ok(size)
-}
-
-/// Render SVG bytes to a square RGBA PNG of `size`².
-///
-/// The SVG's own viewBox is scaled to fill the target exactly — a
-/// non-square viewBox is stretched rather than letterboxed, because these are
-/// texture tiles addressed in UV space, where the aspect correction belongs to
-/// `uv_scale` and not to the image.
-///
-/// With `wrap` on, the tree is drawn nine times on a 3×3 lattice and the
-/// centre cell is kept. Artwork that overflows the viewBox therefore reappears
-/// on the opposite edge instead of being clipped, so a pattern tiles seamlessly
-/// without the author having to hand-split the shapes that straddle the
-/// boundary. This is the one thing a vector source buys that a supplied PNG
-/// cannot: the renderer is ours, so the wrap can be synthesised.
-///
-/// The nine draws composite source-over, which makes the result exactly what
-/// painting the art across an infinite plane of adjacent tiles would give.
-/// That is the right model, and it is why the join is continuous — but it does
-/// mean a *translucent* shape wider than the whole tile overlaps itself, and
-/// so reads darker in the overhang band at each edge (measurably: a 50%-opaque
-/// band drawn from -10 to 110 in a 0..100 viewBox comes out 75% opaque in the
-/// outer 10%). The two bands abut across the join, so the tiling stays
-/// seamless in the strict sense; they are still a visible frame. Art that
-/// stays inside the viewBox is unaffected — `wrap_is_a_no_op_for_contained_art`
-/// pins that — and overhang narrower than the tile only ever lands on the
-/// opposite edge, where the centre cell drew nothing.
-///
-/// Public so a consumer that already has SVG bytes and a resolved size/wrap —
-/// e.g. Studio's live viewport, which rasterizes on the fly outside the
-/// export pipeline — can call the same renderer [`rasterize_svg_textures`] uses
-/// rather than re-implementing it.
-pub fn render_svg(svg: &[u8], size: u32, wrap: bool) -> Result<Vec<u8>> {
-    // `usvg::Options` default carries no fontdb (the `text` feature is off in
-    // Cargo.toml), so this cannot depend on host-installed fonts.
-    let opts = usvg::Options::default();
-    let tree = usvg::Tree::from_data(svg, &opts).context("parsing SVG")?;
-
-    let vb = tree.size();
-    if vb.width() <= 0.0 || vb.height() <= 0.0 {
-        bail!("SVG has a zero-sized viewBox; nothing to rasterize");
-    }
-    let (sx, sy) = (size as f32 / vb.width(), size as f32 / vb.height());
-
-    let mut pixmap = resvg::tiny_skia::Pixmap::new(size, size)
-        .with_context(|| format!("allocating a {size}x{size} pixmap"))?;
-
-    let offsets: &[(f32, f32)] = if wrap {
-        &[
-            (-1.0, -1.0), (0.0, -1.0), (1.0, -1.0),
-            (-1.0, 0.0),  (0.0, 0.0),  (1.0, 0.0),
-            (-1.0, 1.0),  (0.0, 1.0),  (1.0, 1.0),
-        ]
-    } else {
-        &[(0.0, 0.0)]
-    };
-
-    for (dx, dy) in offsets {
-        let t = resvg::tiny_skia::Transform::from_translate(dx * size as f32, dy * size as f32)
-            .pre_scale(sx, sy);
-        resvg::render(&tree, t, &mut pixmap.as_mut());
-    }
-
-    pixmap.encode_png().context("encoding rasterized SVG to PNG")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// A 100x100 viewBox with a red square covering the left half. Deliberately
-    /// asymmetric so a horizontal flip would be detectable.
+    /// A 100x100 viewBox with a red square covering the left half.
     const HALF: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
         <rect x="0" y="0" width="50" height="100" fill="#ff0000"/>
     </svg>"##;
-
-    /// A circle centred on the left edge, so half of it falls outside the
-    /// viewBox. Under wrap it must reappear on the right edge.
-    const OVERHANG: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-        <circle cx="0" cy="50" r="20" fill="#00ff00"/>
-    </svg>"##;
-
-    fn decode(png: &[u8]) -> image::RgbaImage {
-        image::load_from_memory_with_format(png, image::ImageFormat::Png)
-            .expect("decoding rasterized PNG")
-            .to_rgba8()
-    }
-
-    #[test]
-    fn renders_at_requested_size() {
-        let png = render_svg(HALF, 64, false).unwrap();
-        let img = decode(&png);
-        assert_eq!(img.dimensions(), (64, 64));
-    }
-
-    #[test]
-    fn scales_viewbox_to_fill_target() {
-        // The red half should occupy the left half of the output regardless of
-        // the ratio between viewBox units and pixels.
-        let img = decode(&render_svg(HALF, 64, false).unwrap());
-        assert_eq!(img.get_pixel(10, 32).0[0], 255, "left half should be red");
-        assert_eq!(img.get_pixel(54, 32).0[3], 0, "right half should be empty");
-    }
-
-    /// The determinism guarantee the whole build reproducibility story rests
-    /// on: same input, byte-identical output.
-    #[test]
-    fn rasterization_is_deterministic() {
-        let a = render_svg(HALF, 128, false).unwrap();
-        let b = render_svg(HALF, 128, false).unwrap();
-        assert_eq!(a, b, "same SVG + size must produce identical bytes");
-    }
-
-    #[test]
-    fn wrap_brings_overhanging_art_back_on_the_far_edge() {
-        let plain = decode(&render_svg(OVERHANG, 64, false).unwrap());
-        let wrapped = decode(&render_svg(OVERHANG, 64, true).unwrap());
-
-        // Without wrap the right edge is empty; with wrap the clipped half of
-        // the circle reappears there.
-        assert_eq!(plain.get_pixel(63, 32).0[3], 0, "no wrap => right edge empty");
-        assert!(
-            wrapped.get_pixel(63, 32).0[3] > 0,
-            "wrap => clipped art reappears on the opposite edge"
-        );
-        // The left edge is unchanged either way.
-        assert!(plain.get_pixel(0, 32).0[1] > 0);
-        assert!(wrapped.get_pixel(0, 32).0[1] > 0);
-    }
-
-    /// Wrapping must be a no-op for art that stays inside the viewBox, so it
-    /// is safe to enable on any tile without changing its appearance.
-    #[test]
-    fn wrap_is_a_no_op_for_contained_art() {
-        let plain = render_svg(HALF, 64, false).unwrap();
-        let wrapped = render_svg(HALF, 64, true).unwrap();
-        assert_eq!(plain, wrapped);
-    }
-
-    /// The overlap the source-over lattice implies, pinned so it can't drift
-    /// into an asymmetry: a translucent shape wider than the tile darkens by
-    /// the same amount at *both* edges, which is what keeps the join
-    /// continuous even though the band is visible.
-    #[test]
-    fn wrap_overlap_is_symmetric_across_the_join() {
-        const BAND: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-            <rect x="-10" y="0" width="120" height="100" fill="#ff0000" fill-opacity="0.5"/>
-        </svg>"##;
-        let img = decode(&render_svg(BAND, 64, true).unwrap());
-        let alpha = |x| img.get_pixel(x, 32).0[3];
-        assert_eq!(
-            alpha(0),
-            alpha(63),
-            "overhang bands must match across the join or the tile is not seamless"
-        );
-        assert!(
-            alpha(0) > alpha(32),
-            "self-overlap in the overhang band is expected; see render_svg's docs"
-        );
-    }
 
     /// `texture_size` is documented as ignored by raster slots. It must stay
     /// ignored even when a *different* material in the same scene pulls the
@@ -390,19 +214,6 @@ mod tests {
     }
 
     #[test]
-    fn rejects_a_malformed_svg() {
-        assert!(render_svg(b"not an svg at all", 64, false).is_err());
-    }
-
-    #[test]
-    fn is_svg_is_case_insensitive_and_extension_based() {
-        assert!(is_svg(Path::new("a/b/tile.svg")));
-        assert!(is_svg(Path::new("TILE.SVG")));
-        assert!(!is_svg(Path::new("tile.png")));
-        assert!(!is_svg(Path::new("svg")));
-    }
-
-    #[test]
     fn raster_paths_separate_sizes_and_wrap_modes() {
         let p = Path::new("tile.svg");
         let a = raster_path(p, 512, false);
@@ -419,41 +230,5 @@ mod tests {
             "raster path must not carry the source's .svg extension: {}",
             a.display()
         );
-    }
-
-    #[test]
-    fn resolve_svg_size_uses_the_default_when_unset() {
-        let mat = Material::new("m");
-        assert_eq!(resolve_svg_size(&mat).unwrap(), DEFAULT_SVG_SIZE);
-    }
-
-    #[test]
-    fn resolve_svg_size_rejects_zero() {
-        let mut mat = Material::new("m");
-        mat.texture_size = Some(0);
-        let err = resolve_svg_size(&mat).unwrap_err();
-        assert!(format!("{err:#}").contains("texture_size"));
-    }
-
-    #[test]
-    fn resolve_svg_size_rejects_above_the_max() {
-        let mut mat = Material::new("blowup");
-        mat.texture_size = Some(MAX_SVG_SIZE + 1);
-        let err = resolve_svg_size(&mat).unwrap_err();
-        let msg = format!("{err:#}");
-        // Names the offending material so a multi-material scene's error is
-        // actionable, and the bound itself so the fix is obvious.
-        assert!(msg.contains("blowup"), "should name the material: {msg}");
-        assert!(
-            msg.contains(&MAX_SVG_SIZE.to_string()),
-            "should name the bound: {msg}"
-        );
-    }
-
-    #[test]
-    fn resolve_svg_size_accepts_the_max_exactly() {
-        let mut mat = Material::new("m");
-        mat.texture_size = Some(MAX_SVG_SIZE);
-        assert_eq!(resolve_svg_size(&mat).unwrap(), MAX_SVG_SIZE);
     }
 }

--- a/crates/mogen-export/tests/shader.rs
+++ b/crates/mogen-export/tests/shader.rs
@@ -61,6 +61,44 @@ fn builtin_water_shader_projects_name_with_no_declaration() {
     assert_eq!(sh["name"], "water");
 }
 
+/// The built-in water preset now declares `absorption` (see
+/// `mogen_core::shader::water_params`), and that resolution rides to glTF
+/// extras through the exact same `shader_extras` projection a user-declared
+/// shader's params use — no special case for the built-in. A downstream
+/// engine reading `node.extras.shader.params` needs this to actually contain
+/// the value, not just the shader name.
+#[test]
+fn builtin_water_shader_projects_absorption_default_and_override() {
+    let src = r#"
+        material "sea" (color=[0.0, 0.3, 0.5], shader="water")
+        material "pond" (color=[0.15, 0.4, 0.45], shader="water") {
+          shader_params (absorption=2.5)
+        }
+        scene {
+          box "b1" (size=[1,1,1], mat="sea")
+          box "b2" (size=[1,1,1], mat="pond")
+        }
+    "#;
+    let json = parse_glb_json(&compile(src));
+
+    let sea = &find_node(&json, "b1")["extras"]["shader"];
+    assert_eq!(sea["name"], "water");
+    assert!(
+        (sea["params"]["absorption"].as_f64().unwrap()
+            - mogen_core::shader::WATER_ABSORPTION_DEFAULT as f64)
+            .abs()
+            < 1e-6,
+        "a silent material must get the declared default"
+    );
+
+    let pond = &find_node(&json, "b2")["extras"]["shader"];
+    assert_eq!(pond["name"], "water");
+    assert!(
+        (pond["params"]["absorption"].as_f64().unwrap() - 2.5).abs() < 1e-6,
+        "an authored override must win"
+    );
+}
+
 #[test]
 fn standard_material_has_no_shader_extras() {
     let src = r#"scene { box "plain" (size=[1,1,1]) }"#;

--- a/crates/mogen-svg/Cargo.toml
+++ b/crates/mogen-svg/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "mogen-svg"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+mogen-core = { workspace = true }
+anyhow = { workspace = true }
+resvg = { workspace = true }
+usvg = { workspace = true }
+
+[dev-dependencies]
+# Only to decode what the tests just rendered. `resvg` encodes PNG but does not
+# read one back, and asserting on pixels is the only way these tests can claim
+# anything about the render.
+image = { workspace = true }

--- a/crates/mogen-svg/src/lib.rs
+++ b/crates/mogen-svg/src/lib.rs
@@ -1,0 +1,279 @@
+//! Rasterize `.svg` texture references to PNG.
+//!
+//! glTF 2.0 core defines exactly two embeddable image MIME types —
+//! `image/png` and `image/jpeg` — so an SVG can never ship as an SVG. Support
+//! therefore means rasterizing at build time, which suits `mogen` fine: it is
+//! an offline compiler and rasterization is a pure function of
+//! `(bytes, size, wrap)`.
+//!
+//! # Why this is a crate and not a module of `mogen-export`
+//!
+//! Rasterization began life inside the exporter, as a pre-export pass. That is
+//! still where the *pass* belongs — rewriting a [`SceneGraph`]'s texture paths
+//! and layering the bytes over a `TextureSource` is an export-shaped problem,
+//! and `mogen_export::svg` keeps it.
+//!
+//! What does not belong there is the renderer itself. Every consumer that
+//! holds a `Material` and a path — MoGen Studio's live viewport, and any
+//! downstream engine that reads the lowered [`SceneGraph`] and decodes
+//! textures itself rather than going through glTF — sits *beside* the
+//! exporter, not after it. Studio already reached back into `mogen-export`
+//! for exactly these three functions; an engine consuming `mogen-core` +
+//! `mogen-dsl` could not reach them at all without taking a dependency on the
+//! whole exporter, `oxipng`, `fbxcel` and `meshopt` included.
+//!
+//! So the policy lives at the bottom, where anything can call it, and the pass
+//! stays at the top, where only the exporter needs it. There is still exactly
+//! one implementation of "what pixels does this SVG produce" — the point of
+//! the original decision — it is simply reachable now.
+//!
+//! # Dependencies
+//!
+//! `resvg` and `usvg` only, both pure Rust, so this crate cross-compiles to
+//! `wasm32-unknown-unknown` where `image`/`oxipng` cannot. `usvg`'s default
+//! features are off deliberately: they pull in `fontdb`, which enumerates
+//! system fonts at render time and would make output depend on which machine
+//! ran the build. Text in an SVG must be converted to paths first.
+
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+
+use mogen_core::{Material, DEFAULT_SVG_SIZE};
+
+/// Upper bound on the rasterized edge length. 8192² RGBA is 256 MB before PNG
+/// compression, which is already well past anything a texture slot should be
+/// carrying; beyond it a typo in `texture_size` turns into an OOM rather than
+/// an error message.
+pub const MAX_SVG_SIZE: u32 = 8192;
+
+/// Does this path look like an SVG? Extension-based, matching how the rest of
+/// the exporter dispatches on format (`texture::mime_from_extension`).
+pub fn is_svg(path: &Path) -> bool {
+    path.extension()
+        .and_then(|s| s.to_str())
+        .is_some_and(|s| s.eq_ignore_ascii_case("svg"))
+}
+
+/// Resolve a material's `texture_size` to the pixel edge length its `.svg`
+/// slots rasterize to, applying [`DEFAULT_SVG_SIZE`] when unset and rejecting
+/// anything outside `1..=MAX_SVG_SIZE`.
+///
+/// Every consumer of a raw `Material` must resolve the size through here, or
+/// the same SVG rasterizes at two different resolutions depending on which
+/// component asked.
+pub fn resolve_svg_size(mat: &Material) -> Result<u32> {
+    let size = mat.texture_size.unwrap_or(DEFAULT_SVG_SIZE);
+    if size == 0 || size > MAX_SVG_SIZE {
+        bail!(
+            "material \"{}\" sets texture_size = {size}, which is outside the \
+             supported range 1..={MAX_SVG_SIZE}",
+            mat.name
+        );
+    }
+    Ok(size)
+}
+
+/// Render SVG bytes to a square RGBA PNG of `size`².
+///
+/// The SVG's own viewBox is scaled to fill the target exactly — a
+/// non-square viewBox is stretched rather than letterboxed, because these are
+/// texture tiles addressed in UV space, where the aspect correction belongs to
+/// `uv_scale` and not to the image.
+///
+/// With `wrap` on, the tree is drawn nine times on a 3×3 lattice and the
+/// centre cell is kept. Artwork that overflows the viewBox therefore reappears
+/// on the opposite edge instead of being clipped, so a pattern tiles seamlessly
+/// without the author having to hand-split the shapes that straddle the
+/// boundary. This is the one thing a vector source buys that a supplied PNG
+/// cannot: the renderer is ours, so the wrap can be synthesised.
+///
+/// The nine draws composite source-over, which makes the result exactly what
+/// painting the art across an infinite plane of adjacent tiles would give.
+/// That is the right model, and it is why the join is continuous — but it does
+/// mean a *translucent* shape wider than the whole tile overlaps itself, and
+/// so reads darker in the overhang band at each edge (measurably: a 50%-opaque
+/// band drawn from -10 to 110 in a 0..100 viewBox comes out 75% opaque in the
+/// outer 10%). The two bands abut across the join, so the tiling stays
+/// seamless in the strict sense; they are still a visible frame. Art that
+/// stays inside the viewBox is unaffected — `wrap_is_a_no_op_for_contained_art`
+/// pins that — and overhang narrower than the tile only ever lands on the
+/// opposite edge, where the centre cell drew nothing.
+pub fn render_svg(svg: &[u8], size: u32, wrap: bool) -> Result<Vec<u8>> {
+    // `usvg::Options` default carries no fontdb (the `text` feature is off in
+    // Cargo.toml), so this cannot depend on host-installed fonts.
+    let opts = usvg::Options::default();
+    let tree = usvg::Tree::from_data(svg, &opts).context("parsing SVG")?;
+
+    let vb = tree.size();
+    if vb.width() <= 0.0 || vb.height() <= 0.0 {
+        bail!("SVG has a zero-sized viewBox; nothing to rasterize");
+    }
+    let (sx, sy) = (size as f32 / vb.width(), size as f32 / vb.height());
+
+    let mut pixmap = resvg::tiny_skia::Pixmap::new(size, size)
+        .with_context(|| format!("allocating a {size}x{size} pixmap"))?;
+
+    let offsets: &[(f32, f32)] = if wrap {
+        &[
+            (-1.0, -1.0), (0.0, -1.0), (1.0, -1.0),
+            (-1.0, 0.0),  (0.0, 0.0),  (1.0, 0.0),
+            (-1.0, 1.0),  (0.0, 1.0),  (1.0, 1.0),
+        ]
+    } else {
+        &[(0.0, 0.0)]
+    };
+
+    for (dx, dy) in offsets {
+        let t = resvg::tiny_skia::Transform::from_translate(dx * size as f32, dy * size as f32)
+            .pre_scale(sx, sy);
+        resvg::render(&tree, t, &mut pixmap.as_mut());
+    }
+
+    pixmap.encode_png().context("encoding rasterized SVG to PNG")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A 100x100 viewBox with a red square covering the left half. Deliberately
+    /// asymmetric so a horizontal flip would be detectable.
+    const HALF: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+        <rect x="0" y="0" width="50" height="100" fill="#ff0000"/>
+    </svg>"##;
+
+    /// A circle centred on the left edge, so half of it falls outside the
+    /// viewBox. Under wrap it must reappear on the right edge.
+    const OVERHANG: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+        <circle cx="0" cy="50" r="20" fill="#00ff00"/>
+    </svg>"##;
+
+    fn decode(png: &[u8]) -> image::RgbaImage {
+        image::load_from_memory_with_format(png, image::ImageFormat::Png)
+            .expect("decoding rasterized PNG")
+            .to_rgba8()
+    }
+
+    #[test]
+    fn renders_at_requested_size() {
+        let png = render_svg(HALF, 64, false).unwrap();
+        let img = decode(&png);
+        assert_eq!(img.dimensions(), (64, 64));
+    }
+
+    #[test]
+    fn scales_viewbox_to_fill_target() {
+        // The red half should occupy the left half of the output regardless of
+        // the ratio between viewBox units and pixels.
+        let img = decode(&render_svg(HALF, 64, false).unwrap());
+        assert_eq!(img.get_pixel(10, 32).0[0], 255, "left half should be red");
+        assert_eq!(img.get_pixel(54, 32).0[3], 0, "right half should be empty");
+    }
+
+    /// The determinism guarantee the whole build reproducibility story rests
+    /// on: same input, byte-identical output.
+    #[test]
+    fn rasterization_is_deterministic() {
+        let a = render_svg(HALF, 128, false).unwrap();
+        let b = render_svg(HALF, 128, false).unwrap();
+        assert_eq!(a, b, "same SVG + size must produce identical bytes");
+    }
+
+    #[test]
+    fn wrap_brings_overhanging_art_back_on_the_far_edge() {
+        let plain = decode(&render_svg(OVERHANG, 64, false).unwrap());
+        let wrapped = decode(&render_svg(OVERHANG, 64, true).unwrap());
+
+        // Without wrap the right edge is empty; with wrap the clipped half of
+        // the circle reappears there.
+        assert_eq!(plain.get_pixel(63, 32).0[3], 0, "no wrap => right edge empty");
+        assert!(
+            wrapped.get_pixel(63, 32).0[3] > 0,
+            "wrap => clipped art reappears on the opposite edge"
+        );
+        // The left edge is unchanged either way.
+        assert!(plain.get_pixel(0, 32).0[1] > 0);
+        assert!(wrapped.get_pixel(0, 32).0[1] > 0);
+    }
+
+    /// Wrapping must be a no-op for art that stays inside the viewBox, so it
+    /// is safe to enable on any tile without changing its appearance.
+    #[test]
+    fn wrap_is_a_no_op_for_contained_art() {
+        let plain = render_svg(HALF, 64, false).unwrap();
+        let wrapped = render_svg(HALF, 64, true).unwrap();
+        assert_eq!(plain, wrapped);
+    }
+
+    /// The overlap the source-over lattice implies, pinned so it can't drift
+    /// into an asymmetry: a translucent shape wider than the tile darkens by
+    /// the same amount at *both* edges, which is what keeps the join
+    /// continuous even though the band is visible.
+    #[test]
+    fn wrap_overlap_is_symmetric_across_the_join() {
+        const BAND: &[u8] = br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <rect x="-10" y="0" width="120" height="100" fill="#ff0000" fill-opacity="0.5"/>
+        </svg>"##;
+        let img = decode(&render_svg(BAND, 64, true).unwrap());
+        let alpha = |x| img.get_pixel(x, 32).0[3];
+        assert_eq!(
+            alpha(0),
+            alpha(63),
+            "overhang bands must match across the join or the tile is not seamless"
+        );
+        assert!(
+            alpha(0) > alpha(32),
+            "self-overlap in the overhang band is expected; see render_svg's docs"
+        );
+    }
+
+    #[test]
+    fn rejects_a_malformed_svg() {
+        assert!(render_svg(b"not an svg at all", 64, false).is_err());
+    }
+
+    #[test]
+    fn is_svg_is_case_insensitive_and_extension_based() {
+        assert!(is_svg(Path::new("a/b/tile.svg")));
+        assert!(is_svg(Path::new("TILE.SVG")));
+        assert!(!is_svg(Path::new("tile.png")));
+        assert!(!is_svg(Path::new("svg")));
+    }
+
+    #[test]
+    fn resolve_svg_size_uses_the_default_when_unset() {
+        let mat = Material::new("m");
+        assert_eq!(resolve_svg_size(&mat).unwrap(), DEFAULT_SVG_SIZE);
+    }
+
+    #[test]
+    fn resolve_svg_size_rejects_zero() {
+        let mut mat = Material::new("m");
+        mat.texture_size = Some(0);
+        let err = resolve_svg_size(&mat).unwrap_err();
+        assert!(format!("{err:#}").contains("texture_size"));
+    }
+
+    #[test]
+    fn resolve_svg_size_rejects_above_the_max() {
+        let mut mat = Material::new("blowup");
+        mat.texture_size = Some(MAX_SVG_SIZE + 1);
+        let err = resolve_svg_size(&mat).unwrap_err();
+        let msg = format!("{err:#}");
+        // Names the offending material so a multi-material scene's error is
+        // actionable, and the bound itself so the fix is obvious.
+        assert!(msg.contains("blowup"), "should name the material: {msg}");
+        assert!(
+            msg.contains(&MAX_SVG_SIZE.to_string()),
+            "should name the bound: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_svg_size_accepts_the_max_exactly() {
+        let mut mat = Material::new("m");
+        mat.texture_size = Some(MAX_SVG_SIZE);
+        assert_eq!(resolve_svg_size(&mat).unwrap(), MAX_SVG_SIZE);
+    }
+}

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -933,7 +933,10 @@ Declared at the top of the file or inside `scene { ... }`. Attributes:
   chop/foam (`0.05` glassy → `1.0` whitecaps), `metallic` lerps toward
   liquid-metal Fresnel, `transmission` + `alpha_mode="blend"` lets the floor
   show through, and `normal_texture`/`base_color_texture` blend into the
-  procedural waves.
+  procedural waves. It also declares one parameter of its own,
+  `absorption` (float, default `1.5`) — the depth in world units over which
+  transmitted radiance falls to `1/e`, set via `shader_params (absorption=…)`
+  like any other. `0` is clear glass, so the default is deliberately not zero.
 - `gradient` — optional ramp baked into per-vertex `COLOR_0` at export
   time. Four surface forms, all colours are vec3 in sRGB `[0..1]`:
   - `linear(from=[…], to=[…], axis=x|y|z)` — interpolates between two
@@ -1038,8 +1041,9 @@ runs the GLSL — it only carries the path + resolved parameter values as
 `node.extras.shader` metadata on the glTF nodes bound to a referencing
 material. MoGen Studio is the one component that actually compiles a
 declared shader, for live preview. The built-in `water` preset (see
-`shader=` above) is just the first client of this system — declaring your
-own `shader "water" { ... }` shadows it.
+`shader=` above) is just the first client of this system — it declares an
+`absorption` param and resolves it through the same path a user shader's
+params take, and declaring your own `shader "water" { ... }` shadows it.
 
 ```
 shader "ripple" (source="shaders/ripple.glsl") {


### PR DESCRIPTION
Two changes an engine consuming the lowered `SceneGraph` needs, both of which
also remove a reach-around Studio was already doing.

Requested by a downstream consumer (moggy, krazyjakee/moggy#457), but neither
change is engine-specific — both are about the built-in surfaces being
reachable and self-describing on their own terms.

## 1. `mogen-svg`: the rasterizer moves below the exporter

Rasterization shipped as a pre-export pass (#106). That is still the right
shape for rewriting a `SceneGraph`'s texture paths and layering bytes over a
`TextureSource`, and it is unchanged here. What was in the wrong place was the
renderer underneath it.

Every consumer holding a `Material` and a path sits *beside* the exporter, not
after it. `svg.rs`'s own module docs already named the problem — "the consumer
this pass cannot reach" — and Studio's viewport solved it by reaching back into
`mogen-export` for `is_svg` / `render_svg` / `resolve_svg_size`. An engine that
reads the lowered `SceneGraph` and decodes textures itself cannot do even that
without linking the whole exporter, `oxipng` / `fbxcel` / `meshopt` included,
for three pure functions over `(bytes, size, wrap)`.

So the policy moves into a new `mogen-svg` crate — `mogen-core` plus
`resvg`/`usvg`, both pure Rust — and the pass stays in `mogen-export`, which
re-exports the four public items. `mogen_export::is_svg` and friends still
resolve, so **Studio needs no edit**. `textures-svg` becomes `dep:mogen-svg`.

There is still exactly one implementation of "what pixels does this SVG
produce", which was the point of the original decision; it is simply reachable
now. Verified to cross-compile to `wasm32-unknown-unknown`, as the old module
claimed for itself.

## 2. The built-in `water` preset declares `absorption`

`shader="water"` was a bare on/off switch: the preset was seeded with an empty
param list, so an author could not say *how* absorbing the water is, and a
consumer reading the lowered `Material` found a shader name and nothing else.

It now declares `absorption` (float, default `1.5`), resolved through the
ordinary `ShaderDecl::resolve_param` path — `shader_params (absorption=2.5)`
overrides it exactly as for a user-declared shader. The built-in stays the
first client of the general system rather than acquiring a special case, which
is the property #107 is heading toward anyway.

The default is deliberately not zero: zero is the "behaves exactly like clear
glass" case, so defaulting to it would make `shader="water"` a no-op that
reports success. The test asserts the override wins, that a silent material
gets the default, and — the control — that the default is not the disabled
value.

`docs/dsl.md` documents the parameter in both places water is described.

## Verification

- `cargo test --locked -p mogen-svg -p mogen-export -p mogen-dsl -p mogen-core` — 18 suites, all green (664 in `mogen-dsl`, 27 in `svg_textures`)
- `cargo check --workspace --all-targets` — clean
- `cargo check -p mogen-svg --target wasm32-unknown-unknown` — clean

Not run: the Studio GL paths, which need a display seat this machine may not
have. Studio is untouched by construction — it compiles against the same
re-exported names — but that is an argument, not an observed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)