### PR TITLE
dsl: fix lowering accuracy and reduce redundant work

### DIFF
--- a/crates/mogen-dsl/src/lower.rs
+++ b/crates/mogen-dsl/src/lower.rs
@@ -33,6 +33,7 @@ use anyhow::Result;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
 use mogen_core::{subtree_local_aabb, NodeId, SceneGraph};
 
@@ -47,7 +48,9 @@ use crate::skin_lower::{bind_meshes, lower_skeleton};
 
 use anim::{is_anim_decl, lower_animations};
 use geometry_identity::TessellationCacheGuard;
-use lod::{collect_origin_lods, extract_lod_scale, LodByOriginGuard, LodRequestGuard};
+use lod::{
+    collect_origin_lods, extract_lod_scale, LodByOriginGuard, LodMultiplierGuard, LodRequestGuard,
+};
 use material::collect_materials;
 use node::lower_into;
 use physics::collect_physics;
@@ -76,7 +79,7 @@ thread_local! {
     // in this lowering, keyed by the `src` attribute verbatim. Filled by
     // `collect_mesh_binaries` over the *expanded* AST; read by `primitive_mesh`,
     // which reads the file itself when a spec is absent.
-    pub(super) static MESH_BYTES: RefCell<HashMap<String, Vec<u8>>> =
+    pub(super) static MESH_BYTES: RefCell<HashMap<String, Rc<Vec<u8>>>> =
         RefCell::new(HashMap::new());
 }
 
@@ -85,12 +88,13 @@ pub(super) fn source_dir() -> Option<PathBuf> {
     SOURCE_DIR.with(|s| s.borrow().clone())
 }
 
-/// The bytes the caller's [`Loader`] supplied for `mesh (src=spec)`, if any.
+/// Shared bytes the caller's [`Loader`] supplied for `mesh (src=spec)`, if any.
+/// Cloning the handle avoids copying the entire GLB for each mesh instance.
 ///
 /// `None` means "nobody supplied these", **not** "this mesh has no bytes" —
 /// the primitive then resolves the file itself, which is what every loader
 /// written before [`Loader::load_binary`] existed relies on.
-pub(super) fn mesh_bytes(spec: &str) -> Option<Vec<u8>> {
+pub(super) fn mesh_bytes(spec: &str) -> Option<Rc<Vec<u8>>> {
     MESH_BYTES.with(|m| m.borrow().get(spec).cloned())
 }
 
@@ -113,7 +117,7 @@ fn collect_mesh_binaries(
     ast: &[Node],
     base_dir: Option<&Path>,
     loader: &mut dyn Loader,
-) -> HashMap<String, Vec<u8>> {
+) -> HashMap<String, Rc<Vec<u8>>> {
     fn walk(nodes: &[Node], out: &mut Vec<String>) {
         for n in nodes {
             if n.kind == "mesh" {
@@ -132,7 +136,7 @@ fn collect_mesh_binaries(
     let mut map = HashMap::new();
     for spec in specs {
         if let Ok(bytes) = loader.load_binary(&spec, base_dir) {
-            map.insert(spec, bytes);
+            map.insert(spec, Rc::new(bytes));
         }
     }
     map
@@ -142,11 +146,11 @@ fn collect_mesh_binaries(
 /// (possibly failed) lowering's bytes cannot leak into this one — the reason
 /// [`ColliderRequestsGuard`] exists, one map along.
 struct MeshBytesGuard {
-    prev: HashMap<String, Vec<u8>>,
+    prev: HashMap<String, Rc<Vec<u8>>>,
 }
 
 impl MeshBytesGuard {
-    fn set(map: HashMap<String, Vec<u8>>) -> Self {
+    fn set(map: HashMap<String, Rc<Vec<u8>>>) -> Self {
         let prev = MESH_BYTES.with(|m| std::mem::replace(&mut *m.borrow_mut(), map));
         Self { prev }
     }
@@ -297,13 +301,14 @@ pub fn lower_with_loader_lod(
     lod_scale: f32,
 ) -> Result<SceneGraph> {
     let _lod_req = LodRequestGuard::set(lod_scale);
+    let _lod_mul = LodMultiplierGuard::fresh();
     let _src = SourceDirGuard::set(base_dir.map(|p| p.to_path_buf()));
     let _coll = ColliderRequestsGuard::fresh();
     let _tessellations = TessellationCacheGuard::fresh();
     // Top-level `lod_scale (value=N)` multiplies primitive default segment/
     // ring counts. Stash on a thread-local before lowering so `primitive_mesh`
     // can read it without threading an extra arg through every recursive call.
-    // Explicit per-primitive `segments=`/`rings=` still win.
+    // Explicit per-primitive segment/ring counts are scaled too.
     let _lod = LodScaleGuard::set(extract_lod_scale(ast));
     // Per-origin LOD overrides: imported files carry their own
     // `lod_scale` directives that need to apply to that file's geometry,
@@ -332,12 +337,10 @@ pub fn lower_with_loader_lod(
     reg.extend_overlay(imported_reg);
     let user = collect_modules(ast)?;
     reg.extend_overlay(user);
-    // Publish the combined registry for the rest of the lowering pass.
-    // `expand_building` reads it to instantiate door/window/skylight modules.
-    // Clone is unavoidable — `expand_modules` borrows `reg` for the duration
-    // of the call below, and the guard needs an owned value.
-    let _reg_guard = ModuleRegistryGuard::set(reg.clone());
     let (expanded, use_parents) = expand_modules(ast, &reg)?;
+    // Expansion no longer borrows the registry, so move it into the guard.
+    // `expand_building` reads it to instantiate door/window/skylight modules.
+    let _reg_guard = ModuleRegistryGuard::set(reg);
 
     // Give the caller's loader a chance to serve every external mesh, now that
     // module expansion has turned `src=$param` into a real spec and dropped the
@@ -434,58 +437,8 @@ pub fn lower_with_loader_lod(
         }
     }
 
-    // Pass 2.65: auto-weigh physics bodies from the final geometry. Runs after
-    // collider (so it sees the same post attach/conform/skin mesh).
-    let worlds = graph.world_transforms();
-    // (a) Leaves — nodes with their own mesh. Weight = substance density × world
-    // volume (the world-transform determinant folds in this node's + ancestors'
-    // scale, so `scale=2` weighs 8×); centre of gravity = the mesh's volume
-    // centroid, in local space. An explicit `weight=` keeps its overridden mass
-    // but still gets a real centre of gravity.
-    for id in 0..graph.nodes.len() {
-        let node = &graph.nodes[id];
-        let Some(body) = &node.physics else { continue };
-        let Some(mesh) = &node.mesh else { continue };
-        let mass = if body.mass.is_some() {
-            body.mass
-        } else {
-            // Group as `density × (volume × det)` — the same association the
-            // golden GLBs were baked with; regrouping shifts the last f32 ULP.
-            let world_volume = mesh.solid_volume() * worlds[id].determinant().abs();
-            Some(body.weight_per_m3 * world_volume)
-        };
-        let cog = mesh.solid_centroid();
-        let b = graph.nodes[id].physics.as_mut().unwrap();
-        b.mass = mass;
-        b.center_of_gravity = cog;
-    }
-    // (b) Compound bodies — a node that carries a physics body but has no mesh
-    // of its own (a `group phys=…`, possibly inherited) reports the *combined*
-    // mass and mass-weighted centre of gravity of every mesh-bearing descendant,
-    // expressed in its own local frame. An engine can then treat the whole
-    // assembly as one rigid body. Only own-mesh descendants contribute, so a
-    // compound group nested above another never double-counts the shared
-    // leaves. Runs after (a) so leaf masses already exist.
-    for id in 0..graph.nodes.len() {
-        if graph.nodes[id].physics.is_none() || graph.nodes[id].mesh.is_some() {
-            continue;
-        }
-        let mut total = 0.0f32;
-        let mut weighted = glam::Vec3::ZERO;
-        collect_subtree_mass(
-            &graph,
-            NodeId(id as u32),
-            &worlds,
-            &mut total,
-            &mut weighted,
-        );
-        if total > 0.0 {
-            let local_com = worlds[id].inverse().transform_point3(weighted / total);
-            let b = graph.nodes[id].physics.as_mut().unwrap();
-            b.mass = Some(total);
-            b.center_of_gravity = Some([local_com.x, local_com.y, local_com.z]);
-        }
-    }
+    // Pass 2.65: weigh bodies from the final post-attach/conform/skin geometry.
+    physics::weigh_bodies(&mut graph);
 
     // Pass 2.7: propagate `cast_shadow=false` down the subtree so a `group`
     // (or wrapping `use`) can opt out an entire subassembly with one flag.
@@ -494,9 +447,9 @@ pub fn lower_with_loader_lod(
     // landed on `false` during lowering, so no information is lost. The flag
     // is monotone — false stays false — which keeps the propagation order
     // insensitive to sibling traversal.
-    let roots: Vec<NodeId> = graph.roots.clone();
-    for r in roots {
-        propagate_cast_shadow(&mut graph, r, true);
+    for i in 0..graph.roots.len() {
+        let root = graph.roots[i];
+        propagate_cast_shadow(&mut graph, root, true);
     }
 
     // Pass 3: joints first (clips may reference joint names), then clips,
@@ -515,44 +468,14 @@ pub fn lower_with_loader_lod(
     Ok(graph)
 }
 
-/// Accumulate the mass and mass-weighted *world-space* centre of gravity of
-/// every mesh-bearing physics body strictly below `id`. Only own-mesh nodes
-/// contribute, so a compound group above another compound group can't
-/// double-count the leaves they share.
-fn collect_subtree_mass(
-    graph: &SceneGraph,
-    id: NodeId,
-    worlds: &[glam::Mat4],
-    total: &mut f32,
-    weighted: &mut glam::Vec3,
-) {
-    let children = graph.nodes[id.0 as usize].children.clone();
-    for c in children {
-        let node = &graph.nodes[c.0 as usize];
-        if node.mesh.is_some() {
-            if let Some(m) = node.physics.as_ref().and_then(|b| b.mass) {
-                let cog = node
-                    .physics
-                    .as_ref()
-                    .and_then(|b| b.center_of_gravity)
-                    .unwrap_or([0.0, 0.0, 0.0]);
-                let world_pt = worlds[c.0 as usize].transform_point3(glam::Vec3::from_array(cog));
-                *total += m;
-                *weighted += m * world_pt;
-            }
-        }
-        collect_subtree_mass(graph, c, worlds, total, weighted);
-    }
-}
-
 /// Walk the subtree rooted at `id` and clear `cast_shadow` on every node
 /// whose ancestor chain contains a node already opted out. `inherited` is the
 /// effective flag from the parent (`true` for root calls).
 fn propagate_cast_shadow(graph: &mut SceneGraph, id: NodeId, inherited: bool) {
     let effective = inherited && graph.nodes[id.0 as usize].cast_shadow;
     graph.nodes[id.0 as usize].cast_shadow = effective;
-    let children = graph.nodes[id.0 as usize].children.clone();
-    for c in children {
-        propagate_cast_shadow(graph, c, effective);
+    for i in 0..graph.nodes[id.0 as usize].children.len() {
+        let child = graph.nodes[id.0 as usize].children[i];
+        propagate_cast_shadow(graph, child, effective);
     }
 }

--- a/crates/mogen-dsl/src/lower.rs
+++ b/crates/mogen-dsl/src/lower.rs
@@ -1,3 +1,14 @@
+//! Lower expanded DSL nodes into a scene graph.
+//!
+//! Imports and module expansion precede declaration collection and geometry
+//! construction. Attach, conform, and skin binding settle the geometry before
+//! collider bounds and physics masses are computed. Animation lowering and
+//! gradient baking complete the graph.
+//!
+//! File LOD, subtree LOD multipliers, caller density, mesh bytes, tessellation
+//! results, and the module registry are scoped to a lowering call by guards.
+//! Guards restore previous state on return or failure, including nested calls.
+
 mod anim;
 pub mod arch;
 mod blob;
@@ -57,9 +68,9 @@ use physics::collect_physics;
 use shader::{collect_shaders, ensure_builtin_shaders};
 
 thread_local! {
-    // Build-pass-scoped LOD multiplier. Set by `lower()` before walking the
-    // expanded AST and read by `primitive_mesh` so segment/ring defaults can be
-    // scaled without threading an extra arg through every recursive call.
+    // Active file's LOD default. Imported nodes replace this value with their
+    // defining file's setting. `current_lod_scale` combines it with separately
+    // scoped subtree multipliers and the caller's density request.
     pub(super) static LOD_SCALE: Cell<f32> = const { Cell::new(1.0) };
     // Directory of the `.mog` file being lowered. Used by the `mesh`
     // primitive to resolve relative `src` paths. None = no source path
@@ -100,11 +111,11 @@ pub(super) fn mesh_bytes(spec: &str) -> Option<Rc<Vec<u8>>> {
 
 /// Ask `loader` for the bytes behind every `mesh (src=…)` reachable in `ast`.
 ///
-/// **Runs on the expanded AST**, after `expand_modules`, for two reasons that
-/// both bite: a `src=` inside a `module` is `$param`-substituted only by
-/// expansion, and a module nobody `use`s is gone by then — so pre-loading
-/// before expansion would fetch a spec that is not a path yet, and fetch files
-/// for geometry the scene never instantiates.
+/// Runs after module expansion so unused module bodies are not fetched and
+/// repeated module instances share one load per distinct `src` string. String
+/// parameters are not supported; each `mesh` supplies a concrete `src`.
+/// Successful buffers are shared by reference-counted handles for this call;
+/// each instance still decodes its own mesh before applying geometry changes.
 ///
 /// **Failures are dropped, not raised.** A spec the loader cannot serve is
 /// simply absent from the map, and `primitive_mesh` falls back to reading it
@@ -272,28 +283,26 @@ pub fn lower_with_loader(
     lower_with_loader_lod(ast, base_dir, loader, 1.0)
 }
 
-/// [`lower_with_loader`] at a caller-chosen **tessellation density**.
+/// [`lower_with_loader`] at a caller-chosen tessellation density.
 ///
-/// `lod_scale` multiplies every segment / ring / sample count the lowering
-/// produces: `0.5` halves them, `2.0` doubles them, `1.0` is exactly what every
-/// other entry point does. Non-positive and non-finite values fall back to
-/// `1.0`, the rule the `lod_scale (value=N)` directive already follows.
+/// The effective density is the active file's `lod_scale`, multiplied by all
+/// enclosing per-node `lod=` overrides and this request. Imported geometry uses
+/// its defining file's scale (default `1.0`), while subtree overrides and the
+/// request remain active across import boundaries. Non-positive or non-finite
+/// requests use `1.0`.
 ///
-/// **This is a bake-time parameter, not an authoring one.** The DSL already has
-/// three ways for a *file* to state its density — the top-level
-/// `lod_scale (value=N)`, each import's own, and a per-node `lod=N` — and this
-/// changes none of them. It is the knob a **caller** needs to lower the same
-/// AST more than once and get genuinely different geometry each time, which is
-/// what building a LOD chain out of retained analytic parameters requires: a
-/// coarse level here is the same sphere re-tessellated, not a decimated mesh,
-/// so it is exact at every level rather than approximate.
+/// Segment, ring, and sample counts scale linearly, then round and clamp to
+/// primitive-specific minima. Subdivision levels use a logarithmic offset.
+/// Lower densities re-tessellate supported analytic primitives; imported mesh
+/// bytes are unchanged. Minimum counts can make nearby requests produce the
+/// same geometry.
 ///
-/// The request **multiplies** the source's own scales rather than replacing
-/// them, so an authored detail hierarchy survives: a part marked `lod=2` is
-/// still twice its neighbours at every density anyone asks for.
+/// For example, an imported file with `lod_scale=0.5`, inside a `lod=2` group,
+/// lowered with a request of `0.25`, has effective density `0.25`. The importing
+/// file's global scale does not enter that product.
 ///
-/// Existing callers are untouched and produce byte-identical graphs —
-/// `lower_with_loader` passes `1.0`, and a multiply by one changes nothing.
+/// [`lower_with_loader`] passes `1.0`. Each call resets its scoped state and
+/// restores any enclosing call's state on return, including errors.
 pub fn lower_with_loader_lod(
     ast: &[Node],
     base_dir: Option<&Path>,

--- a/crates/mogen-dsl/src/lower/lod.rs
+++ b/crates/mogen-dsl/src/lower/lod.rs
@@ -21,21 +21,9 @@ thread_local! {
     static LOD_BY_ORIGIN: RefCell<HashMap<PathBuf, f32>> =
         RefCell::new(HashMap::new());
 
-    /// The **caller's** tessellation density for this lowering, set by
-    /// [`crate::lower::lower_with_loader_lod`]. 1.0 = exactly what the source
-    /// asked for, which is what every other entry point passes.
-    ///
-    /// Deliberately a *second* thread-local rather than a different starting
-    /// value for `LOD_SCALE`, and that is the load-bearing part. `LOD_SCALE` is
-    /// **replaced** — not multiplied — by [`LodOriginScaleGuard`] on entry to
-    /// every imported subtree, precisely so one file's `lod_scale` cannot leak
-    /// across an `import`. A caller's request folded into `LOD_SCALE` would be
-    /// erased by that replacement, so asking for a coarse bake would coarsen the
-    /// root file and silently leave every imported subtree at full density.
-    ///
-    /// Kept separate it multiplies through *all* of it — the file's own
-    /// `lod_scale`, each import's, and every per-node `lod=` — which is what
-    /// "give me this whole scene at a quarter density" has to mean.
+    /// Caller density for the current lowering. Stored separately from the
+    /// file scale and subtree multiplier so origin changes cannot erase it.
+    /// `current_lod_scale` multiplies all three factors; 1.0 is the default.
     static LOD_REQUEST: Cell<f32> = const { Cell::new(1.0) };
 }
 
@@ -62,9 +50,8 @@ impl Drop for LodRequestGuard {
     }
 }
 
-/// Find a top-level `lod_scale (value=N)` declaration and return its multiplier.
-/// Defaults to 1.0 when absent. Non-finite values and values <= 0 are ignored so a malformed
-/// setting can't silently destroy every mesh.
+/// Return the first positive, finite top-level `lod_scale (value=N)`.
+/// Invalid declarations are skipped; defaults to 1.0 if none is valid.
 pub(super) fn extract_lod_scale(ast: &[Node]) -> f32 {
     for n in ast {
         if n.kind == "lod_scale" {
@@ -142,9 +129,9 @@ impl Drop for LodByOriginGuard {
 /// importing file's scale. Mirrors the `meta` block isolation already
 /// in place — a file's top-level directives don't leak across imports.
 ///
-/// Nodes with no origin (the user's own file, stdlib expansions) leave
-/// `LOD_SCALE` alone so the user's top-level `lod_scale` continues to
-/// apply.
+/// Nodes with no origin (local or stdlib expansions) retain the active file
+/// scale. Subtree multipliers and caller density are stored separately and
+/// survive every origin change.
 pub(super) enum LodOriginScaleGuard {
     /// LOD_SCALE was swapped; the previous value is restored on drop.
     Active(f32),
@@ -181,13 +168,13 @@ impl Drop for LodOriginScaleGuard {
 /// The multiplier compounds with the active scale — a `lod=2.0` on a
 /// subtree inside a file with a top-level `lod_scale (value=0.5)` ends up
 /// at an effective scale of `1.0`, matching what an author would expect
-/// from a "double the detail of this part" override. Non-finite and non-positive values
-/// are ignored (treated as no-op) so a malformed override can't silently
-/// destroy every mesh in the subtree.
+/// from a "double the detail of this part" override. The accumulated multiplier
+/// is independent of the active file's scale and survives imported children.
+/// Non-finite and non-positive values are ignored.
 pub(super) enum LodMultiplierGuard {
     /// Active multiplier applied; the previous subtree multiplier is restored on drop.
     Active(f32),
-    /// Either no `lod` attr present or its value was non-positive — no swap.
+    /// No `lod` attribute, or a non-positive/non-finite value; no swap.
     Inert,
 }
 

--- a/crates/mogen-dsl/src/lower/lod.rs
+++ b/crates/mogen-dsl/src/lower/lod.rs
@@ -7,6 +7,10 @@ use crate::ast::Node;
 use super::LOD_SCALE;
 
 thread_local! {
+    // Subtree multipliers are independent of file defaults: switching origin
+    // must not erase a containing group's `lod=` (even within the same file).
+    static LOD_MULTIPLIER: Cell<f32> = const { Cell::new(1.0) };
+
     /// Per-origin LOD multiplier collected from imported files'
     /// top-level `lod_scale (value=N)` directives. Keyed by the
     /// canonical path stamped onto every imported `Node.origin`.
@@ -59,13 +63,13 @@ impl Drop for LodRequestGuard {
 }
 
 /// Find a top-level `lod_scale (value=N)` declaration and return its multiplier.
-/// Defaults to 1.0 when absent. Values <= 0 fall back to 1.0 so a malformed
+/// Defaults to 1.0 when absent. Non-finite values and values <= 0 are ignored so a malformed
 /// setting can't silently destroy every mesh.
 pub(super) fn extract_lod_scale(ast: &[Node]) -> f32 {
     for n in ast {
         if n.kind == "lod_scale" {
             if let Some(v) = n.attr_number("value") {
-                if v > 0.0 {
+                if v.is_finite() && v > 0.0 {
                     return v;
                 }
             }
@@ -91,7 +95,7 @@ pub(super) fn collect_origin_lods(imported: &[Node]) {
             let Some(v) = n.attr_number("value") else {
                 continue;
             };
-            if v > 0.0 {
+            if v.is_finite() && v > 0.0 {
                 // First decl per origin wins, matching `extract_lod_scale`.
                 map.entry(origin).or_insert(v);
             }
@@ -100,15 +104,14 @@ pub(super) fn collect_origin_lods(imported: &[Node]) {
 }
 
 /// The density every primitive tessellates at right now: the source's own
-/// scale (file-global, per-origin, per-node — all folded into `LOD_SCALE`)
-/// **times** the caller's request.
+/// file scale, multiplied by enclosing per-node overrides and the caller's request.
 ///
 /// A product rather than a choice between the two: an author who marked a hero
 /// prop `lod=2` means "twice whatever else is going on", and that stays true at
 /// every density a baker asks for. Overriding instead would flatten a scene's
 /// authored detail hierarchy the moment anything requested a LOD.
 pub(super) fn current_lod_scale() -> f32 {
-    LOD_SCALE.with(|s| s.get()) * LOD_REQUEST.with(|s| s.get())
+    LOD_SCALE.with(|s| s.get()) * LOD_MULTIPLIER.with(|s| s.get()) * LOD_REQUEST.with(|s| s.get())
 }
 
 /// RAII guard that resets the per-origin LOD map at the start of a
@@ -170,7 +173,7 @@ impl Drop for LodOriginScaleGuard {
     }
 }
 
-/// RAII guard that multiplies `LOD_SCALE` by a per-node `lod=N` attribute for
+/// RAII guard that accumulates a per-node `lod=N` attribute for
 /// the duration of one `lower_into` call. Lets authors mark hero parts
 /// (`lod=2.0`) and background parts (`lod=0.5`) without touching the
 /// file-global `lod_scale (value=N)`.
@@ -178,25 +181,29 @@ impl Drop for LodOriginScaleGuard {
 /// The multiplier compounds with the active scale — a `lod=2.0` on a
 /// subtree inside a file with a top-level `lod_scale (value=0.5)` ends up
 /// at an effective scale of `1.0`, matching what an author would expect
-/// from a "double the detail of this part" override. Non-positive values
+/// from a "double the detail of this part" override. Non-finite and non-positive values
 /// are ignored (treated as no-op) so a malformed override can't silently
 /// destroy every mesh in the subtree.
 pub(super) enum LodMultiplierGuard {
-    /// Active multiplier applied; the previous LOD_SCALE is restored on drop.
+    /// Active multiplier applied; the previous subtree multiplier is restored on drop.
     Active(f32),
     /// Either no `lod` attr present or its value was non-positive — no swap.
     Inert,
 }
 
 impl LodMultiplierGuard {
+    pub(super) fn fresh() -> Self {
+        Self::Active(LOD_MULTIPLIER.with(|s| s.replace(1.0)))
+    }
+
     pub(super) fn for_node(node: &Node) -> Self {
         let Some(mult) = node.attr_number("lod") else {
             return Self::Inert;
         };
-        if !(mult > 0.0) {
+        if !mult.is_finite() || mult <= 0.0 {
             return Self::Inert;
         }
-        let prev = LOD_SCALE.with(|s| {
+        let prev = LOD_MULTIPLIER.with(|s| {
             let cur = s.get();
             s.replace(cur * mult)
         });
@@ -207,7 +214,7 @@ impl LodMultiplierGuard {
 impl Drop for LodMultiplierGuard {
     fn drop(&mut self) {
         if let Self::Active(prev) = *self {
-            LOD_SCALE.with(|s| s.set(prev));
+            LOD_MULTIPLIER.with(|s| s.set(prev));
         }
     }
 }

--- a/crates/mogen-dsl/src/lower/node.rs
+++ b/crates/mogen-dsl/src/lower/node.rs
@@ -36,7 +36,8 @@ pub(super) fn lower_into(
     // `lod=2.0` group can boost detail in a hero subtree (and `lod=0.5`
     // can drop background parts) without touching the file-global
     // `lod_scale`. The multiplier guard compounds with whatever the
-    // origin guard set up; both restore previous values on drop.
+    // origin guard set up. It is stored separately so an imported child
+    // cannot erase its ancestors' multipliers. Both guards restore on drop.
     let _lod_mul = LodMultiplierGuard::for_node(node);
     if node.kind == "mirror" || node.kind == "array" {
         return expand_replicator(node, parent, graph);

--- a/crates/mogen-dsl/src/lower/physics.rs
+++ b/crates/mogen-dsl/src/lower/physics.rs
@@ -4,9 +4,9 @@
 //! Mirrors [`super::material`]. [`collect_physics`] hoists every declaration
 //! into `SceneGraph::physics` (Pass 1, alongside materials). [`bind_physics`]
 //! resolves a geometry node's `phys=` reference into a [`PhysicsBody`] snapshot
-//! and stamps it on the node. The heavy values — `mass` and `center_of_gravity`
-//! — are filled later, once the final mesh exists, by the auto-weigh pass in
-//! [`super::super::lower`] (they need the post-attach/conform geometry).
+//! and stamps it on the node. Mass and centre of gravity are filled later
+//! by [`weigh_bodies`], after attach, conform, and skin binding
+//! settle the geometry. Explicit weights are preserved on meshes and groups.
 
 use anyhow::{anyhow, Result};
 
@@ -73,8 +73,9 @@ type Substance = (String, f32, f32, f32);
 /// ancestor's substance, exactly as `mat=` inherits down the hierarchy (see
 /// [`super::helpers::inherit_material_from_ancestor`]). So `phys=` on a `group`
 /// flows to every child mesh, which then weighs itself. A flat per-node
-/// `weight=<mass>` override is recorded regardless; `mass`/`center_of_gravity`
-/// are otherwise filled by the auto-weigh pass.
+/// `weight=<mass>` override is recorded when a substance resolves; without an
+/// explicit or inherited substance, no body is created. Other mass properties are
+/// filled by [`weigh_bodies`].
 pub(super) fn bind_physics(node: &Node, id: NodeId, graph: &mut SceneGraph) -> Result<()> {
     let substance = if let Some(name) = node.attr_string("phys") {
         let pid = graph
@@ -123,6 +124,9 @@ fn inherited_substance(id: NodeId, graph: &SceneGraph) -> Option<Substance> {
 }
 
 /// Compute masses and local centres of gravity after geometry has settled.
+/// Explicit weights, including zero, are retained. Meshless compounds derive
+/// their centroid from own-mesh descendants; nested group weights do not
+/// contribute to enclosing compounds. Skip this pass when there are no bodies.
 pub(super) fn weigh_bodies(graph: &mut SceneGraph) {
     if !graph.nodes.iter().any(|node| node.physics.is_some()) {
         return;

--- a/crates/mogen-dsl/src/lower/physics.rs
+++ b/crates/mogen-dsl/src/lower/physics.rs
@@ -121,3 +121,83 @@ fn inherited_substance(id: NodeId, graph: &SceneGraph) -> Option<Substance> {
     }
     None
 }
+
+/// Compute masses and local centres of gravity after geometry has settled.
+pub(super) fn weigh_bodies(graph: &mut SceneGraph) {
+    if !graph.nodes.iter().any(|node| node.physics.is_some()) {
+        return;
+    }
+    let worlds = graph.world_transforms();
+    // (a) Leaves — nodes with their own mesh. Weight = substance density × world
+    // volume (the world-transform determinant folds in this node's + ancestors'
+    // scale, so `scale=2` weighs 8×); centre of gravity = the mesh's volume
+    // centroid, in local space. An explicit `weight=` keeps its overridden mass
+    // but still gets a real centre of gravity.
+    for id in 0..graph.nodes.len() {
+        let node = &graph.nodes[id];
+        let Some(body) = &node.physics else { continue };
+        let Some(mesh) = &node.mesh else { continue };
+        let mass = if body.mass.is_some() {
+            body.mass
+        } else {
+            // Group as `density × (volume × det)` — the same association the
+            // golden GLBs were baked with; regrouping shifts the last f32 ULP.
+            let world_volume = mesh.solid_volume() * worlds[id].determinant().abs();
+            Some(body.weight_per_m3 * world_volume)
+        };
+        let cog = mesh.solid_centroid();
+        let b = graph.nodes[id].physics.as_mut().unwrap();
+        b.mass = mass;
+        b.center_of_gravity = cog;
+    }
+    // (b) Compound bodies — a node that carries a physics body but has no mesh
+    // of its own (a `group phys=…`, possibly inherited) reports the *combined*
+    // mass and mass-weighted centre of gravity of every mesh-bearing descendant,
+    // expressed in its own local frame. An engine can then treat the whole
+    // assembly as one rigid body. Only own-mesh descendants contribute, so a
+    // compound group nested above another never double-counts the shared
+    // leaves. Runs after (a) so leaf masses already exist.
+    for id in 0..graph.nodes.len() {
+        if graph.nodes[id].physics.is_none() || graph.nodes[id].mesh.is_some() {
+            continue;
+        }
+        let mut total = 0.0f32;
+        let mut weighted = glam::Vec3::ZERO;
+        collect_subtree_mass(graph, NodeId(id as u32), &worlds, &mut total, &mut weighted);
+        if total > 0.0 {
+            let local_com = worlds[id].inverse().transform_point3(weighted / total);
+            let b = graph.nodes[id].physics.as_mut().unwrap();
+            b.mass.get_or_insert(total);
+            b.center_of_gravity = Some([local_com.x, local_com.y, local_com.z]);
+        }
+    }
+}
+
+/// Accumulate the mass and mass-weighted *world-space* centre of gravity of
+/// every mesh-bearing physics body strictly below `id`. Only own-mesh nodes
+/// contribute, so a compound group above another compound group can't
+/// double-count the leaves they share.
+fn collect_subtree_mass(
+    graph: &SceneGraph,
+    id: NodeId,
+    worlds: &[glam::Mat4],
+    total: &mut f32,
+    weighted: &mut glam::Vec3,
+) {
+    for &c in &graph.nodes[id.0 as usize].children {
+        let node = &graph.nodes[c.0 as usize];
+        if node.mesh.is_some() {
+            if let Some(m) = node.physics.as_ref().and_then(|b| b.mass) {
+                let cog = node
+                    .physics
+                    .as_ref()
+                    .and_then(|b| b.center_of_gravity)
+                    .unwrap_or([0.0, 0.0, 0.0]);
+                let world_pt = worlds[c.0 as usize].transform_point3(glam::Vec3::from_array(cog));
+                *total += m;
+                *weighted += m * world_pt;
+            }
+        }
+        collect_subtree_mass(graph, c, worlds, total, weighted);
+    }
+}

--- a/crates/mogen-dsl/src/lower/primitive.rs
+++ b/crates/mogen-dsl/src/lower/primitive.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use glam::{Mat4, Vec3};
+use std::rc::Rc;
 
 use mogen_core::{Mesh, UvMode};
 use mogen_geom::{
@@ -695,7 +696,7 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Prim
                 // every loader written before that method behaving identically.
                 let bytes = match mesh_bytes(src) {
                     Some(b) => b,
-                    None => std::rc::Rc::new(read_glb_bytes(src, base.as_deref())?),
+                    None => Rc::new(read_glb_bytes(src, base.as_deref())?),
                 };
                 mesh_from_glb_bytes(&bytes).with_context(|| format!("decoding mesh `{src}`"))
             })();

--- a/crates/mogen-dsl/src/lower/primitive.rs
+++ b/crates/mogen-dsl/src/lower/primitive.rs
@@ -695,7 +695,7 @@ pub(super) fn primitive_mesh(node: &Node, uv_mode: UvMode) -> Option<Result<Prim
                 // every loader written before that method behaving identically.
                 let bytes = match mesh_bytes(src) {
                     Some(b) => b,
-                    None => read_glb_bytes(src, base.as_deref())?,
+                    None => std::rc::Rc::new(read_glb_bytes(src, base.as_deref())?),
                 };
                 mesh_from_glb_bytes(&bytes).with_context(|| format!("decoding mesh `{src}`"))
             })();

--- a/crates/mogen-dsl/src/lower/tests/lod.rs
+++ b/crates/mogen-dsl/src/lower/tests/lod.rs
@@ -256,3 +256,57 @@ fn per_node_lod_compounds_with_global_lod_scale() {
         "lod=2 should cancel a global lod_scale=0.5 (base={base_verts}, compound={compound_verts})"
     );
 }
+
+#[test]
+fn non_finite_authored_lod_values_are_ignored() {
+    use crate::ast::Value;
+    use crate::lower::lod::{collect_origin_lods, extract_lod_scale};
+
+    let baseline = lower_src(r#"sphere "s""#);
+    for value in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        let mut ast = crate::parse(r#"lod_scale (value=1) sphere "s" (lod=1)"#).unwrap();
+        ast[0].attrs[0].1 = Value::Number(value);
+        ast[1].attrs[0].1 = Value::Number(value);
+        assert_eq!(extract_lod_scale(&ast), 1.0);
+        let graph = lower(&ast).unwrap();
+        assert_eq!(
+            find_mesh_node(&graph, "s").mesh.as_ref().unwrap().positions,
+            find_mesh_node(&baseline, "s")
+                .mesh
+                .as_ref()
+                .unwrap()
+                .positions,
+        );
+
+        let _origins = LodByOriginGuard::fresh();
+        let _scale = LodScaleGuard::set(2.0);
+        let origin = std::path::Path::new("parts.mog");
+        ast[0].origin = Some(origin.into());
+        collect_origin_lods(&ast);
+        let _origin = crate::lower::lod::LodOriginScaleGuard::for_origin(Some(origin));
+        assert_eq!(LOD_SCALE.with(|scale| scale.get()), 1.0);
+    }
+}
+
+#[test]
+fn nested_lowering_resets_lod_and_restores_it_even_after_failure() {
+    use crate::lower::lod::{current_lod_scale, LodMultiplierGuard};
+
+    let node = crate::parse("group (lod=2)").unwrap().remove(0);
+    let _scale = LodScaleGuard::set(0.5);
+    let _mult = LodMultiplierGuard::for_node(&node);
+    assert_eq!(current_lod_scale(), 1.0);
+
+    let nested = lower_src(r#"sphere "s""#);
+    assert_eq!(
+        find_mesh_node(&nested, "s")
+            .mesh
+            .as_ref()
+            .unwrap()
+            .positions
+            .len(),
+        425
+    );
+    assert!(lower(&crate::parse("group (lod=3) { unknown_primitive }").unwrap()).is_err());
+    assert_eq!(current_lod_scale(), 1.0);
+}

--- a/crates/mogen-dsl/src/lower/tests/physics.rs
+++ b/crates/mogen-dsl/src/lower/tests/physics.rs
@@ -186,3 +186,32 @@ fn unknown_phys_reference_is_an_error() {
     let err = crate::lower::lower(&ast).expect_err("unknown phys should fail");
     assert!(err.to_string().contains("unknown physics material"));
 }
+
+#[test]
+fn compound_weight_override_keeps_geometry_derived_local_cog() {
+    for weight in [0.0, 5.0] {
+        let g = lower_src(&format!(
+            r#"
+            physics "oak" (weight=700kg/m3)
+            scene {{
+                group "assembly" (phys="oak", weight={weight}, pos=[10,20,30], rot=[0,0,90], scale=2) {{
+                    group "nested" {{
+                        box "a" (x=-1, weight=1kg)
+                        box "b" (x=3, weight=3kg)
+                    }}
+                }}
+            }}
+        "#
+        ));
+        let body = find_mesh_node(&g, "assembly").physics.as_ref().unwrap();
+        assert_eq!(body.mass, Some(weight));
+        let cog = Vec3::from_array(body.center_of_gravity.unwrap());
+        assert!(cog.abs_diff_eq(Vec3::new(2.0, 0.0, 0.0), 1e-4), "{cog:?}");
+        let nested = find_mesh_node(&g, "nested").physics.as_ref().unwrap();
+        assert_eq!(
+            nested.mass,
+            Some(4.0),
+            "group overrides must not flow to children"
+        );
+    }
+}

--- a/crates/mogen-dsl/src/module/loader.rs
+++ b/crates/mogen-dsl/src/module/loader.rs
@@ -93,7 +93,13 @@ pub trait Loader {
     /// scene using one could not be lowered there at all.
     ///
     /// `spec` is the attribute verbatim; `base_dir` is the directory of the
-    /// `.mog` being lowered — the same one `load` receives.
+    /// root `.mog` being lowered (the lowering entry point's `base_dir`).
+    ///
+    /// Lowering asks once per distinct `src` in the expanded AST, so unused
+    /// modules do not trigger loads. Successful buffers are shared for that
+    /// lowering call; each mesh instance still owns its decoded geometry.
+    /// A loader error leaves the primitive falling back to `read_glb_bytes`.
+    /// Cached bytes are discarded when the call ends, including on failure.
     ///
     /// That browser is `mogen-wasm`'s `JsLoader`, which overrides this to
     /// answer from the binary asset map the JS host already passes for

--- a/crates/mogen-dsl/tests/lod_request.rs
+++ b/crates/mogen-dsl/tests/lod_request.rs
@@ -145,3 +145,79 @@ fn an_import_honours_the_request_too() {
     assert!(coarse < base, "an imported subtree ignored a coarse request: {coarse} vs {base}");
     assert!(fine > base, "an imported subtree ignored a fine request: {fine} vs {base}");
 }
+
+#[test]
+fn imported_lod_preserves_subtree_multipliers_and_restores_siblings() {
+    struct Parts;
+    impl Loader for Parts {
+        fn load(&mut self, spec: &str, _base: Option<&Path>) -> Result<LoadedFile> {
+            let source = match spec {
+                "parts.mog" => {
+                    r#"
+                    lod_scale (value=0.5)
+                    module "part" {
+                        group (lod=2) {
+                            sphere "nested" (radius=1, lod=0.5)
+                            use "other"
+                        }
+                        sphere "import_sibling" (radius=1)
+                    }
+                "#
+                }
+                "other.mog" => {
+                    r#"
+                    lod_scale (value=0.25)
+                    module "other" { sphere "other" (radius=1) }
+                "#
+                }
+                _ => anyhow::bail!("unexpected import: {spec}"),
+            };
+            Ok(LoadedFile {
+                canonical: spec.into(),
+                source: source.into(),
+            })
+        }
+    }
+    let ast = parse(
+        r#"
+        import "parts.mog"
+        import "other.mog"
+        lod_scale (value=2)
+        scene {
+            group (lod=2) { use "part" }
+            sphere "local_sibling" (radius=1)
+        }
+    "#,
+    )
+    .unwrap();
+    let vertices = |graph: &mogen_core::SceneGraph, name: &str| {
+        graph
+            .nodes
+            .iter()
+            .find(|n| n.name == name)
+            .unwrap()
+            .mesh
+            .as_ref()
+            .unwrap()
+            .positions
+            .len()
+    };
+    for request in [0.5, 1.0, 2.0] {
+        let graph = lower_with_loader_lod(&ast, None, &mut Parts, request).unwrap();
+        // Imported file scales replace the caller file's scale; all enclosing
+        // per-node multipliers survive, including across another import.
+        for (name, scale) in [
+            ("nested", 0.5 * 2.0 * 2.0 * 0.5),
+            ("other", 0.25 * 2.0 * 2.0),
+            ("import_sibling", 0.5 * 2.0),
+            ("local_sibling", 2.0),
+        ] {
+            let expected = lower_at(SPHERE, scale * request).unwrap();
+            assert_eq!(
+                vertices(&graph, name),
+                vertices(&expected, "ball"),
+                "{name}, request={request}"
+            );
+        }
+    }
+}

--- a/crates/mogen-dsl/tests/mesh_loader.rs
+++ b/crates/mogen-dsl/tests/mesh_loader.rs
@@ -154,3 +154,51 @@ fn a_declining_loader_falls_back_to_the_disk_read() {
     let verts: usize = graph.nodes.iter().filter_map(|n| n.mesh.as_ref()).map(|m| m.positions.len()).sum();
     assert!(verts > 0, "the fallback did not load the mesh");
 }
+
+#[test]
+fn expanded_mesh_instances_load_once_and_keep_independent_geometry() {
+    let ast = parse(&format!(
+        r#"
+        module "unused" {{ mesh (src="unused.glb") }}
+        module "part" {{ mesh (src="{ABSENT}") }}
+        scene {{
+            use "part"
+            mesh "anchored" (src="{ABSENT}", anchor=bottom)
+            use "part"
+        }}
+    "#
+    ))
+    .unwrap();
+    let mut loader = MemoryLoader {
+        spec: ABSENT.into(),
+        bytes: glb_bytes(),
+        calls: 0,
+    };
+    let graph = lower_with_loader(&ast, None, &mut loader).unwrap();
+    assert_eq!(
+        loader.calls, 1,
+        "deduplicate after expansion and unused module removal"
+    );
+    let meshes: Vec<_> = graph.nodes.iter().filter_map(|n| n.mesh.as_ref()).collect();
+    assert_eq!(meshes.len(), 3);
+    assert_eq!(meshes[0].positions, meshes[2].positions);
+    let min_y = meshes[1]
+        .positions
+        .iter()
+        .map(|p| p[1])
+        .fold(f32::INFINITY, f32::min);
+    assert!(min_y.abs() < 1e-5, "anchor should affect only its own mesh");
+}
+
+#[test]
+fn mesh_bytes_do_not_leak_between_lowerings() {
+    let mut loader = MemoryLoader {
+        spec: ABSENT.into(),
+        bytes: glb_bytes(),
+        calls: 0,
+    };
+    lower_with_loader(&scene(), None, &mut loader).unwrap();
+    loader.spec = "a-different-asset.glb".into();
+    assert!(lower_with_loader(&scene(), None, &mut loader).is_err());
+    assert_eq!(loader.calls, 2);
+}

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -120,7 +120,10 @@ and compounds with the global setting. Per-primitive minimums still apply
 (`lod=0.1` won't collapse a cylinder below three sides).
 Imported geometry uses its defining file's `lod_scale` (default `1.0`), while
 all enclosing per-node `lod=` multipliers still apply across import boundaries.
-Non-positive or non-finite LOD settings are ignored.
+The first positive, finite top-level `lod_scale` in each file sets that file's
+default; if none is present, it uses `1.0`. Invalid per-node `lod=` values are
+ignored. Nested overrides multiply and do not affect siblings outside their
+subtree.
 
 ```
 scene {
@@ -130,6 +133,36 @@ scene {
   sphere "background_rock" (radius=0.4, lod=0.5)  // halved detail
 }
 ```
+
+For example, save this module as `parts.mog`:
+
+```mog
+lod_scale (value=0.5)
+module "part" {
+  group (lod=2) { sphere "detail" (radius=0.5) }
+  sphere "plain" (radius=0.5)
+}
+```
+
+Then import it from a file in the same directory:
+
+```mog
+import "parts.mog"
+lod_scale (value=0.25)
+scene {
+  group (lod=2) { use "part" }
+  sphere "local" (radius=0.5)
+}
+```
+
+`detail` uses `0.5 × 2 × 2 = 2.0`; `plain` uses `0.5 × 2 = 1.0`.
+`local` uses the importing file's `0.25`. The import's file scale replaces the
+importer's file scale, while the enclosing groups' multipliers remain active.
+
+Library callers can apply another multiplier with `lower_with_loader_lod`.
+A request of `0.5` halves each of those effective scales, including imported
+geometry; invalid requests use `1.0`. Counts still round and clamp to each
+primitive's minimum, and subdivision levels use the logarithmic rule above.
 
 ---
 
@@ -1125,10 +1158,12 @@ mass-weighted centre of gravity of its whole subtree, so an engine can treat the
 assembly as one rigid body. An explicit group `weight=` overrides that group's
 computed mass while retaining the geometry-derived centre of gravity. The
 weight override does not propagate to children; enclosing compounds sum the
-mesh-bearing descendants without double-counting nested groups.
-Weight units carry a dimension — a mass literal
-(`5kg`) is only valid on `weight=`; using one elsewhere (`size=[5kg,1,1]`) is a
-parse error.
+mesh-bearing descendants without double-counting nested groups. See the
+[physics guide](./physics.md#compound-bodies) for a worked example and export
+rules for empty groups.
+
+Weight units carry a dimension — a mass literal (`5kg`) is only valid on
+`weight=`; using one elsewhere (`size=[5kg,1,1]`) is a parse error.
 
 See [`physics.md`](./physics.md) for the full spec: weight units, the `extras`
 shape engines read, validation codes, and current limitations.
@@ -1805,13 +1840,19 @@ Path resolution: relative paths join onto the importing file's directory;
 absolute paths are used verbatim; paths are canonicalised before
 deduplication (so `"lib.mog"` and `"./lib.mog"` load once).
 
-What gets lifted:
+How imported content is handled:
 
 - **`module` declarations** — added to the importer's module registry.
 - **`material` declarations** (top-level or inside the imported scene) —
   added to the material registry. Texture paths are rooted at the
   *defining* file's directory.
 - **Top-level `scene { … }`** — synthesised as `module "<stem>" () { … }`.
+  Top-level animation and skeleton declarations join that module and take
+  effect when it is instantiated; they require a scene in the imported file.
+- **`lod_scale`** — retained as that file's tessellation default. Enclosing
+  `lod=` overrides still apply; see [Per-node LOD](#per-node-lod-overrides).
+- **`meta`** — stays with its source file and does not replace the importer's
+  scene metadata.
 
 Rules:
 
@@ -1820,10 +1861,11 @@ Rules:
 - Module shadowing: **stdlib < imports < user declarations**.
 - Synthesised scene-as-module name collisions across imports are a hard
   error — rename one with `(as=chair_a)`.
-- Material name collisions across imports are a hard error — re-declare
-  the material in the importer to shadow.
-- Imported files may contain only `import`, `module`, `material`, and one
-  top-level `scene { … }`. Joints, clips, skeletons aren't composable yet.
+- Materials with the same name in different files remain distinct. Geometry
+  first resolves materials in its defining file, then falls back to a name
+  lookup when that file has no matching declaration.
+- Imported files support `import`, `module`, `material`, `lod_scale`, `meta`,
+  at most one top-level `scene`, and animation/skeleton declarations as above.
 
 ---
 

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -118,6 +118,9 @@ Any geometry/group node accepts `lod=N`, which **multiplies** the active
 LOD scale for that node's subtree. RAII-scoped (doesn't leak into siblings)
 and compounds with the global setting. Per-primitive minimums still apply
 (`lod=0.1` won't collapse a cylinder below three sides).
+Imported geometry uses its defining file's `lod_scale` (default `1.0`), while
+all enclosing per-node `lod=` multipliers still apply across import boundaries.
+Non-positive or non-finite LOD settings are ignored.
 
 ```
 scene {
@@ -1119,7 +1122,11 @@ for props whose weight shouldn't follow from their size.
 every child without its own `phys=` inherits it and weighs itself. A group that
 carries a substance but no mesh of its own reports the **compound** weight and
 mass-weighted centre of gravity of its whole subtree, so an engine can treat the
-assembly as one rigid body. Weight units carry a dimension — a mass literal
+assembly as one rigid body. An explicit group `weight=` overrides that group's
+computed mass while retaining the geometry-derived centre of gravity. The
+weight override does not propagate to children; enclosing compounds sum the
+mesh-bearing descendants without double-counting nested groups.
+Weight units carry a dimension — a mass literal
 (`5kg`) is only valid on `weight=`; using one elsewhere (`size=[5kg,1,1]`) is a
 parse error.
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,7 +1,7 @@
 # MoGen module catalog
 
 Modules are parametric sub-graphs: reusable snippets of DSL that take scalar
-parameters, expand to a tree of primitives, and can expose connectors for
+or vec3 parameters, expand to a tree of primitives, and can expose connectors for
 downstream composition. The full language is documented in
 [`dsl.md`](./dsl.md); this page is a catalog of the modules shipped in the
 **stdlib** and a recipe for adding more.
@@ -28,16 +28,19 @@ Given a call `use "leg" (height=0.5)`:
    list. Unknown argument names are a hard error (catches typos).
 3. Fill declared defaults for any parameter the caller omitted.
 4. Expand the module body, substituting every `$name` with its bound
-   numeric value. `vec3`, `list`, string, or ident defaults are not
-   accepted — every parameter is scalar.
-5. Recurse: module bodies may themselves call `use`, up to a recursion-
-   depth check that prevents accidental loops.
+   scalar or vec3 value. Defaults may be scalar numbers/expressions or
+   constant vec3 values; list, string, and ident defaults are rejected.
+5. Expand nested `use` calls. Direct and indirect recursive module calls
+   are rejected.
 
 Expansion happens **before** the scene graph is built — by the time
 lowering runs, every `$name` has been replaced and every `use` node has
 been replaced with its expanded body. See
 [`dsl.md` §Modules](./dsl.md#modules-module-and-use) and
 [§Imports](./dsl.md#imports-import) for the full resolution rules.
+Imported module geometry uses its defining file's `lod_scale`, while enclosing
+`lod=` attributes still multiply through the expanded body. See the
+[LOD example](./dsl.md#per-node-lod-overrides) for nested groups and imports.
 
 ---
 
@@ -45,10 +48,10 @@ been replaced with its expanded body. See
 
 Three rules cover almost everything:
 
-1. **All parameters are scalars.** Numeric defaults are required
-   (`height=0.5`, `count=4`); `vec3` / list / string / ident defaults are
-   rejected. If you want a positioned pose, pass the three components as
-   separate scalars.
+1. **Parameters are scalars or vec3s.** Use numeric defaults
+   (`height=0.5`, `count=4`) or constant vectors (`color=[0.3,0.5,0.7]`).
+   Vec3 defaults cannot reference other parameters. List, string, and ident
+   defaults are rejected.
 
 2. **Reference parameters as `$name`** inside the body. They compose into
    expressions in any numeric attribute position — `pos=[0, $h * 0.5, 0]`,

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -88,6 +88,28 @@ and back toward the heavy backrest). An engine can treat the group as a single
 `RigidBody3D` and the children as its collision shapes. Nested groups each sum
 their own subtree without double-counting the shared leaves.
 
+An explicit group `weight=` overrides its computed total, including when the
+override is zero. Its centre of gravity still comes from its descendants'
+masses and positions. For example:
+
+```mog
+physics "oak" (weight=700kg/m3)
+scene {
+  group "assembly" (phys="oak", weight=5kg, pos=[10,20,30], rot=[0,0,90], scale=2) {
+    group "parts" {
+      box "light" (size=[4,1,1], x=-1, weight=1kg)
+      box "heavy" (size=[4,1,1], x=3, weight=3kg)
+    }
+  }
+}
+```
+
+`assembly` weighs exactly 5 kg and has local centre of gravity `[2, 0, 0]`:
+`(-1 × 1 + 3 × 3) / (1 + 3) = 2` on X. Its placement, rotation, and scale do
+not change that local point. The inner `parts` group still weighs 4 kg. Weight
+overrides do not propagate to children, and an enclosing compound sums the
+mesh-bearing descendants rather than a nested group's overridden weight.
+
 ## Weight units
 
 Weights work exactly like [lengths](./dsl.md#length-units): append a suffix, and
@@ -124,9 +146,14 @@ node's real mesh, mogen computes:
 - **centre of gravity** = the mesh's volume centroid (centre of mass for a
   uniform-density solid), in the node's local space.
 
-Both are deterministic functions of the geometry: same source ⇒ same numbers.
-A node with `phys=` but no mesh (e.g. on a bare `group`) still exports the
-substance's feel; it just carries no computed weight or centre of gravity.
+These calculations run after attach, conform, and skin binding, using the
+final geometry and transforms. An explicit weight replaces the calculated mass;
+the centre of gravity remains geometry-derived.
+
+A node without its own mesh uses the [compound-body rules](#compound-bodies).
+If it has no contributing descendants with a positive total mass, it has no
+computed mass or centre of gravity. It still exports its substance properties
+and any explicit weight override.
 
 ## What ends up in the glTF
 
@@ -146,7 +173,10 @@ sitting alongside the existing `role` / `tags` / `collider` metadata:
 }
 ```
 
-`weight` and `center_of_gravity` are omitted when the node has no mesh to weigh.
+`weight` is emitted whenever a computed mass or an explicit override exists;
+`center_of_gravity` is emitted whenever a centroid was computed. This includes
+meshless compound groups. An empty group with `phys="oak", weight=5kg` exports
+its substance and `weight: 5`, but no `center_of_gravity`.
 A downstream importer (the companion **godot-mog**) reads this block to build a
 `RigidBody3D` + `PhysicsMaterial` with the mass and centre of mass already set —
 no hand-authoring. mogen itself stays a plain-glTF producer; the reconstruction
@@ -164,9 +194,9 @@ mass properties.
   `bounce` outside `[0, 1]`.
 - **W0102** — an unknown attribute on a `physics` block. In particular
   `density=` is *not* accepted — it's the jargon `weight=` replaces.
-- **W0215** — a node's flat `weight=` override with no `phys=` attribute on the
-  same node. Without a substance to override, the mass is never computed and
-  the number is silently dropped.
+- **W0215** — a node's flat `weight=` override with no own or inherited
+  `phys=`. Without a substance, no physics body is created and the override
+  has no effect.
 
 ## Mesh-merge
 
@@ -181,8 +211,8 @@ one uniform body), physics drops — the same way UVs drop on a mixed-UV merge.
 ## Limitations and follow-ups
 
 - **Compound bodies read own-mesh descendants.** A group's aggregate sums its
-  mesh-bearing descendants. A standalone `weight=` override on a bodiless,
-  childless node isn't counted into an ancestor's aggregate.
+  mesh-bearing descendants. Overrides on meshless groups are retained on
+  those groups but do not contribute to an ancestor's aggregate.
 - **Inertia tensor is not emitted.** Weight and centre of gravity are computed;
   a full inertia tensor for angular dynamics is a natural next step.
 - **Collision shape is separate.** Physics carries mass properties; the

--- a/docs/studio.md
+++ b/docs/studio.md
@@ -134,7 +134,7 @@ The inspector binds the currently selected node to its attributes:
 - **Per-attribute fields** — drag-numeric inputs, vec3 spinners, colour pickers for material colours, dropdowns for enum-like attrs (`anchor`, `axis`, `alpha_mode`).
 - **Material editor** — every authored material gets a collapsing section. Edit base color, roughness, metallic, alpha mode, transmission, emissive, etc.; changes flow back to the source `material "…"` declaration via the same span-preserving edit machinery.
 - **Texture roster** — each material's texture slots show ✓ / ✗ markers based on whether the referenced PNG actually exists at the resolved path. Missing textures are visible *before* you try to build.
-- **LOD scale slider** — edits the top-level `lod_scale (value=N)` directive in place. Drag down to iterate quickly on big scenes; drag back to `1.0` and Studio removes the directive entirely so saved files stay clean.
+- **LOD scale slider** — edits the top-level `lod_scale (value=N)` directive in place. Drag down to iterate quickly on big scenes; drag back to `1.0` and Studio removes the directive entirely so saved files stay clean. Imported geometry uses its defining file's own setting; use an enclosing group's `lod=` to scale an imported subtree (see [LOD overrides](./dsl.md#per-node-lod-overrides)).
 - **Per-file export options** — `include_animations`, `include_textures`, `merge_sibling_meshes` (sticky per file).
 
 Edits made in the inspector and via gizmos are persisted into the


### PR DESCRIPTION
Imported geometry was resetting LOD at each node, which erased enclosing groups’ `lod=` overrides. Compound physics bodies also replaced explicit group weights with their computed mass. Preserve subtree LOD multipliers across import boundaries, ignore non-finite LOD settings, and retain explicit group weights while still deriving their local centre of gravity.

Reduce lowering overhead by sharing loaded GLB buffers, moving the expanded module registry into its guard, removing child-list clones during physics and shadow traversal, and skipping the physics post-pass when there are no bodies. Keep the physics post-pass in the physics module.

Add six regression tests covering nested imports, sibling isolation, non-finite settings, state restoration after failures, transformed compound bodies, and repeated external meshes. Align the DSL, physics, module, Studio, and API documentation with the implementation. Include runnable import/LOD and transformed compound-weight examples; correct outdated module parameter, import, and physics export rules.

Validation:

- `cargo test -p mogen-dsl`: 687 tests passed on the rebased branch.
- `git diff origin/master --check`: passed.
- `cargo test -p mogen --test goldens`: 14 passed, 8 failed on both this branch and unchanged `master` (`4ab71c2`). All eight failing outputs are byte-identical between the two builds; existing golden files were left unchanged. Failures: `chair`, `chair_array`, `chair_mat`, `chair_module`, `drone`, `mirror_test`, `sword`, `table`.
- `cargo fmt --all -- --check`: reports pre-existing formatting differences, also reproduced on unchanged `master`. New code was formatted without reformatting unrelated files.


Documentation validation:

- `cargo doc -p mogen-dsl --no-deps --document-private-items`: completed; existing private-item and unresolved-link warnings remain in unchanged documentation.
- Built the new Markdown examples with the CLI and inspected the exported GLBs: imported LOD densities match 2.0, 1.0, and 0.25; the compound exports 5 kg and local centroid `[2, 0, 0]`, while its inner group remains 4 kg. An empty physics group retains its explicit weight and omits its centroid.
- Checked all five added documentation links/anchors and confirmed the follow-up Rust edits change comments only.
